### PR TITLE
fix(ci): tighten ci-passed gate against silent skipped jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,11 +119,28 @@ jobs:
   ci-passed:
     name: CI Passed
     if: always()
-    needs: [clippy, fmt, deny, typos]
+    needs: [changes, clippy, fmt, deny, typos]
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
-      - run: |
-          if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+      - name: Check required jobs
+        env:
+          NEEDS: ${{ toJSON(needs) }}
+        run: |
+          set -euo pipefail
+          # Any failure or cancellation is a hard fail.
+          if printf '%s' "$NEEDS" | grep -qE '"result": *"(failure|cancelled)"'; then
+            echo "::error::One or more required jobs failed or were cancelled"
+            printf '%s\n' "$NEEDS"
             exit 1
           fi
+          # `changes` and `typos` have no `if:` guard, so they must succeed
+          # (never legitimately skipped — skipped means GitHub error).
+          for job in changes typos; do
+            result=$(printf '%s' "$NEEDS" | python3 -c "import json,sys; print(json.loads(sys.stdin.read())['$job']['result'])")
+            if [ "$result" != "success" ]; then
+              echo "::error::Required job '$job' did not succeed (result=$result)"
+              exit 1
+            fi
+          done
+          echo "All required jobs passed (paths-filter skips are allowed for code-gated jobs)"


### PR DESCRIPTION
## What does this PR do?

Tighten the `ci-passed` gate in `ci.yml` so that:

1. Any `failure` or `cancelled` result still fails the gate (existing behavior).
2. `changes` and `typos`, which have **no `if:` guard** and must always run, now fail the gate if they end up `skipped` (previously such a skip would silently be treated as success).
3. `clippy` / `fmt` / `deny` can legitimately be `skipped` via the `paths-filter` gate (e.g. for docs-only PRs) without blocking the CI.

## Checklist

- [x] `cargo clippy` passes with zero warnings
- [x] `cargo test` passes
- [x] `cargo fmt --check` passes
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)