### PR TITLE
ci: add actionlint and zizmor workflow linters

### DIFF
--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -1,0 +1,46 @@
+name: Lint Workflows
+
+on:
+  pull_request:
+    paths: ['.github/workflows/**']
+  push:
+    branches: [main]
+    paths: ['.github/workflows/**']
+
+permissions:
+  contents: read
+
+concurrency:
+  group: lint-workflows-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  actionlint:
+    name: actionlint
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Run actionlint
+        run: |
+          bash <(curl -fsSL --retry 3 https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash) 1.7.7
+          ./actionlint -color
+
+  zizmor:
+    name: zizmor
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+      - name: Run zizmor
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: uvx zizmor@1.14.2 --min-severity medium --format github .


### PR DESCRIPTION
## What does this PR do?

Add a dedicated `Lint Workflows` workflow that runs [actionlint](https://github.com/rhysd/actionlint) and [zizmor](https://woodruffw.github.io/zizmor/) on every PR and push to main that touches `.github/workflows/**`.

### actionlint

Catches shell issues, typos, misuse of contexts, invalid runner labels, etc. — the same tool that caught the `runner.os` context misuse earlier in this release cycle. Pinned to `1.7.7` via the upstream-recommended `download-actionlint.bash` script.

### zizmor

Security-focused linter specific to GitHub Actions, authored by William Woodruff (PyCA `cryptography`, pip, trusted-publishing). Flags script-injection, over-scoped permissions, untrusted checkout of PR head, float-pinned actions, etc. — the class of issues that became widely visible during the [tj-actions/changed-files CVE-2025-30066](https://nvd.nist.gov/vuln/detail/CVE-2025-30066) incident in March 2025.

Pinned to `zizmor@1.14.2` and run at `--min-severity medium`.

### Triggered on workflow edits only

`paths: ['.github/workflows/**']` — no need to burn CI minutes on unrelated source changes. Matches the pattern used by `skills.yml` in this repo.

### Why a separate workflow (not added to `ci.yml`)

- `ci.yml` has a carefully-designed paths-filter gate and `ci-passed` fan-in. Mixing a linter that only runs on YAML edits into that gate complicates the contract.
- A dedicated workflow is trivial to debug and iterate on, and its result appears as its own required check in branch protection.

## OSS precedent

- `astral-sh/uv` has `check-zizmor.yml` with the same `uvx zizmor` pattern.
- `rust-lang/rust` CI runs actionlint separately.
- `denoland/deno` runs both.

## Verification

After merge, edit any file under `.github/workflows/` in a PR and confirm the new `Lint Workflows` check runs (both `actionlint` and `zizmor` legs).
