### PR TITLE
fix(bridge): wait for document.readyState after LoadStatus::Complete

### DIFF
--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -312,6 +312,7 @@ fn handle_request(
 ) -> Result<ServoPage> {
     let deadline = Instant::now() + Duration::from_secs(req.timeout_secs);
     spin_until(servo, loaded, deadline, req.timeout_secs)?;
+    wait_for_ready_state(servo, webview, deadline);
 
     let html = eval_js(servo, webview, "document.documentElement.outerHTML")?;
     let inner_text = eval_js(servo, webview, "document.body.innerText").ok();
@@ -407,6 +408,23 @@ fn spin_until(servo: &servo::Servo, condition: &Cell<bool>, deadline: Instant, t
         std::thread::sleep(SPIN_INTERVAL);
     }
     Ok(())
+}
+
+/// Wait for `document.readyState` to reach `"complete"`, or the deadline elapses.
+///
+/// TODO(upstream): Servo's `LoadStatus::Complete` fires before the DOM is fully
+/// parsed on pages with heavy inline scripts (e.g. amazon.co.jp); see
+/// servo/servo#41972. Drop this function once upstream fires `LoadStatus::Complete`
+/// at `document.readyState == "complete"` — `spin_until` would then suffice.
+fn wait_for_ready_state(servo: &servo::Servo, webview: &WebView, deadline: Instant) {
+    while Instant::now() < deadline {
+        servo.spin_event_loop();
+        if matches!(eval_js(servo, webview, "document.readyState"), Ok(s) if s == "complete") {
+            return;
+        }
+        std::thread::sleep(SPIN_INTERVAL);
+    }
+    eprintln!("warning: document did not finish loading; content may be incomplete");
 }
 
 fn eval_js(servo: &servo::Servo, webview: &WebView, script: &str) -> Result<String> {


### PR DESCRIPTION
## Summary

Servo's `LoadStatus::Complete` delegate callback is documented to be equivalent to `document.readyState == "complete"`, but on pages that stream chunked HTML with large inline `<script>` blocks (e.g. amazon.co.jp) the callback fires well before the DOM is fully parsed. The result is that `document.body` is `null`, JS evaluation against the body fails, screenshots come out blank, and Readability extraction returns nothing.

This adds a `wait_for_ready_state` step after `spin_until` that polls `document.readyState` until it reaches `"complete"` (or the existing request deadline elapses). We drive the Servo event loop each iteration so async script and layout work can keep progressing between polls — the same idiom Servo's own `tests/common/mod.rs` `spin()` helper uses.

This is a workaround for a known Servo upstream issue ([servo/servo#41972](https://github.com/servo/servo/issues/41972): "Improve handling of load blocking events"). The TODO in the function docstring tracks the upstream fix: once Servo fires `LoadStatus::Complete` at the correct time, `wait_for_ready_state` can be deleted outright and `spin_until` will be sufficient on its own.

### Why polling rather than `Condvar::wait_timeout`?

Servo's `WebView` / `WebViewDelegate` are `!Send` (`Rc<RefCell<...>>` internals) and the `notify_load_status_changed` delegate callback fires on the same servo-engine thread as the caller. That rules out a blocking `Condvar` wait — the thread doing the `wait` is also the thread that would need to fire the `notify_one`, and `spin_event_loop` is what drives the callback in the first place. Polling is therefore the only workable design within Servo's current embedder API; surveyed implementations (`plotly_static`, `openfang`, Servo's own test helpers) all do the same thing.

## Test Plan

Local verification on macOS 15 aarch64, Rust 1.95.0, binary built from this branch.

## Checklist

- [x] `cargo clippy` passes with zero warnings
- [x] `cargo test` passes
- [x] `cargo fmt --check` passes
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it