### PR TITLE
fix(release): set shell bash on Build release and Strip binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,6 +100,7 @@ jobs:
         run: printf 'LIBCLANG_PATH=C:\\Program Files\\LLVM\\bin\n' >> "$GITHUB_ENV"
 
       - name: Build release binary
+        shell: bash
         run: cargo build --release --locked --target "$TARGET"
 
       - name: Bundle Windows ANGLE DLLs
@@ -123,6 +124,7 @@ jobs:
 
       - name: Strip binary (Unix)
         if: runner.os != 'Windows'
+        shell: bash
         run: strip "target/$TARGET/release/servo-fetch"
 
       - name: Determine archive name


### PR DESCRIPTION
## What does this PR do?

Fix the Windows build failure in the v0.2.1 release run: `Build release binary` ran under PowerShell and expanded `$TARGET` (the env variable name) as PowerShell's empty `$TARGET`, producing `error: target was empty`.

## Checklist

- [x] `cargo clippy` passes with zero warnings
- [x] `cargo test` passes
- [x] `cargo fmt --check` passes
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)