### PR TITLE
refactor: improve type safety and test coverage

### DIFF
--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -41,10 +41,35 @@ struct Delegate {
 }
 
 /// A captured console message from the page.
-#[derive(serde::Serialize)]
+#[derive(serde::Serialize, Clone)]
 pub(crate) struct ConsoleMessage {
-    pub level: String,
+    pub level: ConsoleLevel,
     pub message: String,
+}
+
+/// Console message severity level.
+#[derive(Debug, Clone, Copy, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum ConsoleLevel {
+    Log,
+    Debug,
+    Info,
+    Warn,
+    Error,
+    Trace,
+}
+
+impl std::fmt::Display for ConsoleLevel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Log => f.write_str("log"),
+            Self::Debug => f.write_str("debug"),
+            Self::Info => f.write_str("info"),
+            Self::Warn => f.write_str("warn"),
+            Self::Error => f.write_str("error"),
+            Self::Trace => f.write_str("trace"),
+        }
+    }
 }
 
 impl WebViewDelegate for Delegate {
@@ -80,18 +105,15 @@ impl WebViewDelegate for Delegate {
     fn show_console_message(&self, _webview: WebView, level: ConsoleLogLevel, message: String) {
         let mut msgs = self.console_messages.borrow_mut();
         if msgs.len() < MAX_CONSOLE_MESSAGES {
-            let level_str = match level {
-                ConsoleLogLevel::Log => "log",
-                ConsoleLogLevel::Debug => "debug",
-                ConsoleLogLevel::Info => "info",
-                ConsoleLogLevel::Warn => "warn",
-                ConsoleLogLevel::Error => "error",
-                ConsoleLogLevel::Trace => "trace",
+            let level = match level {
+                ConsoleLogLevel::Log => ConsoleLevel::Log,
+                ConsoleLogLevel::Debug => ConsoleLevel::Debug,
+                ConsoleLogLevel::Info => ConsoleLevel::Info,
+                ConsoleLogLevel::Warn => ConsoleLevel::Warn,
+                ConsoleLogLevel::Error => ConsoleLevel::Error,
+                ConsoleLogLevel::Trace => ConsoleLevel::Trace,
             };
-            msgs.push(ConsoleMessage {
-                level: level_str.to_string(),
-                message,
-            });
+            msgs.push(ConsoleMessage { level, message });
         }
     }
 
@@ -150,6 +172,7 @@ impl WebViewDelegate for Delegate {
     }
 }
 
+#[derive(Default)]
 pub(crate) struct ServoPage {
     pub html: String,
     pub inner_text: Option<String>,
@@ -159,6 +182,15 @@ pub(crate) struct ServoPage {
     pub pdf_data: Option<Vec<u8>>,
     pub accessibility_tree: Option<String>,
     pub console_messages: Vec<ConsoleMessage>,
+}
+
+/// Options for fetching a page via Servo.
+pub(crate) struct FetchOptions<'a> {
+    pub url: &'a str,
+    pub timeout_secs: u64,
+    pub screenshot: bool,
+    pub accessibility_tree: bool,
+    pub js: Option<&'a str>,
 }
 
 struct FetchRequest {
@@ -171,13 +203,7 @@ struct FetchRequest {
 }
 
 /// Fetch a page via Servo. First call spawns a persistent Servo thread.
-pub(crate) fn fetch_page(
-    url: &str,
-    timeout_secs: u64,
-    take_screenshot: bool,
-    need_a11y: bool,
-    custom_js: Option<&str>,
-) -> Result<ServoPage> {
+pub(crate) fn fetch_page(opts: &FetchOptions<'_>) -> Result<ServoPage> {
     static SENDER: std::sync::OnceLock<mpsc::Sender<FetchRequest>> = std::sync::OnceLock::new();
 
     // Suppress stderr before Servo init to avoid OpenGL driver noise.
@@ -197,11 +223,11 @@ pub(crate) fn fetch_page(
     let (reply_tx, reply_rx) = mpsc::channel();
     sender
         .send(FetchRequest {
-            url: url.to_string(),
-            timeout_secs,
-            take_screenshot,
-            need_a11y,
-            custom_js: custom_js.map(String::from),
+            url: opts.url.to_string(),
+            timeout_secs: opts.timeout_secs,
+            take_screenshot: opts.screenshot,
+            need_a11y: opts.accessibility_tree,
+            custom_js: opts.js.map(String::from),
             reply: reply_tx,
         })
         .map_err(|_| anyhow!("Servo engine is not running (it may have crashed on a previous request)"))?;
@@ -456,6 +482,82 @@ fn jsvalue_to_json(val: &JSValue) -> Result<serde_json::Value> {
         })
     }
     convert(val, 0)
+}
+
+// macOS's Apple Silicon OpenGL driver writes noise to fd 2 via fprintf.
+// Temporarily redirect fd 2 → /dev/null using POSIX dup/dup2 save-restore.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn console_level_display() {
+        assert_eq!(ConsoleLevel::Log.to_string(), "log");
+        assert_eq!(ConsoleLevel::Error.to_string(), "error");
+        assert_eq!(ConsoleLevel::Trace.to_string(), "trace");
+    }
+
+    #[test]
+    fn console_level_serializes_lowercase() {
+        let json = serde_json::to_string(&ConsoleLevel::Warn).unwrap();
+        assert_eq!(json, "\"warn\"");
+    }
+
+    #[test]
+    fn console_message_serializes() {
+        let msg = ConsoleMessage {
+            level: ConsoleLevel::Error,
+            message: "test".into(),
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        assert!(json.contains("\"level\":\"error\""));
+        assert!(json.contains("\"message\":\"test\""));
+    }
+
+    #[test]
+    fn servo_page_default_is_empty() {
+        let page = ServoPage::default();
+        assert!(page.html.is_empty());
+        assert!(page.inner_text.is_none());
+        assert!(page.screenshot.is_none());
+        assert!(page.accessibility_tree.is_none());
+        assert!(page.console_messages.is_empty());
+    }
+
+    #[test]
+    fn jsvalue_to_json_primitives() {
+        assert_eq!(jsvalue_to_json(&JSValue::Null).unwrap(), serde_json::Value::Null);
+        assert_eq!(jsvalue_to_json(&JSValue::Undefined).unwrap(), serde_json::Value::Null);
+        assert_eq!(
+            jsvalue_to_json(&JSValue::Boolean(true)).unwrap(),
+            serde_json::json!(true)
+        );
+        assert_eq!(
+            jsvalue_to_json(&JSValue::Number(42.0)).unwrap(),
+            serde_json::json!(42.0)
+        );
+        assert_eq!(
+            jsvalue_to_json(&JSValue::String("hello".into())).unwrap(),
+            serde_json::json!("hello")
+        );
+    }
+
+    #[test]
+    fn jsvalue_to_json_array() {
+        let val = JSValue::Array(vec![JSValue::Number(1.0), JSValue::String("two".into())]);
+        let result = jsvalue_to_json(&val).unwrap();
+        assert_eq!(result, serde_json::json!([1.0, "two"]));
+    }
+
+    #[test]
+    fn jsvalue_to_json_nested_depth_limit() {
+        let mut val = JSValue::Null;
+        for _ in 0..65 {
+            val = JSValue::Array(vec![val]);
+        }
+        assert!(jsvalue_to_json(&val).is_err());
+    }
 }
 
 // macOS's Apple Silicon OpenGL driver writes noise to fd 2 via fprintf.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -44,9 +44,18 @@ pub struct Cli {
     #[arg(long, value_name = "CSS")]
     pub selector: Option<String>,
 
-    /// Output raw HTML or plain text instead of Readability extraction (html or text)
-    #[arg(long, value_name = "MODE", conflicts_with_all = ["json", "screenshot", "js", "selector"])]
-    pub raw: Option<String>,
+    /// Output raw HTML or plain text instead of Readability extraction
+    #[arg(long, value_name = "MODE", value_enum, conflicts_with_all = ["json", "screenshot", "js", "selector"])]
+    pub raw: Option<RawMode>,
+}
+
+/// Raw output mode.
+#[derive(Debug, Clone, Copy, clap::ValueEnum)]
+pub enum RawMode {
+    /// Raw HTML
+    Html,
+    /// Plain text (document.body.innerText)
+    Text,
 }
 
 /// Available subcommands.
@@ -129,6 +138,14 @@ mod tests {
                 .to_string()
                 .contains("not allowed")
         );
+    }
+
+    #[test]
+    fn raw_mode_from_str() {
+        use clap::ValueEnum;
+        assert!(RawMode::from_str("html", true).is_ok());
+        assert!(RawMode::from_str("text", true).is_ok());
+        assert!(RawMode::from_str("xml", true).is_err());
     }
 }
 

--- a/src/command.rs
+++ b/src/command.rs
@@ -14,10 +14,10 @@ pub struct Markdown<'a> {
 
 impl Markdown<'_> {
     pub fn execute(&self) -> Result<()> {
-        let mut input = servo_fetch::extract::ExtractInput::new(&self.page.html, self.url);
-        input.layout_json = self.page.layout_json.as_deref();
-        input.inner_text = self.page.inner_text.as_deref();
-        input.selector = self.selector;
+        let input = servo_fetch::extract::ExtractInput::new(&self.page.html, self.url)
+            .with_layout_json(self.page.layout_json.as_deref())
+            .with_inner_text(self.page.inner_text.as_deref())
+            .with_selector(self.selector);
         let text = servo_fetch::extract::extract_text(&input)?;
         write!(std::io::stdout(), "{}", servo_fetch::sanitize::sanitize(&text))?;
         Ok(())
@@ -32,10 +32,10 @@ pub struct Json<'a> {
 
 impl Json<'_> {
     pub fn execute(&self) -> Result<()> {
-        let mut input = servo_fetch::extract::ExtractInput::new(&self.page.html, self.url);
-        input.layout_json = self.page.layout_json.as_deref();
-        input.inner_text = self.page.inner_text.as_deref();
-        input.selector = self.selector;
+        let input = servo_fetch::extract::ExtractInput::new(&self.page.html, self.url)
+            .with_layout_json(self.page.layout_json.as_deref())
+            .with_inner_text(self.page.inner_text.as_deref())
+            .with_selector(self.selector);
         let json = servo_fetch::extract::extract_json(&input)?;
         writeln!(std::io::stdout(), "{}", servo_fetch::sanitize::sanitize(&json))?;
         Ok(())
@@ -67,15 +67,14 @@ pub struct JsEval<'a> {
 
 pub struct Raw<'a> {
     pub page: &'a ServoPage,
-    pub mode: &'a str,
+    pub mode: &'a crate::cli::RawMode,
 }
 
 impl Raw<'_> {
     pub fn execute(&self) -> Result<()> {
         let content = match self.mode {
-            "html" => &self.page.html,
-            "text" => self.page.inner_text.as_deref().unwrap_or(""),
-            other => bail!("unknown raw mode '{other}'; use 'html' or 'text'"),
+            crate::cli::RawMode::Html => &self.page.html,
+            crate::cli::RawMode::Text => self.page.inner_text.as_deref().unwrap_or(""),
         };
         write!(std::io::stdout(), "{}", servo_fetch::sanitize::sanitize(content))?;
         Ok(())
@@ -96,13 +95,7 @@ mod tests {
     fn mock_page(html: &str) -> ServoPage {
         ServoPage {
             html: html.to_string(),
-            inner_text: None,
-            layout_json: None,
-            screenshot: None,
-            js_result: None,
-            pdf_data: None,
-            accessibility_tree: None,
-            console_messages: Vec::new(),
+            ..ServoPage::default()
         }
     }
 

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -87,6 +87,27 @@ impl<'a> ExtractInput<'a> {
             selector: None,
         }
     }
+
+    /// Set the layout JSON data.
+    #[must_use]
+    pub fn with_layout_json(mut self, layout_json: Option<&'a str>) -> Self {
+        self.layout_json = layout_json;
+        self
+    }
+
+    /// Set the inner text fallback.
+    #[must_use]
+    pub fn with_inner_text(mut self, inner_text: Option<&'a str>) -> Self {
+        self.inner_text = inner_text;
+        self
+    }
+
+    /// Set the CSS selector for targeted extraction.
+    #[must_use]
+    pub fn with_selector(mut self, selector: Option<&'a str>) -> Self {
+        self.selector = selector;
+        self
+    }
 }
 
 /// Extract readable content as Markdown text.
@@ -302,5 +323,16 @@ mod tests {
         let result = filter(html, Some(layout));
         assert!(!result.contains("<footer"));
         assert!(result.contains("content"));
+    }
+
+    #[test]
+    fn extract_input_builder() {
+        let input = ExtractInput::new("<html></html>", "https://example.com")
+            .with_layout_json(Some("[]"))
+            .with_inner_text(Some("hello"))
+            .with_selector(Some("article"));
+        assert_eq!(input.layout_json, Some("[]"));
+        assert_eq!(input.inner_text, Some("hello"));
+        assert_eq!(input.selector, Some("article"));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,7 +76,13 @@ fn run(args: &cli::Cli) -> anyhow::Result<()> {
         let _ = std::io::Write::flush(&mut std::io::stderr());
     }
 
-    let page = bridge::fetch_page(url.as_str(), args.timeout, need_screenshot, false, args.js.as_deref());
+    let page = bridge::fetch_page(&bridge::FetchOptions {
+        url: url.as_str(),
+        timeout_secs: args.timeout,
+        screenshot: need_screenshot,
+        accessibility_tree: false,
+        js: args.js.as_deref(),
+    });
 
     if is_tty {
         eprint!("\r\x1b[K");

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -23,10 +23,18 @@ pub(super) async fn fetch_page(
 ) -> Result<bridge::ServoPage, ErrorData> {
     let url = url.to_string();
     let js = js.map(String::from);
-    tokio::task::spawn_blocking(move || bridge::fetch_page(&url, timeout, screenshot, need_a11y, js.as_deref()))
-        .await
-        .map_err(|e| ErrorData::internal_error(e.to_string(), None))?
-        .map_err(|e| ErrorData::internal_error(format!("{e:#}"), None))
+    tokio::task::spawn_blocking(move || {
+        bridge::fetch_page(&bridge::FetchOptions {
+            url: &url,
+            timeout_secs: timeout,
+            screenshot,
+            accessibility_tree: need_a11y,
+            js: js.as_deref(),
+        })
+    })
+    .await
+    .map_err(|e| ErrorData::internal_error(e.to_string(), None))?
+    .map_err(|e| ErrorData::internal_error(format!("{e:#}"), None))
 }
 
 pub(super) fn extract(
@@ -35,10 +43,10 @@ pub(super) fn extract(
     json: bool,
     selector: Option<&str>,
 ) -> Result<String, ErrorData> {
-    let mut input = ExtractInput::new(&page.html, url);
-    input.layout_json = page.layout_json.as_deref();
-    input.inner_text = page.inner_text.as_deref();
-    input.selector = selector;
+    let input = ExtractInput::new(&page.html, url)
+        .with_layout_json(page.layout_json.as_deref())
+        .with_inner_text(page.inner_text.as_deref())
+        .with_selector(selector);
     if json {
         extract::extract_json(&input)
     } else {


### PR DESCRIPTION
## What does this PR do?

Improves type safety across the codebase and adds test coverage for previously untested code.

## How to test

1. `cargo test` — 102 tests pass
2. `cargo clippy` — zero warnings

## Checklist

- [x] `cargo clippy` passes with zero warnings
- [x] `cargo test` passes
- [x] `cargo fmt --check` passes
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)