### PR TITLE
chore: tighten project configs and migrate lints to Cargo.toml

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,5 +1,8 @@
 edition = "2024"
+style_edition = "2024"
+
 max_width = 120
+
 use_field_init_shorthand = true
 use_try_shorthand = true
 newline_style = "Unix"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,14 +52,26 @@ opt-level = "s"
 panic = "abort"
 debug = "line-tables-only"
 
+[lints.rust]
+missing_docs = "warn"
+unreachable_pub = "warn"
+unused_lifetimes = "warn"
+unused_macro_rules = "warn"
+unused_qualifications = "warn"
+
 [lints.clippy]
 pedantic = { level = "warn", priority = -1 }
 module_name_repetitions = { level = "allow", priority = 1 }
 implicit_clone = "warn"
+redundant_clone = "warn"
 redundant_type_annotations = "warn"
 use_self = "warn"
 missing_assert_message = "warn"
-redundant_clone = "warn"
+cast_possible_truncation = "warn"
+cast_sign_loss = "warn"
+cast_precision_loss = "warn"
+missing_errors_doc = "allow"
+missing_panics_doc = "allow"
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,6 +1,7 @@
 msrv = "1.86.0"
 allow-unwrap-in-tests = true
 allow-expect-in-tests = true
+allow-dbg-in-tests = true
 cognitive-complexity-threshold = 30
 too-many-arguments-threshold = 7
 doc-valid-idents = ["SpiderMonkey", "AccessKit", "JavaScript", "WebView", ".."]

--- a/deny.toml
+++ b/deny.toml
@@ -1,7 +1,6 @@
 [advisories]
 version = 2
 yanked = "deny"
-# Servo's transitive dependencies have known advisories we cannot fix.
 ignore = [
     "RUSTSEC-2023-0071", # bincode unmaintained
     "RUSTSEC-2024-0436", # paste unmaintained
@@ -41,3 +40,4 @@ wildcards = "deny"
 unknown-registry = "deny"
 unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []

--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -137,7 +137,7 @@ impl WebViewDelegate for Delegate {
         let agent = ureq::Agent::new_with_config(
             ureq::config::Config::builder()
                 .max_redirects(0)
-                .timeout_global(Some(std::time::Duration::from_secs(15)))
+                .timeout_global(Some(Duration::from_secs(15)))
                 .build(),
         );
         let Ok(head_resp) = agent.head(url.as_str()).call() else {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -17,7 +17,7 @@ Examples:
   servo-fetch https://example.com --selector article  Extract specific section
   servo-fetch mcp                              Start MCP server (stdio)"
 )]
-pub struct Cli {
+pub(crate) struct Cli {
     #[command(subcommand)]
     pub command: Option<Command>,
 
@@ -51,7 +51,7 @@ pub struct Cli {
 
 /// Raw output mode.
 #[derive(Debug, Clone, Copy, clap::ValueEnum)]
-pub enum RawMode {
+pub(crate) enum RawMode {
     /// Raw HTML
     Html,
     /// Plain text (document.body.innerText)
@@ -60,7 +60,7 @@ pub enum RawMode {
 
 /// Available subcommands.
 #[derive(clap::Subcommand)]
-pub enum Command {
+pub(crate) enum Command {
     /// Start MCP server (stdio transport by default, or HTTP with --port)
     Mcp {
         /// Port for Streamable HTTP transport. Omit for stdio.
@@ -72,7 +72,7 @@ pub enum Command {
 /// Validate and sanitize a URL for fetching.
 ///
 /// Delegates to [`crate::net::validate_url`].
-pub fn validate_url(input: &str) -> anyhow::Result<url::Url> {
+pub(crate) fn validate_url(input: &str) -> anyhow::Result<url::Url> {
     crate::net::validate_url(input)
 }
 

--- a/src/command.rs
+++ b/src/command.rs
@@ -6,14 +6,14 @@ use anyhow::{Context as _, Result, bail};
 
 use crate::bridge::ServoPage;
 
-pub struct Markdown<'a> {
+pub(crate) struct Markdown<'a> {
     pub page: &'a ServoPage,
     pub url: &'a str,
     pub selector: Option<&'a str>,
 }
 
 impl Markdown<'_> {
-    pub fn execute(&self) -> Result<()> {
+    pub(crate) fn execute(&self) -> Result<()> {
         let input = servo_fetch::extract::ExtractInput::new(&self.page.html, self.url)
             .with_layout_json(self.page.layout_json.as_deref())
             .with_inner_text(self.page.inner_text.as_deref())
@@ -24,14 +24,14 @@ impl Markdown<'_> {
     }
 }
 
-pub struct Json<'a> {
+pub(crate) struct Json<'a> {
     pub page: &'a ServoPage,
     pub url: &'a str,
     pub selector: Option<&'a str>,
 }
 
 impl Json<'_> {
-    pub fn execute(&self) -> Result<()> {
+    pub(crate) fn execute(&self) -> Result<()> {
         let input = servo_fetch::extract::ExtractInput::new(&self.page.html, self.url)
             .with_layout_json(self.page.layout_json.as_deref())
             .with_inner_text(self.page.inner_text.as_deref())
@@ -42,13 +42,13 @@ impl Json<'_> {
     }
 }
 
-pub struct Screenshot<'a> {
+pub(crate) struct Screenshot<'a> {
     pub page: &'a ServoPage,
     pub path: &'a str,
 }
 
 impl Screenshot<'_> {
-    pub fn execute(&self) -> Result<()> {
+    pub(crate) fn execute(&self) -> Result<()> {
         match self.page.screenshot {
             Some(ref img) => {
                 img.save(self.path)
@@ -61,17 +61,17 @@ impl Screenshot<'_> {
     }
 }
 
-pub struct JsEval<'a> {
+pub(crate) struct JsEval<'a> {
     pub result: &'a str,
 }
 
-pub struct Raw<'a> {
+pub(crate) struct Raw<'a> {
     pub page: &'a ServoPage,
     pub mode: &'a crate::cli::RawMode,
 }
 
 impl Raw<'_> {
-    pub fn execute(&self) -> Result<()> {
+    pub(crate) fn execute(&self) -> Result<()> {
         let content = match self.mode {
             crate::cli::RawMode::Html => &self.page.html,
             crate::cli::RawMode::Text => self.page.inner_text.as_deref().unwrap_or(""),
@@ -82,7 +82,7 @@ impl Raw<'_> {
 }
 
 impl JsEval<'_> {
-    pub fn execute(&self) -> Result<()> {
+    pub(crate) fn execute(&self) -> Result<()> {
         writeln!(std::io::stdout(), "{}", servo_fetch::sanitize::sanitize(self.result))?;
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,6 @@
 //!   from output strings.
 
 #![forbid(unsafe_code)]
-#![warn(missing_docs)]
 
 pub mod extract;
 pub mod layout;

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -9,7 +9,7 @@ use rmcp::transport::streamable_http_server::{
 };
 
 /// Start the MCP server on stdio or Streamable HTTP transport.
-pub async fn run(port: Option<u16>) -> anyhow::Result<()> {
+pub(crate) async fn run(port: Option<u16>) -> anyhow::Result<()> {
     if let Some(port) = port {
         run_http(port).await
     } else {

--- a/typos.toml
+++ b/typos.toml
@@ -1,2 +1,25 @@
 [files]
-extend-exclude = ["/target/", "Cargo.lock"]
+extend-exclude = [
+    "target/",
+    "Cargo.lock",
+    "tests/fixtures/",
+]
+
+[default]
+extend-ignore-identifiers-re = ["^[0-9a-f]{7,10}$"]
+
+[default.extend-identifiers]
+dom_smoothie = "dom_smoothie"
+dom_query = "dom_query"
+htmd = "htmd"
+rmcp = "rmcp"
+schemars = "schemars"
+thiserror = "thiserror"
+aws_lc_rs = "aws_lc_rs"
+
+[default.extend-words]
+servo = "servo"
+SpiderMonkey = "SpiderMonkey"
+AccessKit = "AccessKit"
+WebView = "WebView"
+JavaScript = "JavaScript"


### PR DESCRIPTION
## Summary

Tighten project configs and migrate lints to Cargo.toml.

## Checklist

- [x] `cargo clippy` passes with zero warnings
- [x] `cargo test` passes
- [x] `cargo fmt --check` passes
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it