### PR TITLE
chore(ci): add 7-day cooldown to dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
     open-pull-requests-limit: 10
     commit-message:
       prefix: "chore(deps)"
+    cooldown:
+      default-days: 7
     groups:
       patch-updates:
         update-types: ["patch"]
@@ -16,3 +18,5 @@ updates:
       interval: weekly
     commit-message:
       prefix: "chore(ci)"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
## Summary

Add a 7-day cooldown to Dependabot updates so a newly-published package isn't PR'd until it has survived a week of scrutiny in the wild.

Addresses the two `zizmor/dependabot-cooldown` warnings ([#10](https://github.com/konippi/servo-fetch/security/code-scanning/10), [#11](https://github.com/konippi/servo-fetch/security/code-scanning/11)) raised against `.github/dependabot.yml` — one for each `updates:` block.

### Why 7 days

The goal is to give the broader ecosystem enough time to notice and revoke a supply-chain-compromised release before we auto-merge it. 7 days is the common trade-off:

- Long enough that advisories, social-media reports, and downstream CI failures typically surface.
- Short enough that legitimate bug-fix releases still reach us within the same sprint.

Large orgs sometimes go to 14 or 30 days; for a small CLI project with one maintainer, 7 days is adequate. Easy to raise later if we see a near-miss.

## Test Plan

- YAML parses and each `updates:` block has `cooldown.default-days: 7` (verified locally with `ruby -e 'require "yaml"; ...'`).
- After merge, zizmor alerts #10 and #11 should auto-resolve on the next scan.

## Checklist

- [x] `cargo clippy` passes with zero warnings (no code changes)
- [x] `cargo test` passes (no code changes)
- [x] `cargo fmt --check` passes (no code changes)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it
