### PR TITLE
ci: add release-verify workflow for manual dispatch

### DIFF
--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -1,0 +1,128 @@
+name: Validate
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch or tag to validate"
+        required: true
+        default: "main"
+
+jobs:
+  validate:
+    name: ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-24.04
+          - target: aarch64-apple-darwin
+            os: macos-latest
+          - target: x86_64-apple-darwin
+            os: macos-15-intel
+          - target: x86_64-pc-windows-msvc
+            os: windows-2022
+    env:
+      RUST_BACKTRACE: 1
+      CARGO_INCREMENTAL: 0
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          ref: ${{ inputs.ref }}
+
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: stable
+          targets: ${{ matrix.target }}
+
+      - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+      - name: Configure sccache
+        shell: bash
+        run: |
+          echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
+          echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
+          echo "CCACHE=sccache" >> "$GITHUB_ENV"
+
+      - name: Install system dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake clang pkg-config libfontconfig-dev libfreetype-dev \
+            libssl-dev libglib2.0-dev libegl1-mesa-dev \
+            xvfb libegl1 libgles2 libgl1-mesa-dri mesa-utils \
+            libfontconfig1 libfreetype6 libharfbuzz0b libx11-6 libxcb1 libxcb-render0 libxcb-shape0 libxcb-xfixes0
+
+      - name: Set LIBCLANG_PATH (Windows)
+        if: runner.os == 'Windows'
+        shell: bash
+        run: echo "LIBCLANG_PATH=C:\\Program Files\\LLVM\\bin" >> "$GITHUB_ENV"
+
+      - name: Build release binary
+        run: cargo build --release --locked --target ${{ matrix.target }}
+
+      - name: Prepare binary directory (copy Windows DLLs)
+        shell: bash
+        run: |
+          BIN_DIR=target/${{ matrix.target }}/release
+          if [[ "${{ runner.os }}" == "Windows" ]]; then
+            cp "$BIN_DIR"/build/mozangle-*/out/libEGL.dll "$BIN_DIR"/
+            cp "$BIN_DIR"/build/mozangle-*/out/libGLESv2.dll "$BIN_DIR"/
+          fi
+
+      - name: Run scenarios
+        shell: bash
+        env:
+          TARGET: ${{ matrix.target }}
+          RUNNER_OS: ${{ runner.os }}
+        run: |
+          set -uo pipefail
+          BIN="target/${TARGET}/release/servo-fetch"
+          [[ "$RUNNER_OS" == "Windows" ]] && BIN="$BIN.exe"
+          RUN=("$BIN")
+          [[ "$RUNNER_OS" == "Linux" ]] && RUN=(xvfb-run --auto-servernum --server-args="-screen 0 1280x800x24" "$BIN")
+
+          pass=0 fail=0 total=0
+          ok()  { total=$((total + 1)); pass=$((pass + 1)); echo "  [PASS] $1"; }
+          bad() { total=$((total + 1)); fail=$((fail + 1)); echo "  [FAIL] $1"; }
+
+          echo "=== Scenarios on $TARGET ($RUNNER_OS) ==="
+
+          "$BIN" --help >/dev/null 2>&1 && ok 'S1 --help' || bad 'S1 --help'
+          "$BIN" 'not-a-url' >/dev/null 2>&1 && bad 'S2 invalid URL rejected' || ok 'S2 invalid URL rejected'
+          "$BIN" 'file:///etc/passwd' >/dev/null 2>&1 && bad 'S3 file:// rejected' || ok 'S3 file:// rejected'
+          "$BIN" 'http://127.0.0.1' >/dev/null 2>&1 && bad 'S4 SSRF 127.0.0.1 blocked' || ok 'S4 SSRF 127.0.0.1 blocked'
+
+          out=$(mktemp)
+          if "${RUN[@]}" 'https://example.com' >"$out" 2>/dev/null && grep -q 'Example Domain' "$out"; then
+            ok 'S5 markdown fetch'; else bad 'S5 markdown fetch'; fi
+          rm -f "$out"
+
+          out=$(mktemp)
+          if "${RUN[@]}" --json 'https://example.com' >"$out" 2>/dev/null && python3 -c 'import json,sys; json.load(open(sys.argv[1]))' "$out" 2>/dev/null; then
+            ok 'S6 --json valid'; else bad 'S6 --json valid'; fi
+          rm -f "$out"
+
+          png="$(mktemp).png"
+          if "${RUN[@]}" --screenshot "$png" 'https://example.com' >/dev/null 2>&1 \
+            && python3 -c "import sys; assert open(sys.argv[1],'rb').read(8) == b'\x89PNG\r\n\x1a\n'" "$png" 2>/dev/null; then
+            ok 'S7 --screenshot PNG'; else bad 'S7 --screenshot PNG'; fi
+          rm -f "$png"
+
+          out=$(mktemp)
+          if "${RUN[@]}" --selector 'h1' 'https://example.com' >"$out" 2>/dev/null && grep -q 'Example Domain' "$out"; then
+            ok 'S8 --selector h1'; else bad 'S8 --selector h1'; fi
+          rm -f "$out"
+
+          out=$(mktemp)
+          if "${RUN[@]}" --js 'document.title' 'https://example.com' >"$out" 2>/dev/null && grep -q 'Example Domain' "$out"; then
+            ok 'S9 --js'; else bad 'S9 --js'; fi
+          rm -f "$out"
+
+          if "${RUN[@]}" 'https://example.com' >/dev/null 2>&1 && "${RUN[@]}" 'https://example.com' >/dev/null 2>&1; then
+            ok 'S10 sequential fetch'; else bad 'S10 sequential fetch'; fi
+
+          echo "=== Summary: $pass/$total passed, $fail failed ==="
+          exit "$fail"


### PR DESCRIPTION
Adds a manually-triggered workflow that builds the release binary on all 4 target platforms and runs 10 end-to-end scenarios (CLI validation, fetch, JSON, screenshot, selector, JS, sequential fetch) against it. Useful for verifying a fix branch before tagging a release.

Trigger with: `gh workflow run release-verify.yml --ref main -f ref=<branch-or-tag>`