### PR TITLE
fix(release): pass --repo to gh release edit so checkout is not required

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -209,7 +209,8 @@ jobs:
       contents: write
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      REPO: ${{ github.repository }}
       TAG: ${{ github.ref_name }}
     steps:
       - name: Mark release as non-draft
-        run: gh release edit "$TAG" --draft=false
+        run: gh release edit "$TAG" --repo "$REPO" --draft=false


### PR DESCRIPTION
## What does this PR do?

Fix the `Publish Release` job of v0.2.1 release, which failed with:

```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

## Checklist

- [x] `cargo clippy` passes with zero warnings
- [x] `cargo test` passes
- [x] `cargo fmt --check` passes
- [x] Commit messages follow Conventional Commits