### PR TITLE
chore: bump version to 0.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6388,7 +6388,7 @@ dependencies = [
 
 [[package]]
 name = "servo-fetch"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "servo-fetch"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2024"
 description = "A browser engine in a binary. Fetch, render, and extract web content powered by Servo."
 license = "MIT"


### PR DESCRIPTION
## Summary

Bump version to 0.2.2.

## Test Plan

```
cargo check   # Cargo.lock updated via cargo
```

## Checklist

- [x] `cargo clippy` passes with zero warnings
- [x] `cargo test` passes
- [x] `cargo fmt --check` passes
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it