### PR TITLE
fix: harden input validation and document security limitations

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -34,4 +34,6 @@ servo-fetch processes untrusted web content. The following areas are in scope:
 
 - Servo's `evaluate_javascript` runs in the page context (no isolated world)
 - DNS rebinding attacks are not mitigated at the URL validation layer
+- Sub-resource requests (images, scripts, iframes) loaded by the page are not subject to SSRF validation — only the initial navigation URL is checked
+- JavaScript executed via `--js` or `execute_js` can make secondary network requests (e.g. `fetch()`) that bypass URL validation, constrained only by the browser's Same-Origin Policy
 - Process isolation (seccomp-bpf) is not yet implemented

--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -42,7 +42,10 @@ impl WebViewDelegate for Delegate {
         let is_http = matches!(navigation_request.url.scheme(), "http" | "https");
         match navigation_request.url.host_str() {
             Some(host) if is_http && !crate::net::is_private_host(host) => navigation_request.allow(),
-            _ => navigation_request.deny(),
+            _ => {
+                eprintln!("warning: blocked navigation to {}", navigation_request.url);
+                navigation_request.deny();
+            }
         }
     }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -37,7 +37,7 @@ pub struct Cli {
     pub js: Option<String>,
 
     /// Timeout in seconds for page load
-    #[arg(short = 't', long, default_value_t = 30, value_name = "SECS")]
+    #[arg(short = 't', long, default_value_t = 30, value_parser = clap::value_parser!(u64).range(1..), value_name = "SECS")]
     pub timeout: u64,
 
     /// CSS selector to extract a specific section

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -63,6 +63,7 @@ pub(super) async fn take_screenshot(url: &str, timeout: u64) -> Result<CallToolR
 }
 
 pub(super) fn paginate(content: &str, start: usize, max_len: usize) -> String {
+    let max_len = max_len.max(1);
     let total = content.len();
     let start = floor_char_boundary(content, start);
     if start >= total {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -118,5 +118,5 @@ fn timeout_produces_error() {
         .args(["--timeout=0", "https://example.com"])
         .assert()
         .failure()
-        .stderr(predicate::str::contains("timed out"));
+        .stderr(predicate::str::contains("invalid value '0'"));
 }


### PR DESCRIPTION
## What does this PR do?

- Reject `--timeout 0` at parse time via `clap::value_parser!(u64).range(1..)`
- Guard `paginate` against `max_len=0` to prevent degenerate behavior
- Warn on stderr when navigation is blocked (previously silent 30s hang)
- Document sub-resource SSRF and JS eval limitations in SECURITY.md

## How to test

1. `cargo run -- --timeout=0 https://example.com` → clap error, no Servo startup
2. `cargo test` → all 93 tests pass

## Checklist

- [x] `cargo clippy` passes with zero warnings
- [x] `cargo test` passes
- [x] `cargo fmt --check` passes
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
