### PR TITLE
docs: use tree URL for npx skills add to avoid full repo clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ servo-fetch mcp --port 8080
 servo-fetch ships with an [Agent Skills](https://agentskills.io/) package for AI coding agents. Install with [`npx skills`](https://github.com/vercel-labs/skills):
 
 ```bash
-npx skills add konippi/servo-fetch
+npx skills add https://github.com/konippi/servo-fetch/tree/main/skills/servo-fetch
 ```
 
 ## Why servo-fetch


### PR DESCRIPTION
## What does this PR do?

Use tree URL for npx skills add to avoid full repo clone.

## Checklist

- [x] `cargo clippy` passes with zero warnings
- [x] `cargo test` passes
- [x] `cargo fmt --check` passes
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
