### PR TITLE
fix(ci): install llvm for mozjs_sys aarch64 Linux source build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake clang pkg-config libfontconfig-dev libfreetype-dev \
+          sudo apt-get install -y cmake clang llvm pkg-config libfontconfig-dev libfreetype-dev \
             libssl-dev libglib2.0-dev libegl1-mesa-dev \
             xvfb libegl1 libgles2 libgl1-mesa-dri mesa-utils \
             libfontconfig1 libfreetype6 libharfbuzz0b libx11-6 libxcb1 libxcb-render0 libxcb-shape0 libxcb-xfixes0

--- a/.github/workflows/test-smoke.yml
+++ b/.github/workflows/test-smoke.yml
@@ -57,7 +57,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake clang pkg-config libfontconfig-dev libfreetype-dev \
+          sudo apt-get install -y cmake clang llvm pkg-config libfontconfig-dev libfreetype-dev \
             libssl-dev libglib2.0-dev libegl1-mesa-dev \
             xvfb libegl1 libgles2 libgl1-mesa-dri mesa-utils \
             libfontconfig1 libfreetype6 libharfbuzz0b libx11-6 libxcb1 libxcb-render0 libxcb-shape0 libxcb-xfixes0


### PR DESCRIPTION
## What does this PR do?

Fix the `aarch64-unknown-linux-gnu` build failure in the current smoke-test run ([run 24993962903](https://github.com/konippi/servo-fetch/actions/runs/24993962903)).

## Root cause

`mozjs_sys` (SpiderMonkey bindings) ships pre-built archives for common targets (x86_64 Linux, macOS, Windows) and downloads them during `build.rs`. For `aarch64-unknown-linux-gnu` no pre-built is published, so it falls back to building from source, which requires `llvm-objdump`:

```
warning: mozjs_sys@0.140.8-2: Failed to link pre-built archive by entity not found. Building from source instead.
  ERROR: Cannot find llvm-objdump
  gmake: *** [.../makefile.cargo:199: maybe-configure] Error 1
```

The other four matrix legs are unaffected because they successfully download the pre-built archive and never enter the source-build path.

## Fix

Install the `llvm` package (which provides `llvm-objdump`) alongside `clang` in the Linux apt step of both `release.yml` and `test-smoke.yml`.

## Trade-off

`aarch64-unknown-linux-gnu` now builds `mozjs_sys` from source, which adds ~20–40 minutes to that job. Acceptable for release-validation workflows; no change to PR-gating `ci.yml` which runs on `ubuntu-24.04` (x86_64) and still hits the pre-built path.

## Verification

After merge, re-run the smoke workflow against `main`:

```bash
gh workflow run test-smoke.yml -f ref=main
```

All five targets should reach the L1/L2 smoke stages.
