### PR TITLE
chore: tighten lint config and remove unused committed.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,8 @@ module_name_repetitions = { level = "allow", priority = 1 }
 implicit_clone = "warn"
 redundant_type_annotations = "warn"
 use_self = "warn"
+missing_assert_message = "warn"
+redundant_clone = "warn"
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/clippy.toml
+++ b/clippy.toml
@@ -3,3 +3,4 @@ allow-unwrap-in-tests = true
 allow-expect-in-tests = true
 cognitive-complexity-threshold = 30
 too-many-arguments-threshold = 7
+doc-valid-idents = ["SpiderMonkey", "AccessKit", "JavaScript", "WebView", ".."]

--- a/committed.toml
+++ b/committed.toml
@@ -1,2 +1,0 @@
-style = "conventional"
-merge_commit = false

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -198,7 +198,7 @@ fn parse_article(html: &str, url: &str, layout_json: Option<&str>, inner_text: O
                     text_content: markdown,
                     byline: article.byline.clone(),
                     excerpt: article.excerpt.clone(),
-                    lang: article.lang.clone(),
+                    lang: article.lang,
                 };
             }
         }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -95,11 +95,11 @@ impl ServoMcp {
         } else {
             let fmt = p.format.unwrap_or_default();
             match fmt {
-                OutputFormat::Html => page.html.clone(),
-                OutputFormat::Text => page.inner_text.clone().unwrap_or_default(),
+                OutputFormat::Html => page.html,
+                OutputFormat::Text => page.inner_text.unwrap_or_default(),
                 OutputFormat::Json => tools::extract(&page, &url, true, p.selector.as_deref())?,
                 OutputFormat::Markdown => tools::extract(&page, &url, false, p.selector.as_deref())?,
-                OutputFormat::AccessibilityTree => page.accessibility_tree.clone().unwrap_or_default(),
+                OutputFormat::AccessibilityTree => page.accessibility_tree.unwrap_or_default(),
             }
         };
         Ok(CallToolResult::success(vec![Content::text(tools::paginate(


### PR DESCRIPTION
## What does this PR do?

Tighten lint config and remove unused `committed.toml`.

## Checklist

- [x] `cargo clippy` passes with zero warnings
- [x] `cargo test` passes
- [x] `cargo fmt --check` passes
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
