### PR TITLE
fix: install rustls CryptoProvider to prevent startup crash

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,6 +92,14 @@ jobs:
       - name: Build release binary
         run: cargo build --release --locked --target ${{ matrix.target }}
 
+      - name: Smoke test (non-cross)
+        if: matrix.target != 'aarch64-unknown-linux-gnu' && matrix.target != 'aarch64-unknown-linux-musl'
+        shell: bash
+        run: |
+          BIN=target/${{ matrix.target }}/release/servo-fetch
+          [[ "${{ runner.os }}" == "Windows" ]] && BIN="$BIN.exe"
+          "$BIN" https://example.com > /dev/null
+
       - name: Strip binary (Unix)
         if: runner.os != 'Windows'
         run: strip target/${{ matrix.target }}/release/servo-fetch

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6403,6 +6403,7 @@ dependencies = [
  "pdf-extract",
  "predicates",
  "rmcp",
+ "rustls",
  "schemars",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,16 +37,17 @@ axum = "0.8"
 base64 = "0.22"
 pdf-extract = "0.10"
 ureq = "3"
+rustls = { version = "0.23", default-features = false, features = ["aws-lc-rs"] }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
 [profile.release]
-strip = true
 lto = true
 codegen-units = 1
 opt-level = "s"
 panic = "abort"
+debug = "line-tables-only"
 
 [lints.clippy]
 pedantic = { level = "warn", priority = -1 }

--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -206,9 +206,6 @@ struct FetchRequest {
 pub(crate) fn fetch_page(opts: &FetchOptions<'_>) -> Result<ServoPage> {
     static SENDER: std::sync::OnceLock<mpsc::Sender<FetchRequest>> = std::sync::OnceLock::new();
 
-    // Suppress stderr before Servo init to avoid OpenGL driver noise.
-    let guard = stderr_guard::StderrGuard::suppress();
-
     let sender = SENDER.get_or_init(|| {
         let (tx, rx) = mpsc::channel::<FetchRequest>();
         std::thread::Builder::new()
@@ -232,13 +229,9 @@ pub(crate) fn fetch_page(opts: &FetchOptions<'_>) -> Result<ServoPage> {
         })
         .map_err(|_| anyhow!("Servo engine is not running (it may have crashed on a previous request)"))?;
 
-    let result = reply_rx
+    reply_rx
         .recv()
-        .map_err(|_| anyhow!("Servo engine crashed while processing this page. Try a different URL."))?;
-
-    drop(guard);
-
-    result
+        .map_err(|_| anyhow!("Servo engine crashed while processing this page. Try a different URL."))?
 }
 
 #[expect(clippy::needless_pass_by_value)]
@@ -372,9 +365,14 @@ fn handle_request(
 
 fn build_servo() -> Result<(Rc<SoftwareRenderingContext>, servo::Servo)> {
     let size = PhysicalSize::new(layout::VIEWPORT_WIDTH, layout::VIEWPORT_HEIGHT);
-    let ctx = SoftwareRenderingContext::new(size).map_err(|e| anyhow!("failed to create rendering context: {e:?}"))?;
-    ctx.make_current()
-        .map_err(|e| anyhow!("failed to make context current: {e:?}"))?;
+    let ctx = {
+        let _guard = stderr_guard::StderrGuard::suppress();
+        let ctx =
+            SoftwareRenderingContext::new(size).map_err(|e| anyhow!("failed to create rendering context: {e:?}"))?;
+        ctx.make_current()
+            .map_err(|e| anyhow!("failed to make context current: {e:?}"))?;
+        ctx
+    };
 
     let prefs = Preferences {
         accessibility_enabled: true,
@@ -483,9 +481,6 @@ fn jsvalue_to_json(val: &JSValue) -> Result<serde_json::Value> {
     }
     convert(val, 0)
 }
-
-// macOS's Apple Silicon OpenGL driver writes noise to fd 2 via fprintf.
-// Temporarily redirect fd 2 → /dev/null using POSIX dup/dup2 save-restore.
 
 #[cfg(test)]
 mod tests {

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,10 @@ fn main() {
         libc::signal(libc::SIGPIPE, libc::SIG_DFL);
     }
 
+    rustls::crypto::aws_lc_rs::default_provider()
+        .install_default()
+        .expect("Failed to install rustls crypto provider");
+
     let args = cli::Cli::parse();
 
     // All paths use process::exit to avoid C++ static destructor races with SpiderMonkey.


### PR DESCRIPTION
## What does this PR do?

Fixes an immediate crash on every `servo-fetch` invocation.

Servo 0.1.0's `ResourceManager` thread panics on its first TLS handshake when no rustls `CryptoProvider` is installed, which aborts the process with SIGSEGV before any page can be fetched. This installs `aws_lc_rs` as the default provider at the start of `main`, matching the pattern used by servoshell and servo's `winit_minimal` example.

## How to test

1. `cargo build --release && ./target/release/servo-fetch https://example.com` — should exit 0 and print the example.com page as Markdown.
2. `./target/release/servo-fetch --json https://example.com` and `--screenshot out.png https://example.com` — both exit 0; the JSON is valid and the PNG is a 1280×800 RGBA image.

## Checklist

- [x] `cargo clippy` passes with zero warnings
- [x] `cargo test` passes
- [x] `cargo fmt --check` passes
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)