### PR TITLE
ci: print stderr on scenario failure

### DIFF
--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -78,54 +78,114 @@ jobs:
           TARGET: ${{ matrix.target }}
           RUNNER_OS: ${{ runner.os }}
         run: |
-          set -uo pipefail
+          set -u
           BIN="target/${TARGET}/release/servo-fetch"
           [[ "$RUNNER_OS" == "Windows" ]] && BIN="$BIN.exe"
           RUN=("$BIN")
           [[ "$RUNNER_OS" == "Linux" ]] && RUN=(xvfb-run --auto-servernum --server-args="-screen 0 1280x800x24" "$BIN")
 
-          pass=0 fail=0 total=0
-          last_err=""
-          ok()  { total=$((total + 1)); pass=$((pass + 1)); echo "  [PASS] $1"; }
-          bad() { total=$((total + 1)); fail=$((fail + 1)); echo "  [FAIL] $1"; [ -n "$last_err" ] && echo "    stderr: $last_err"; }
+          pass=0 fail=0
+          # dump: name, "pass"/"fail", stdout, stderr
+          report() {
+            local name=$1 result=$2 out=$3 err=$4
+            if [[ "$result" == "pass" ]]; then
+              pass=$((pass + 1)); echo "  [PASS] $name"
+            else
+              fail=$((fail + 1))
+              echo "  [FAIL] $name"
+              echo "    --- stderr ---"; sed 's/^/    | /' "$err" | head -n 20
+              echo "    --- stdout (first 200 bytes) ---"; head -c 200 "$out" | sed 's/^/    | /'
+              echo ""
+            fi
+          }
 
           echo "=== Scenarios on $TARGET ($RUNNER_OS) ==="
 
-          "$BIN" --help >/dev/null 2>&1 && ok 'S1 --help' || bad 'S1 --help'
-          "$BIN" 'not-a-url' >/dev/null 2>&1 && bad 'S2 invalid URL rejected' || ok 'S2 invalid URL rejected'
-          "$BIN" 'file:///etc/passwd' >/dev/null 2>&1 && bad 'S3 file:// rejected' || ok 'S3 file:// rejected'
-          "$BIN" 'http://127.0.0.1' >/dev/null 2>&1 && bad 'S4 SSRF 127.0.0.1 blocked' || ok 'S4 SSRF 127.0.0.1 blocked'
+          # S1-S4: CLI-only, no Servo startup required
+          out=$(mktemp) err=$(mktemp)
+          "$BIN" --help >"$out" 2>"$err"
+          [[ $? == 0 ]] && report 'S1 --help' pass "$out" "$err" || report 'S1 --help' fail "$out" "$err"
+          rm -f "$out" "$err"
 
           out=$(mktemp) err=$(mktemp)
-          if "${RUN[@]}" 'https://example.com' >"$out" 2>"$err" && grep -q 'Example Domain' "$out"; then
-            ok 'S5 markdown fetch'; else last_err=$(tr '\n' '|' <"$err" | head -c 500); bad 'S5 markdown fetch'; fi
-          rm -f "$out" "$err"; last_err=""
+          "$BIN" 'not-a-url' >"$out" 2>"$err"
+          [[ $? != 0 ]] && report 'S2 invalid URL rejected' pass "$out" "$err" || report 'S2 invalid URL rejected' fail "$out" "$err"
+          rm -f "$out" "$err"
 
           out=$(mktemp) err=$(mktemp)
-          if "${RUN[@]}" --json 'https://example.com' >"$out" 2>"$err" && python3 -c 'import json,sys; json.load(open(sys.argv[1]))' "$out" 2>/dev/null; then
-            ok 'S6 --json valid'; else last_err=$(tr '\n' '|' <"$err" | head -c 500); bad 'S6 --json valid'; fi
-          rm -f "$out" "$err"; last_err=""
-
-          png="$(mktemp).png" err=$(mktemp)
-          if "${RUN[@]}" --screenshot "$png" 'https://example.com' >/dev/null 2>"$err" \
-            && python3 -c "import sys; assert open(sys.argv[1],'rb').read(8) == b'\x89PNG\r\n\x1a\n'" "$png" 2>/dev/null; then
-            ok 'S7 --screenshot PNG'; else last_err=$(tr '\n' '|' <"$err" | head -c 500); bad 'S7 --screenshot PNG'; fi
-          rm -f "$png" "$err"; last_err=""
+          "$BIN" 'file:///etc/passwd' >"$out" 2>"$err"
+          [[ $? != 0 ]] && report 'S3 file:// rejected' pass "$out" "$err" || report 'S3 file:// rejected' fail "$out" "$err"
+          rm -f "$out" "$err"
 
           out=$(mktemp) err=$(mktemp)
-          if "${RUN[@]}" --selector 'h1' 'https://example.com' >"$out" 2>"$err" && grep -q 'Example Domain' "$out"; then
-            ok 'S8 --selector h1'; else last_err=$(tr '\n' '|' <"$err" | head -c 500); bad 'S8 --selector h1'; fi
-          rm -f "$out" "$err"; last_err=""
+          "$BIN" 'http://127.0.0.1' >"$out" 2>"$err"
+          [[ $? != 0 ]] && report 'S4 SSRF 127.0.0.1 blocked' pass "$out" "$err" || report 'S4 SSRF 127.0.0.1 blocked' fail "$out" "$err"
+          rm -f "$out" "$err"
 
+          # S5: basic markdown fetch
           out=$(mktemp) err=$(mktemp)
-          if "${RUN[@]}" --js 'document.title' 'https://example.com' >"$out" 2>"$err" && grep -q 'Example Domain' "$out"; then
-            ok 'S9 --js'; else last_err=$(tr '\n' '|' <"$err" | head -c 500); bad 'S9 --js'; fi
-          rm -f "$out" "$err"; last_err=""
+          "${RUN[@]}" 'https://example.com' >"$out" 2>"$err"
+          if [[ $? == 0 ]] && grep -q 'Example Domain' "$out"; then
+            report 'S5 markdown fetch' pass "$out" "$err"
+          else
+            report 'S5 markdown fetch' fail "$out" "$err"
+          fi
+          rm -f "$out" "$err"
 
-          err=$(mktemp)
-          if "${RUN[@]}" 'https://example.com' >/dev/null 2>"$err" && "${RUN[@]}" 'https://example.com' >/dev/null 2>>"$err"; then
-            ok 'S10 sequential fetch'; else last_err=$(tr '\n' '|' <"$err" | head -c 500); bad 'S10 sequential fetch'; fi
-          rm -f "$err"; last_err=""
+          # S6: JSON
+          out=$(mktemp) err=$(mktemp)
+          "${RUN[@]}" --json 'https://example.com' >"$out" 2>"$err"
+          if [[ $? == 0 ]] && python3 -c 'import json,sys; json.load(open(sys.argv[1]))' "$out" 2>/dev/null; then
+            report 'S6 --json valid' pass "$out" "$err"
+          else
+            report 'S6 --json valid' fail "$out" "$err"
+          fi
+          rm -f "$out" "$err"
 
+          # S7: screenshot
+          png="$(mktemp).png"; err=$(mktemp); out=$(mktemp)
+          "${RUN[@]}" --screenshot "$png" 'https://example.com' >"$out" 2>"$err"
+          if [[ $? == 0 ]] && python3 -c "import sys; assert open(sys.argv[1],'rb').read(8) == b'\x89PNG\r\n\x1a\n'" "$png" 2>/dev/null; then
+            report 'S7 --screenshot PNG' pass "$out" "$err"
+          else
+            report 'S7 --screenshot PNG' fail "$out" "$err"
+          fi
+          rm -f "$png" "$err" "$out"
+
+          # S8: --selector
+          out=$(mktemp) err=$(mktemp)
+          "${RUN[@]}" --selector 'h1' 'https://example.com' >"$out" 2>"$err"
+          if [[ $? == 0 ]] && grep -q 'Example Domain' "$out"; then
+            report 'S8 --selector h1' pass "$out" "$err"
+          else
+            report 'S8 --selector h1' fail "$out" "$err"
+          fi
+          rm -f "$out" "$err"
+
+          # S9: --js
+          out=$(mktemp) err=$(mktemp)
+          "${RUN[@]}" --js 'document.title' 'https://example.com' >"$out" 2>"$err"
+          if [[ $? == 0 ]] && grep -q 'Example Domain' "$out"; then
+            report 'S9 --js' pass "$out" "$err"
+          else
+            report 'S9 --js' fail "$out" "$err"
+          fi
+          rm -f "$out" "$err"
+
+          # S10: two sequential fetches in separate processes
+          out1=$(mktemp) err1=$(mktemp) out2=$(mktemp) err2=$(mktemp)
+          "${RUN[@]}" 'https://example.com' >"$out1" 2>"$err1"; r1=$?
+          "${RUN[@]}" 'https://example.com' >"$out2" 2>"$err2"; r2=$?
+          if [[ $r1 == 0 && $r2 == 0 ]]; then
+            report 'S10 sequential fetch' pass "$out2" "$err2"
+          else
+            echo "  [FAIL] S10 sequential fetch (r1=$r1 r2=$r2)"
+            echo "    --- run1 stderr ---"; sed 's/^/    | /' "$err1" | head -n 20
+            echo "    --- run2 stderr ---"; sed 's/^/    | /' "$err2" | head -n 20
+            fail=$((fail + 1))
+          fi
+          rm -f "$out1" "$err1" "$out2" "$err2"
+
+          total=$((pass + fail))
           echo "=== Summary: $pass/$total passed, $fail failed ==="
           exit "$fail"


### PR DESCRIPTION
The previous attempt to capture stderr silently discarded the message. Rewrite the scenario runner so each failing case dumps its stderr (first 20 lines) and a short stdout sample inline, and split S10 into two separate processes so we can see stderr from each.