### PR TITLE
fix(release): remove sccache from release pipeline to prevent cache poisoning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,9 +66,6 @@ jobs:
     env:
       RUST_BACKTRACE: 1
       CARGO_INCREMENTAL: 0
-      SCCACHE_GHA_ENABLED: "true"
-      RUSTC_WRAPPER: sccache
-      CCACHE: sccache
       TARGET: ${{ matrix.target }}
       VERSION: ${{ needs.create-release.outputs.version }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -82,8 +79,6 @@ jobs:
         with:
           toolchain: "1.95.0"
           targets: ${{ matrix.target }}
-
-      - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
 
       - name: Install system dependencies (Linux)
         if: runner.os == 'Linux'


### PR DESCRIPTION
## Summary

Remove `sccache` from `release.yml` to close the `zizmor/cache-poisoning` error ([alert #9](https://github.com/konippi/servo-fetch/security/code-scanning/9)).

### Why remove, not gate

`release.yml` triggers only on `refs/tags/v*.*.*`. That means every invocation is a release build that publishes artifacts to GitHub Releases and crates.io. Under that model, reusing a GHA cache is a straight-up supply-chain risk:

- Any PR or branch run that writes to the shared sccache namespace could plant a poisoned compiler output.
- The next tag push reads that cached artifact and ships it as `servo-fetch v0.2.x`.
- The `mozilla-actions/sccache-action` uses a single GHA cache namespace per repo, so branch-scoped isolation does not help here.

This is exactly the pattern described in [Adnan Khan's GitHub Actions cache poisoning write-up](https://adnanthekhan.com/posts/angular-compromise-through-dev-infra/) from December 2025 (Angular compromise).

Turning sccache off only on tag push would be possible (`SCCACHE_GHA_ENABLED: ${{ !startsWith(github.ref, 'refs/tags/') }}`), but `release.yml` **only runs on tag push**, so "off on tag" equals "always off". Deleting the 4 lines (env + step) is the simpler and more obviously-correct change.

### What this costs

Each `Build ${{ matrix.target }}` job will now do a full Servo compile from scratch. We accept that:

- Tag pushes are rare (one per release).
- Release builds should be reproducible anyway — a cold compile is closer to that goal than a warm one.
- `ci.yml` (which runs on every PR) still uses sccache; this PR does not touch that.

## Test Plan

- `actionlint .github/workflows/release.yml` — clean.
- After merge, zizmor alert #9 should auto-resolve on the next scan.
- The next tag push (`v0.2.2` or later) should succeed end-to-end without sccache. Expect roughly 20–40 minutes longer per matrix leg versus the current cached path.

## Checklist

- [x] `cargo clippy` passes with zero warnings (no code changes)
- [x] `cargo test` passes (no code changes)
- [x] `cargo fmt --check` passes (no code changes)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it
