### PR TITLE
fix(release): publish crate before marking release as non-draft

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -168,22 +168,9 @@ jobs:
             gh release upload "$GITHUB_REF_NAME" "$ARCHIVE.tar.gz" "$ARCHIVE.tar.gz.sha256"
           fi
 
-  publish-release:
-    name: Publish Release
-    needs: [create-release, build-release]
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-      - name: Mark release as non-draft
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release edit "$GITHUB_REF_NAME" --draft=false
-
   publish-crate:
     name: Publish to crates.io
-    needs: [publish-release]
+    needs: [create-release, build-release]
     runs-on: ubuntu-24.04
     permissions:
       id-token: write
@@ -197,4 +184,19 @@ jobs:
       - uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe # v1.0.4
         id: auth
       - name: Publish to crates.io
-        run: cargo publish --locked --no-verify --token ${{ steps.auth.outputs.token }}
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+        run: cargo publish --locked --no-verify
+
+  publish-release:
+    name: Publish Release
+    needs: [create-release, build-release, publish-crate]
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Mark release as non-draft
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release edit "$GITHUB_REF_NAME" --draft=false


### PR DESCRIPTION
## What does this PR do?

Fix three correctness issues in `release.yml` that could lead to a half-published release where the GitHub release is live but the crate is missing (or vice versa).

### C1: `publish-crate` now has explicit fan-in on `build-release`

**Before:** `publish-crate: needs: [publish-release]` only — the release was considered "done" the moment it was flipped to non-draft, and `publish-crate` ran afterward with no direct dependency on the build artifacts.

**After:** `publish-crate: needs: [create-release, build-release]` — the crate publish explicitly waits for all five matrix legs of `build-release` to succeed before touching crates.io.

### C2: Crate publish moved **before** release flip to non-draft

**Before:** `create-release → build-release → publish-release → publish-crate`. If `cargo publish` failed (e.g. transient crates.io outage), the GitHub release was already public with artifacts that point to a version not on crates.io. Users running `cargo install servo-fetch` would fail.

**After:** `create-release → build-release → publish-crate → publish-release`. If `cargo publish` fails the release stays draft, the maintainer gets an actionable red job to retry or fix, and no half-state is visible to users. This matches the order used by [ripgrep](https://github.com/BurntSushi/ripgrep/blob/master/.github/workflows/release.yml), [tokio](https://github.com/tokio-rs/tokio), and [gitoxide](https://github.com/Byron/gitoxide/blob/main/.github/workflows/release.yml): publish to the registry first, announce second.

### H1: `cargo publish` token moved from `--token` flag to `CARGO_REGISTRY_TOKEN` env

**Before:** `cargo publish --token ${{ steps.auth.outputs.token }}` passed the token on the command line. Process-list visible on the runner, visible in shell trace if `set -x` is ever enabled, and against the explicit recommendation of [rust-lang/crates-io-auth-action](https://github.com/rust-lang/crates-io-auth-action).

**After:** `env: CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}` — cargo picks it up from env, the flag isn't present on the command line, and it stops appearing in `ps` output.

## Follow-ups (not in this PR)

- Apply `concurrency` on release.yml (tracked in the broader workflow hardening).
- Consider a GitHub `environment` with a manual approval gate for `publish-crate` (one-way door).
- `cargo package --list` pre-flight before `cargo publish --no-verify` (tracked in PR #30).

## Verification

Cannot be verified in CI without actually tagging a release. Manual review of the job order and the two fan-in edges (`publish-crate -> build-release`, `publish-release -> publish-crate`) is the gate.
