### PR TITLE
feat: add accessibility tree, user stylesheets, and console capture

### DIFF
--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -1,6 +1,7 @@
 //! Servo engine bridge — persistent Servo thread with channel-based communication.
 
 use std::cell::{Cell, RefCell};
+use std::collections::HashMap;
 use std::rc::Rc;
 use std::sync::mpsc;
 use std::time::{Duration, Instant};
@@ -10,8 +11,8 @@ use dpi::PhysicalSize;
 use euclid::{Box2D, Point2D};
 use image::RgbaImage;
 use servo::{
-    JSValue, LoadStatus, NavigationRequest, Preferences, RenderingContext, ServoBuilder, SoftwareRenderingContext,
-    WebView, WebViewBuilder, WebViewDelegate,
+    ConsoleLogLevel, JSValue, LoadStatus, NavigationRequest, Preferences, RenderingContext, ServoBuilder,
+    SoftwareRenderingContext, UserContentManager, WebView, WebViewBuilder, WebViewDelegate,
 };
 
 use servo_fetch::layout;
@@ -21,10 +22,29 @@ const SETTLE_DURATION: Duration = Duration::from_millis(500);
 const SPIN_INTERVAL: Duration = Duration::from_millis(10);
 const LAYOUT_JS: &str = include_str!("js/layout.js");
 const MAX_PDF_BYTES: u64 = 50 * 1024 * 1024;
+const MAX_CONSOLE_MESSAGES: usize = 100;
+
+/// CSS injected via user stylesheets to strip common noise elements.
+/// Uses the user origin with `!important` to override author styles.
+const NOISE_REMOVAL_CSS: &str = "\
+[aria-label*=\"cookie\" i], [aria-label*=\"consent\" i], \
+[class*=\"cookie-banner\" i], [class*=\"cookie-consent\" i], \
+[id*=\"cookie\" i][class*=\"banner\" i], \
+[class*=\"newsletter-popup\" i], [class*=\"subscribe-modal\" i] \
+{ display: none !important; }";
 
 struct Delegate {
     loaded: Rc<Cell<bool>>,
     pdf_data: Rc<RefCell<Option<Vec<u8>>>>,
+    a11y_nodes: Rc<RefCell<HashMap<servo::accesskit::NodeId, servo::accesskit::Node>>>,
+    console_messages: Rc<RefCell<Vec<ConsoleMessage>>>,
+}
+
+/// A captured console message from the page.
+#[derive(serde::Serialize)]
+pub(crate) struct ConsoleMessage {
+    pub level: String,
+    pub message: String,
 }
 
 impl WebViewDelegate for Delegate {
@@ -46,6 +66,32 @@ impl WebViewDelegate for Delegate {
                 eprintln!("warning: blocked navigation to {}", navigation_request.url);
                 navigation_request.deny();
             }
+        }
+    }
+
+    fn notify_accessibility_tree_update(&self, _webview: WebView, tree_update: servo::accesskit::TreeUpdate) {
+        // TreeUpdate is incremental — merge nodes into a single map to build the full tree.
+        let mut nodes = self.a11y_nodes.borrow_mut();
+        for (id, node) in tree_update.nodes {
+            nodes.insert(id, node);
+        }
+    }
+
+    fn show_console_message(&self, _webview: WebView, level: ConsoleLogLevel, message: String) {
+        let mut msgs = self.console_messages.borrow_mut();
+        if msgs.len() < MAX_CONSOLE_MESSAGES {
+            let level_str = match level {
+                ConsoleLogLevel::Log => "log",
+                ConsoleLogLevel::Debug => "debug",
+                ConsoleLogLevel::Info => "info",
+                ConsoleLogLevel::Warn => "warn",
+                ConsoleLogLevel::Error => "error",
+                ConsoleLogLevel::Trace => "trace",
+            };
+            msgs.push(ConsoleMessage {
+                level: level_str.to_string(),
+                message,
+            });
         }
     }
 
@@ -111,12 +157,15 @@ pub(crate) struct ServoPage {
     pub screenshot: Option<RgbaImage>,
     pub js_result: Option<String>,
     pub pdf_data: Option<Vec<u8>>,
+    pub accessibility_tree: Option<String>,
+    pub console_messages: Vec<ConsoleMessage>,
 }
 
 struct FetchRequest {
     url: String,
     timeout_secs: u64,
     take_screenshot: bool,
+    need_a11y: bool,
     custom_js: Option<String>,
     reply: mpsc::Sender<Result<ServoPage>>,
 }
@@ -126,6 +175,7 @@ pub(crate) fn fetch_page(
     url: &str,
     timeout_secs: u64,
     take_screenshot: bool,
+    need_a11y: bool,
     custom_js: Option<&str>,
 ) -> Result<ServoPage> {
     static SENDER: std::sync::OnceLock<mpsc::Sender<FetchRequest>> = std::sync::OnceLock::new();
@@ -150,6 +200,7 @@ pub(crate) fn fetch_page(
             url: url.to_string(),
             timeout_secs,
             take_screenshot,
+            need_a11y,
             custom_js: custom_js.map(String::from),
             reply: reply_tx,
         })
@@ -180,9 +231,14 @@ fn servo_thread(rx: mpsc::Receiver<FetchRequest>) {
         let rc_dyn: Rc<dyn RenderingContext> = rc_ctx.clone();
         let loaded = Rc::new(Cell::new(false));
         let pdf_data: Rc<RefCell<Option<Vec<u8>>>> = Rc::new(RefCell::new(None));
+        let a11y_nodes: Rc<RefCell<HashMap<servo::accesskit::NodeId, servo::accesskit::Node>>> =
+            Rc::new(RefCell::new(HashMap::new()));
+        let console_messages: Rc<RefCell<Vec<ConsoleMessage>>> = Rc::new(RefCell::new(Vec::new()));
         let delegate = Rc::new(Delegate {
             loaded: loaded.clone(),
             pdf_data: pdf_data.clone(),
+            a11y_nodes: a11y_nodes.clone(),
+            console_messages: console_messages.clone(),
         });
 
         let parsed_url = match url::Url::parse(&req.url) {
@@ -193,23 +249,48 @@ fn servo_thread(rx: mpsc::Receiver<FetchRequest>) {
             }
         };
 
+        // Set up user stylesheets for noise removal.
+        let ucm = Rc::new(UserContentManager::new(&servo));
+        if let Some(stylesheet) = create_noise_removal_stylesheet() {
+            ucm.add_stylesheet(Rc::new(stylesheet));
+        }
+
         let webview = WebViewBuilder::new(&servo, rc_dyn)
             .url(parsed_url)
             .delegate(delegate)
+            .user_content_manager(ucm)
             .build();
 
-        let result = handle_request(&servo, &webview, &rc_ctx, &loaded, &pdf_data, &req);
+        // Only enable accessibility tree collection when explicitly requested,
+        // to avoid the overhead of building the a11y tree on every fetch.
+        if req.need_a11y {
+            webview.set_accessibility_active(true);
+        }
+
+        let result = handle_request(
+            &servo,
+            &webview,
+            &rc_ctx,
+            &loaded,
+            &pdf_data,
+            &a11y_nodes,
+            &console_messages,
+            &req,
+        );
         drop(webview);
         let _ = req.reply.send(result);
     }
 }
 
+#[expect(clippy::too_many_arguments)]
 fn handle_request(
     servo: &servo::Servo,
     webview: &WebView,
     rc_ctx: &Rc<SoftwareRenderingContext>,
     loaded: &Cell<bool>,
     pdf_data: &RefCell<Option<Vec<u8>>>,
+    a11y_nodes: &RefCell<HashMap<servo::accesskit::NodeId, servo::accesskit::Node>>,
+    console_messages: &RefCell<Vec<ConsoleMessage>>,
     req: &FetchRequest,
 ) -> Result<ServoPage> {
     let deadline = Instant::now() + Duration::from_secs(req.timeout_secs);
@@ -236,6 +317,21 @@ fn handle_request(
         .map(|expr| eval_js(servo, webview, expr))
         .transpose()?;
 
+    // Serialize the merged accessibility tree, masking password field values.
+    let accessibility_tree = {
+        let mut nodes = a11y_nodes.borrow_mut();
+        if nodes.is_empty() {
+            None
+        } else {
+            for node in nodes.values_mut() {
+                if node.role() == servo::accesskit::Role::PasswordInput {
+                    node.clear_value();
+                }
+            }
+            serde_json::to_string(&*nodes).ok()
+        }
+    };
+
     Ok(ServoPage {
         html,
         inner_text,
@@ -243,6 +339,8 @@ fn handle_request(
         screenshot,
         js_result,
         pdf_data: pdf_data.borrow_mut().take(),
+        accessibility_tree,
+        console_messages: console_messages.borrow_mut().drain(..).collect(),
     })
 }
 
@@ -253,6 +351,7 @@ fn build_servo() -> Result<(Rc<SoftwareRenderingContext>, servo::Servo)> {
         .map_err(|e| anyhow!("failed to make context current: {e:?}"))?;
 
     let prefs = Preferences {
+        accessibility_enabled: true,
         dom_webgpu_enabled: false,
         dom_webxr_enabled: false,
         dom_serviceworker_enabled: false,
@@ -263,6 +362,22 @@ fn build_servo() -> Result<(Rc<SoftwareRenderingContext>, servo::Servo)> {
     let rc = Rc::new(ctx);
     let servo = ServoBuilder::default().preferences(prefs).build();
     Ok((rc, servo))
+}
+
+/// Create a user stylesheet for noise removal. Uses serde deserialization because
+/// `UserStyleSheet` does not expose a public constructor in servo v0.1.0.
+fn create_noise_removal_stylesheet() -> Option<servo::user_contents::UserStyleSheet> {
+    let result = serde_json::from_value(serde_json::json!({
+        "source": NOISE_REMOVAL_CSS,
+        "url": "servo-fetch://user-stylesheet/noise-removal"
+    }));
+    match result {
+        Ok(stylesheet) => Some(stylesheet),
+        Err(e) => {
+            eprintln!("warning: failed to create noise removal stylesheet: {e}");
+            None
+        }
+    }
 }
 
 fn spin_until(servo: &servo::Servo, condition: &Cell<bool>, deadline: Instant, timeout_secs: u64) -> Result<()> {

--- a/src/command.rs
+++ b/src/command.rs
@@ -101,6 +101,8 @@ mod tests {
             screenshot: None,
             js_result: None,
             pdf_data: None,
+            accessibility_tree: None,
+            console_messages: Vec::new(),
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,7 +76,7 @@ fn run(args: &cli::Cli) -> anyhow::Result<()> {
         let _ = std::io::Write::flush(&mut std::io::stderr());
     }
 
-    let page = bridge::fetch_page(url.as_str(), args.timeout, need_screenshot, args.js.as_deref());
+    let page = bridge::fetch_page(url.as_str(), args.timeout, need_screenshot, false, args.js.as_deref());
 
     if is_tty {
         eprint!("\r\x1b[K");

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -20,13 +20,15 @@ pub(super) enum OutputFormat {
     Json,
     Html,
     Text,
+    #[serde(rename = "accessibility_tree")]
+    AccessibilityTree,
 }
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 pub(super) struct FetchParams {
     #[schemars(description = "URL to fetch (http/https only)")]
     url: String,
-    #[schemars(description = "Output format. Default: markdown")]
+    #[schemars(description = "Output format: markdown (default), json, html, text, or accessibility_tree")]
     format: Option<OutputFormat>,
     #[schemars(description = "Max characters to return. Default: 5000")]
     max_length: Option<usize>,
@@ -71,7 +73,7 @@ impl ServoMcp {
     }
 
     #[tool(
-        description = "Fetch a URL and extract readable content using the Servo browser engine (JS execution + CSS layout). Navbars, sidebars, and footers are stripped automatically. Use `selector` to extract a specific CSS-selected section instead of full-page Readability extraction. Long content is truncated at max_length; use start_index to paginate."
+        description = "Fetch a URL and extract readable content using the Servo browser engine (JS execution + CSS layout). Navbars, sidebars, and footers are stripped automatically. Use `selector` to extract a specific CSS-selected section instead of full-page Readability extraction. Set format to `accessibility_tree` to get the page's accessibility tree with bounding boxes. Long content is truncated at max_length; use start_index to paginate."
     )]
     async fn fetch(&self, Parameters(p): Parameters<FetchParams>) -> Result<CallToolResult, ErrorData> {
         let url = tools::validated_url(&p.url)?;
@@ -86,7 +88,8 @@ impl ServoMcp {
             ));
         }
 
-        let page = tools::fetch_page(&url, timeout, false, None).await?;
+        let need_a11y = matches!(p.format, Some(OutputFormat::AccessibilityTree));
+        let page = tools::fetch_page(&url, timeout, false, need_a11y, None).await?;
         let full = if let Some(ref pdf_bytes) = page.pdf_data {
             servo_fetch::extract::extract_pdf(pdf_bytes)
         } else {
@@ -96,6 +99,7 @@ impl ServoMcp {
                 OutputFormat::Text => page.inner_text.clone().unwrap_or_default(),
                 OutputFormat::Json => tools::extract(&page, &url, true, p.selector.as_deref())?,
                 OutputFormat::Markdown => tools::extract(&page, &url, false, p.selector.as_deref())?,
+                OutputFormat::AccessibilityTree => page.accessibility_tree.clone().unwrap_or_default(),
             }
         };
         Ok(CallToolResult::success(vec![Content::text(tools::paginate(
@@ -113,7 +117,7 @@ impl ServoMcp {
     }
 
     #[tool(
-        description = "Evaluate a JavaScript expression in a loaded page. Examples: document.title, [...document.querySelectorAll('h2')].map(e => e.textContent)"
+        description = "Evaluate a JavaScript expression in a loaded page. Console messages (log, warn, error) are appended to the result. Examples: document.title, [...document.querySelectorAll('h2')].map(e => e.textContent)"
     )]
     async fn execute_js(&self, Parameters(p): Parameters<ExecuteJsParams>) -> Result<CallToolResult, ErrorData> {
         if p.expression.len() > MAX_JS_LEN {
@@ -125,11 +129,19 @@ impl ServoMcp {
         let url = tools::validated_url(&p.url)?;
         let timeout = p.timeout.unwrap_or(30).clamp(1, MAX_TIMEOUT_SECS);
 
-        let page = tools::fetch_page(&url, timeout, false, Some(&p.expression)).await?;
+        let page = tools::fetch_page(&url, timeout, false, false, Some(&p.expression)).await?;
         let mut result = page.js_result.unwrap_or_default();
         if result.len() > MAX_JS_OUTPUT_LEN {
             result.truncate(tools::floor_char_boundary(&result, MAX_JS_OUTPUT_LEN));
             result.push_str("\n<output truncated>");
+        }
+        // Append console messages if any were captured.
+        if !page.console_messages.is_empty() {
+            result.push_str("\n\n--- console output ---\n");
+            for msg in &page.console_messages {
+                use std::fmt::Write as _;
+                let _ = writeln!(result, "[{}] {}", msg.level, msg.message);
+            }
         }
         Ok(CallToolResult::success(vec![Content::text(
             servo_fetch::sanitize::sanitize(&result).into_owned(),

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -18,11 +18,12 @@ pub(super) async fn fetch_page(
     url: &str,
     timeout: u64,
     screenshot: bool,
+    need_a11y: bool,
     js: Option<&str>,
 ) -> Result<bridge::ServoPage, ErrorData> {
     let url = url.to_string();
     let js = js.map(String::from);
-    tokio::task::spawn_blocking(move || bridge::fetch_page(&url, timeout, screenshot, js.as_deref()))
+    tokio::task::spawn_blocking(move || bridge::fetch_page(&url, timeout, screenshot, need_a11y, js.as_deref()))
         .await
         .map_err(|e| ErrorData::internal_error(e.to_string(), None))?
         .map_err(|e| ErrorData::internal_error(format!("{e:#}"), None))
@@ -47,7 +48,7 @@ pub(super) fn extract(
 }
 
 pub(super) async fn take_screenshot(url: &str, timeout: u64) -> Result<CallToolResult, ErrorData> {
-    let page = fetch_page(url, timeout, true, None).await?;
+    let page = fetch_page(url, timeout, true, false, None).await?;
     let img = page
         .screenshot
         .ok_or_else(|| ErrorData::internal_error("screenshot capture failed", None))?;


### PR DESCRIPTION
## What does this PR do?

Adds three new Servo-native features to servo-fetch:

**Accessibility tree** — Enables Servo's AccessKit integration (`accessibility_enabled: true`, `set_accessibility_active`). Incremental `TreeUpdate`s are merged into a complete node map. Available via `format: "accessibility_tree"` in the MCP fetch tool. Password field values are masked before serialization.

**User stylesheets** — Injects noise-removal CSS via `UserContentManager::add_stylesheet()` to hide common cookie banners and newsletter popups. Logs a warning if stylesheet creation fails.

**Console capture** — Implements `show_console_message()` to collect console output (up to 100 messages). Appended to `execute_js` results automatically.

## How to test

1. `cargo test` — all 93 tests pass
2. `cargo clippy` — zero warnings
3. MCP: `fetch(url: "...", format: "accessibility_tree")` returns a11y tree JSON
4. MCP: `execute_js` results now include console output section

## Checklist

- [x] `cargo clippy` passes with zero warnings
- [x] `cargo test` passes
- [x] `cargo fmt --check` passes
- [x] Commit messages follow Conventional Commits