### PR TITLE
fix(ci): guard XVFB array expansion for macOS bash 3.2

### DIFF
--- a/.github/workflows/test-smoke.yml
+++ b/.github/workflows/test-smoke.yml
@@ -116,7 +116,7 @@ jobs:
         env:
           RUNNER_OS_NAME: ${{ runner.os }}
         run: |
-          set -euxo pipefail
+          set -eux -o pipefail
           BIN="target/${TARGET}/release/servo-fetch"
           [[ "$RUNNER_OS_NAME" == "Windows" ]] && BIN="$BIN.exe"
           if [[ "$RUNNER_OS_NAME" == "Linux" ]]; then
@@ -126,7 +126,7 @@ jobs:
           fi
 
           for i in 1 2 3; do
-            "${XVFB[@]}" "$BIN" 'https://example.com' | grep -q 'Example Domain' && exit 0
+            "${XVFB[@]+"${XVFB[@]}"}" "$BIN" 'https://example.com' | grep -q 'Example Domain' && exit 0
             echo "attempt $i failed; sleeping 15s" >&2
             sleep 15
           done
@@ -138,7 +138,7 @@ jobs:
         env:
           RUNNER_OS_NAME: ${{ runner.os }}
         run: |
-          set -euxo pipefail
+          set -eux -o pipefail
           BIN="target/${TARGET}/release/servo-fetch"
           [[ "$RUNNER_OS_NAME" == "Windows" ]] && BIN="$BIN.exe"
           if [[ "$RUNNER_OS_NAME" == "Linux" ]]; then
@@ -148,13 +148,13 @@ jobs:
           fi
           SHOT="$RUNNER_TEMP/shot.png"
 
-          "${XVFB[@]}" "$BIN" --json 'https://example.com' \
+          "${XVFB[@]+"${XVFB[@]}"}" "$BIN" --json 'https://example.com' \
             | python3 -c 'import json,sys; json.load(sys.stdin)'
           sleep 2
 
-          "${XVFB[@]}" "$BIN" --screenshot "$SHOT" 'https://example.com'
+          "${XVFB[@]+"${XVFB[@]}"}" "$BIN" --screenshot "$SHOT" 'https://example.com'
           head -c 8 "$SHOT" | cmp -s - <(printf '\x89PNG\r\n\x1a\n')
           sleep 2
 
-          "${XVFB[@]}" "$BIN" --js 'document.title' 'https://example.com' \
+          "${XVFB[@]+"${XVFB[@]}"}" "$BIN" --js 'document.title' 'https://example.com' \
             | grep -q 'Example Domain'


### PR DESCRIPTION
## What does this PR do?

Fix the smoke-test failure on macOS runners, where both `x86_64-apple-darwin` and `aarch64-apple-darwin` exited with:

```
/Users/runner/work/_temp/xxx.sh: line 12: XVFB[@]: unbound variable
```

## Root cause

macOS ships **bash 3.2** (not upgraded since 2007 for GPL reasons). In bash 3.2 an empty array expanded with `"${XVFB[@]}"` under `set -u` (nounset) is reported as an **unbound variable**. Newer bash (4.4+, what Linux and Windows git-bash use) returns zero words as expected.

The `Smoke (L2)` and `Smoke (L3)` steps both do:

```bash
set -euxo pipefail
if [[ "$RUNNER_OS_NAME" == "Linux" ]]; then
  XVFB=(xvfb-run ...)
else
  XVFB=()         # empty array
fi
"${XVFB[@]}" "$BIN" ...   # fails on macOS bash 3.2
```

## Related

- Does **not** fix the Linux-only SIGSEGV (exit 139). That is tracked in #37.
