### PR TITLE
ci: skip verify on cargo publish to avoid redundant Servo rebuild

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -170,4 +170,4 @@ jobs:
       - name: Publish to crates.io
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: cargo publish --locked
+        run: cargo publish --locked --no-verify


### PR DESCRIPTION
## What does this PR do?

Fix `cargo publish` failure in release workflow by adding `--no-verify`.

## How to test

1. Diff is a single line change in release.yaml

## Checklist

- [x] `cargo clippy` passes with zero warnings
- [x] `cargo test` passes
- [x] `cargo fmt --check` passes
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)