### PR TITLE
refactor: consolidate fetch parameters and tighten public docs

### DIFF
--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -24,8 +24,7 @@ const LAYOUT_JS: &str = include_str!("js/layout.js");
 const MAX_PDF_BYTES: u64 = 50 * 1024 * 1024;
 const MAX_CONSOLE_MESSAGES: usize = 100;
 
-/// CSS injected via user stylesheets to strip common noise elements.
-/// Uses the user origin with `!important` to override author styles.
+/// CSS injected as a user stylesheet to strip common noise elements.
 const NOISE_REMOVAL_CSS: &str = "\
 [aria-label*=\"cookie\" i], [aria-label*=\"consent\" i], \
 [class*=\"cookie-banner\" i], [class*=\"cookie-consent\" i], \
@@ -132,8 +131,7 @@ impl WebViewDelegate for Delegate {
             }
         }
 
-        // HEAD request to check Content-Type without downloading the body.
-        // Disable redirects to prevent SSRF via redirect to private IPs.
+        // HEAD first to check Content-Type; no redirects to prevent SSRF.
         let agent = ureq::Agent::new_with_config(
             ureq::config::Config::builder()
                 .max_redirects(0)
@@ -151,7 +149,7 @@ impl WebViewDelegate for Delegate {
             .is_some_and(|ct| ct.to_ascii_lowercase().starts_with("application/pdf"));
 
         if !is_pdf {
-            return; // Not a PDF — let Servo handle normally.
+            return; // Let Servo handle non-PDF responses normally.
         }
 
         // Fetch the PDF body with a size limit.
@@ -172,6 +170,7 @@ impl WebViewDelegate for Delegate {
     }
 }
 
+/// Captured output of a single page load.
 #[derive(Default)]
 pub(crate) struct ServoPage {
     pub html: String,
@@ -184,26 +183,49 @@ pub(crate) struct ServoPage {
     pub console_messages: Vec<ConsoleMessage>,
 }
 
-/// Options for fetching a page via Servo.
+/// Parameters for a [`fetch_page`] call.
 pub(crate) struct FetchOptions<'a> {
     pub url: &'a str,
     pub timeout_secs: u64,
-    pub screenshot: bool,
-    pub accessibility_tree: bool,
-    pub js: Option<&'a str>,
+    pub mode: FetchMode,
+}
+
+/// What to do once the page has loaded. Variants are mutually exclusive.
+pub(crate) enum FetchMode {
+    /// Capture HTML, inner text, and layout metadata for Readability extraction.
+    Content { include_a11y: bool },
+    /// Render a PNG screenshot of the viewport.
+    Screenshot,
+    /// Evaluate the given JavaScript expression and return its result.
+    ExecuteJs { expression: String },
+}
+
+impl FetchMode {
+    fn take_screenshot(&self) -> bool {
+        matches!(self, Self::Screenshot)
+    }
+
+    fn needs_accessibility_tree(&self) -> bool {
+        matches!(self, Self::Content { include_a11y: true })
+    }
+
+    fn custom_js(&self) -> Option<&str> {
+        match self {
+            Self::ExecuteJs { expression } => Some(expression.as_str()),
+            _ => None,
+        }
+    }
 }
 
 struct FetchRequest {
     url: String,
     timeout_secs: u64,
-    take_screenshot: bool,
-    need_a11y: bool,
-    custom_js: Option<String>,
+    mode: FetchMode,
     reply: mpsc::Sender<Result<ServoPage>>,
 }
 
 /// Fetch a page via Servo. First call spawns a persistent Servo thread.
-pub(crate) fn fetch_page(opts: &FetchOptions<'_>) -> Result<ServoPage> {
+pub(crate) fn fetch_page(opts: FetchOptions<'_>) -> Result<ServoPage> {
     static SENDER: std::sync::OnceLock<mpsc::Sender<FetchRequest>> = std::sync::OnceLock::new();
 
     let sender = SENDER.get_or_init(|| {
@@ -222,9 +244,7 @@ pub(crate) fn fetch_page(opts: &FetchOptions<'_>) -> Result<ServoPage> {
         .send(FetchRequest {
             url: opts.url.to_string(),
             timeout_secs: opts.timeout_secs,
-            take_screenshot: opts.screenshot,
-            need_a11y: opts.accessibility_tree,
-            custom_js: opts.js.map(String::from),
+            mode: opts.mode,
             reply: reply_tx,
         })
         .map_err(|_| anyhow!("Servo engine is not running (it may have crashed on a previous request)"))?;
@@ -248,16 +268,11 @@ fn servo_thread(rx: mpsc::Receiver<FetchRequest>) {
 
     while let Ok(req) = rx.recv() {
         let rc_dyn: Rc<dyn RenderingContext> = rc_ctx.clone();
-        let loaded = Rc::new(Cell::new(false));
-        let pdf_data: Rc<RefCell<Option<Vec<u8>>>> = Rc::new(RefCell::new(None));
-        let a11y_nodes: Rc<RefCell<HashMap<servo::accesskit::NodeId, servo::accesskit::Node>>> =
-            Rc::new(RefCell::new(HashMap::new()));
-        let console_messages: Rc<RefCell<Vec<ConsoleMessage>>> = Rc::new(RefCell::new(Vec::new()));
         let delegate = Rc::new(Delegate {
-            loaded: loaded.clone(),
-            pdf_data: pdf_data.clone(),
-            a11y_nodes: a11y_nodes.clone(),
-            console_messages: console_messages.clone(),
+            loaded: Rc::new(Cell::new(false)),
+            pdf_data: Rc::new(RefCell::new(None)),
+            a11y_nodes: Rc::new(RefCell::new(HashMap::new())),
+            console_messages: Rc::new(RefCell::new(Vec::new())),
         });
 
         let parsed_url = match url::Url::parse(&req.url) {
@@ -274,44 +289,30 @@ fn servo_thread(rx: mpsc::Receiver<FetchRequest>) {
 
         let webview = WebViewBuilder::new(&servo, rc_dyn)
             .url(parsed_url)
-            .delegate(delegate)
+            .delegate(delegate.clone())
             .user_content_manager(ucm)
             .build();
 
-        // Only enable accessibility tree collection when explicitly requested,
-        // to avoid the overhead of building the a11y tree on every fetch.
-        if req.need_a11y {
+        // Collect the a11y tree only when requested — building it is expensive.
+        if req.mode.needs_accessibility_tree() {
             webview.set_accessibility_active(true);
         }
 
-        let result = handle_request(
-            &servo,
-            &webview,
-            &rc_ctx,
-            &loaded,
-            &pdf_data,
-            &a11y_nodes,
-            &console_messages,
-            &req,
-        );
+        let result = handle_request(&servo, &webview, &rc_ctx, &delegate, &req);
         drop(webview);
         let _ = req.reply.send(result);
     }
 }
 
-#[expect(clippy::too_many_arguments)]
 fn handle_request(
     servo: &servo::Servo,
     webview: &WebView,
     rc_ctx: &Rc<SoftwareRenderingContext>,
-    loaded: &Cell<bool>,
-    pdf_data: &RefCell<Option<Vec<u8>>>,
-    a11y_nodes: &RefCell<HashMap<servo::accesskit::NodeId, servo::accesskit::Node>>,
-    console_messages: &RefCell<Vec<ConsoleMessage>>,
+    delegate: &Delegate,
     req: &FetchRequest,
 ) -> Result<ServoPage> {
     let deadline = Instant::now() + Duration::from_secs(req.timeout_secs);
-    spin_until(servo, loaded, deadline, req.timeout_secs)?;
+    spin_until(servo, &delegate.loaded, deadline, req.timeout_secs)?;
     wait_for_ready_state(servo, webview, deadline);
 
     let html = eval_js(servo, webview, "document.documentElement.outerHTML")?;
@@ -319,7 +320,7 @@ fn handle_request(
     let layout_json = eval_js(servo, webview, LAYOUT_JS).ok();
 
     #[expect(clippy::cast_possible_wrap)]
-    let screenshot = if req.take_screenshot {
+    let screenshot = if req.mode.take_screenshot() {
         let rect = Box2D::new(
             Point2D::new(0, 0),
             Point2D::new(layout::VIEWPORT_WIDTH as i32, layout::VIEWPORT_HEIGHT as i32),
@@ -330,14 +331,14 @@ fn handle_request(
     };
 
     let js_result = req
-        .custom_js
-        .as_deref()
+        .mode
+        .custom_js()
         .map(|expr| eval_js(servo, webview, expr))
         .transpose()?;
 
     // Serialize the merged accessibility tree, masking password field values.
     let accessibility_tree = {
-        let mut nodes = a11y_nodes.borrow_mut();
+        let mut nodes = delegate.a11y_nodes.borrow_mut();
         if nodes.is_empty() {
             None
         } else {
@@ -356,9 +357,9 @@ fn handle_request(
         layout_json,
         screenshot,
         js_result,
-        pdf_data: pdf_data.borrow_mut().take(),
+        pdf_data: delegate.pdf_data.borrow_mut().take(),
         accessibility_tree,
-        console_messages: console_messages.borrow_mut().drain(..).collect(),
+        console_messages: delegate.console_messages.borrow_mut().drain(..).collect(),
     })
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -69,9 +69,7 @@ pub(crate) enum Command {
     },
 }
 
-/// Validate and sanitize a URL for fetching.
-///
-/// Delegates to [`crate::net::validate_url`].
+/// Validate and sanitize a URL for fetching. Forwards to [`crate::net::validate_url`].
 pub(crate) fn validate_url(input: &str) -> anyhow::Result<url::Url> {
     crate::net::validate_url(input)
 }

--- a/src/command.rs
+++ b/src/command.rs
@@ -6,6 +6,7 @@ use anyhow::{Context as _, Result, bail};
 
 use crate::bridge::ServoPage;
 
+/// Output an extracted article as Markdown to stdout.
 pub(crate) struct Markdown<'a> {
     pub page: &'a ServoPage,
     pub url: &'a str,
@@ -24,6 +25,7 @@ impl Markdown<'_> {
     }
 }
 
+/// Output an extracted article as JSON to stdout.
 pub(crate) struct Json<'a> {
     pub page: &'a ServoPage,
     pub url: &'a str,
@@ -42,6 +44,7 @@ impl Json<'_> {
     }
 }
 
+/// Save the rendered screenshot to a PNG file.
 pub(crate) struct Screenshot<'a> {
     pub page: &'a ServoPage,
     pub path: &'a str,
@@ -61,10 +64,12 @@ impl Screenshot<'_> {
     }
 }
 
+/// Print the result of an evaluated JavaScript expression to stdout.
 pub(crate) struct JsEval<'a> {
     pub result: &'a str,
 }
 
+/// Print raw HTML or inner text to stdout.
 pub(crate) struct Raw<'a> {
     pub page: &'a ServoPage,
     pub mode: &'a crate::cli::RawMode,

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -46,9 +46,7 @@ pub struct ArticleData {
     pub url: Option<String>,
 }
 
-/// Extract text content from a PDF byte slice.
-///
-/// Returns the extracted text, or an empty string if extraction fails.
+/// Extract text content from a PDF byte slice, or an empty string on failure.
 #[must_use]
 pub fn extract_pdf(data: &[u8]) -> String {
     match pdf_extract::extract_text_from_mem(data) {
@@ -113,8 +111,7 @@ impl<'a> ExtractInput<'a> {
 /// Extract readable content as Markdown text.
 ///
 /// # Errors
-///
-/// Returns [`ExtractError::Fmt`] if the Markdown assembly fails.
+/// Returns [`ExtractError::Fmt`] if Markdown assembly fails.
 pub fn extract_text(input: &ExtractInput<'_>) -> Result<String, ExtractError> {
     if let Some(selector) = input.selector {
         return Ok(extract_by_selector(input.html, input.layout_json, selector));
@@ -138,7 +135,6 @@ pub fn extract_text(input: &ExtractInput<'_>) -> Result<String, ExtractError> {
 /// Extract readable content as JSON.
 ///
 /// # Errors
-///
 /// Returns [`ExtractError::Json`] if JSON serialization fails.
 pub fn extract_json(input: &ExtractInput<'_>) -> Result<String, ExtractError> {
     if let Some(selector) = input.selector {

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -8,34 +8,69 @@ pub const VIEWPORT_WIDTH: u32 = 1280;
 /// Default viewport height used by Servo for rendering.
 pub const VIEWPORT_HEIGHT: u32 = 800;
 
+/// ARIA roles that influence our layout heuristics.
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum Role {
+    Navigation,
+    Complementary,
+    Contentinfo,
+    #[serde(untagged)]
+    Other(String),
+}
+
+impl Role {
+    fn as_str(&self) -> &str {
+        match self {
+            Self::Navigation => "navigation",
+            Self::Complementary => "complementary",
+            Self::Contentinfo => "contentinfo",
+            Self::Other(s) => s,
+        }
+    }
+}
+
+/// CSS `position` values that we treat as stacking overlays (likely navbars).
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+enum Position {
+    Fixed,
+    Sticky,
+    #[serde(other)]
+    Other,
+}
+
+impl Position {
+    fn is_stacking(&self) -> bool {
+        matches!(self, Self::Fixed | Self::Sticky)
+    }
+}
+
 /// A page element with CSS layout data, deserialized from the injected JS.
-///
-/// The `tag` field contains the HTML tag name in uppercase, as returned by
-/// `Element.tagName` in JavaScript.
 #[derive(Deserialize)]
 pub struct LayoutElement {
     tag: String,
-    role: Option<String>,
+    role: Option<Role>,
     w: f64,
     h: f64,
-    position: String,
+    position: Position,
 }
 
 impl LayoutElement {
     fn is_navbar(&self) -> bool {
-        matches!(self.position.as_str(), "fixed" | "sticky") && self.h < f64::from(VIEWPORT_HEIGHT) * 0.2
+        self.position.is_stacking() && self.h < f64::from(VIEWPORT_HEIGHT) * 0.2
     }
 
     fn is_sidebar(&self) -> bool {
         let is_narrow = self.w < f64::from(VIEWPORT_WIDTH) * 0.3;
         let is_side_tag = matches!(self.tag.as_str(), "ASIDE" | "NAV");
-        let is_side_role = matches!(self.role.as_deref(), Some("navigation" | "complementary"));
+        let is_side_role = matches!(self.role, Some(Role::Navigation | Role::Complementary));
         is_narrow && (is_side_tag || is_side_role)
     }
 
     fn is_footer(&self) -> bool {
         let is_full_width = self.w >= f64::from(VIEWPORT_WIDTH) * 0.8;
-        (self.tag == "FOOTER" && is_full_width) || self.role.as_deref() == Some("contentinfo")
+        (self.tag == "FOOTER" && is_full_width) || self.role == Some(Role::Contentinfo)
     }
 
     fn should_remove(&self) -> bool {
@@ -44,9 +79,6 @@ impl LayoutElement {
 }
 
 /// CSS selectors for elements that should be stripped before passing to readability.
-///
-/// Each selector is as specific as possible to avoid removing unrelated elements
-/// that happen to share the same tag name.
 #[must_use]
 pub fn selectors_to_strip(elements: &[LayoutElement]) -> Vec<String> {
     let mut sels: Vec<String> = elements
@@ -54,8 +86,8 @@ pub fn selectors_to_strip(elements: &[LayoutElement]) -> Vec<String> {
         .filter(|el| el.should_remove())
         .map(|el| {
             let tag = el.tag.to_lowercase();
-            match el.role.as_deref() {
-                Some(role) => format!("{tag}[role=\"{role}\"]"),
+            match &el.role {
+                Some(role) => format!("{tag}[role=\"{}\"]", role.as_str()),
                 None => tag,
             }
         })
@@ -69,64 +101,64 @@ pub fn selectors_to_strip(elements: &[LayoutElement]) -> Vec<String> {
 mod tests {
     use super::*;
 
-    fn el(tag: &str, w: f64, h: f64, position: &str, role: Option<&str>) -> LayoutElement {
+    fn el(tag: &str, w: f64, h: f64, position: Position, role: Option<Role>) -> LayoutElement {
         LayoutElement {
             tag: tag.to_string(),
-            role: role.map(String::from),
+            role,
             w,
             h,
-            position: position.to_string(),
+            position,
         }
     }
 
     #[test]
     fn detects_fixed_navbar() {
-        let sels = selectors_to_strip(&[el("HEADER", 1280.0, 60.0, "fixed", None)]);
+        let sels = selectors_to_strip(&[el("HEADER", 1280.0, 60.0, Position::Fixed, None)]);
         assert_eq!(sels, vec!["header"]);
     }
 
     #[test]
     fn detects_sticky_navbar() {
-        let sels = selectors_to_strip(&[el("NAV", 1280.0, 50.0, "sticky", None)]);
+        let sels = selectors_to_strip(&[el("NAV", 1280.0, 50.0, Position::Sticky, None)]);
         assert_eq!(sels, vec!["nav"]);
     }
 
     #[test]
     fn ignores_tall_fixed_element() {
-        let sels = selectors_to_strip(&[el("DIV", 1280.0, 400.0, "fixed", None)]);
+        let sels = selectors_to_strip(&[el("DIV", 1280.0, 400.0, Position::Fixed, None)]);
         assert!(sels.is_empty());
     }
 
     #[test]
     fn detects_narrow_aside_as_sidebar() {
-        let sels = selectors_to_strip(&[el("ASIDE", 300.0, 800.0, "static", None)]);
+        let sels = selectors_to_strip(&[el("ASIDE", 300.0, 800.0, Position::Other, None)]);
         assert_eq!(sels, vec!["aside"]);
     }
 
     #[test]
     fn detects_footer() {
-        let sels = selectors_to_strip(&[el("FOOTER", 1280.0, 100.0, "static", None)]);
+        let sels = selectors_to_strip(&[el("FOOTER", 1280.0, 100.0, Position::Other, None)]);
         assert_eq!(sels, vec!["footer"]);
     }
 
     #[test]
     fn ignores_narrow_footer() {
         // A <footer> inside an <article> is typically narrow — should not be stripped.
-        let sels = selectors_to_strip(&[el("FOOTER", 600.0, 50.0, "static", None)]);
+        let sels = selectors_to_strip(&[el("FOOTER", 600.0, 50.0, Position::Other, None)]);
         assert!(sels.is_empty());
     }
 
     #[test]
     fn detects_contentinfo_role_as_footer() {
-        let sels = selectors_to_strip(&[el("DIV", 1280.0, 100.0, "static", Some("contentinfo"))]);
+        let sels = selectors_to_strip(&[el("DIV", 1280.0, 100.0, Position::Other, Some(Role::Contentinfo))]);
         assert_eq!(sels, vec!["div[role=\"contentinfo\"]"]);
     }
 
     #[test]
     fn deduplicates_selectors() {
         let elements = vec![
-            el("NAV", 200.0, 50.0, "fixed", None),
-            el("NAV", 250.0, 40.0, "sticky", None),
+            el("NAV", 200.0, 50.0, Position::Fixed, None),
+            el("NAV", 250.0, 40.0, Position::Sticky, None),
         ];
         let sels = selectors_to_strip(&elements);
         assert_eq!(sels, vec!["nav"]);
@@ -134,7 +166,29 @@ mod tests {
 
     #[test]
     fn detects_complementary_role_as_sidebar() {
-        let sels = selectors_to_strip(&[el("DIV", 250.0, 800.0, "static", Some("complementary"))]);
+        let sels = selectors_to_strip(&[el("DIV", 250.0, 800.0, Position::Other, Some(Role::Complementary))]);
         assert_eq!(sels, vec!["div[role=\"complementary\"]"]);
+    }
+
+    #[test]
+    fn deserializes_role_from_json() {
+        let el: LayoutElement =
+            serde_json::from_str(r#"{"tag":"DIV","role":"navigation","w":100.0,"h":50.0,"position":"static"}"#)
+                .unwrap();
+        assert_eq!(el.role, Some(Role::Navigation));
+    }
+
+    #[test]
+    fn deserializes_unknown_role_as_other() {
+        let el: LayoutElement =
+            serde_json::from_str(r#"{"tag":"DIV","role":"banner","w":100.0,"h":50.0,"position":"static"}"#).unwrap();
+        assert_eq!(el.role, Some(Role::Other("banner".to_string())));
+    }
+
+    #[test]
+    fn deserializes_unknown_position_as_other() {
+        let el: LayoutElement =
+            serde_json::from_str(r#"{"tag":"DIV","role":null,"w":100.0,"h":50.0,"position":"absolute"}"#).unwrap();
+        assert_eq!(el.position, Position::Other);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,6 @@ fn main() {
 
     let args = cli::Cli::parse();
 
-    // All paths use flush_and_exit to avoid SpiderMonkey shutdown races on Linux.
     if let Some(cli::Command::Mcp { port }) = args.command {
         flush_and_exit(run_mcp(port));
     }
@@ -63,17 +62,10 @@ fn is_broken_pipe(err: &anyhow::Error) -> bool {
 fn flush_and_exit(code: i32) -> ! {
     let _ = std::io::stdout().flush();
     let _ = std::io::stderr().flush();
-    // SpiderMonkey (bundled by the `servo` crate) registers C++ static destructors
-    // that race on `pthread_mutex_destroy` during process exit on Linux, producing
-    // `MutexImpl::~MutexImpl: pthread_mutex_destroy failed: Device or resource busy`
-    // followed by SIGSEGV (exit 139). Skip the atexit chain on Linux with `_exit`;
-    // macOS and Windows do not exhibit this and keep the regular `process::exit`.
-    // Firefox and Chromium use the same pattern for renderer/helper shutdown.
+    // On Linux, SpiderMonkey's static destructors race on `pthread_mutex_destroy`
+    // during process exit, producing a post-exit SIGSEGV.
     #[cfg(target_os = "linux")]
     #[allow(unsafe_code)]
-    // SAFETY: `_exit` is async-signal-safe. Stdio is flushed above, and we hold
-    // no Rust allocations that require Drop for correctness (rustls/tokio/stdio
-    // register no atexit handlers we depend on).
     unsafe {
         libc::_exit(code);
     }
@@ -87,7 +79,6 @@ fn run(args: &cli::Cli) -> anyhow::Result<()> {
         .as_deref()
         .ok_or_else(|| anyhow::anyhow!("URL is required. Run with --help for usage."))?;
     let url = cli::validate_url(url_str)?;
-    let need_screenshot = args.screenshot.is_some();
 
     let is_tty = std::io::stderr().is_terminal();
     if is_tty {
@@ -95,12 +86,17 @@ fn run(args: &cli::Cli) -> anyhow::Result<()> {
         let _ = std::io::Write::flush(&mut std::io::stderr());
     }
 
-    let page = bridge::fetch_page(&bridge::FetchOptions {
+    let mode = if args.screenshot.is_some() {
+        bridge::FetchMode::Screenshot
+    } else if let Some(expr) = args.js.clone() {
+        bridge::FetchMode::ExecuteJs { expression: expr }
+    } else {
+        bridge::FetchMode::Content { include_a11y: false }
+    };
+    let page = bridge::fetch_page(bridge::FetchOptions {
         url: url.as_str(),
         timeout_secs: args.timeout,
-        screenshot: need_screenshot,
-        accessibility_tree: false,
-        js: args.js.as_deref(),
+        mode,
     });
 
     if is_tty {
@@ -109,7 +105,6 @@ fn run(args: &cli::Cli) -> anyhow::Result<()> {
 
     let page = page?;
 
-    // PDF detected by Servo's load_web_resource callback (Content-Type based)
     if let Some(ref pdf_bytes) = page.pdf_data {
         let text = servo_fetch::extract::extract_pdf(pdf_bytes);
         write!(std::io::stdout(), "{}", servo_fetch::sanitize::sanitize(&text))?;

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -12,6 +12,7 @@ const MAX_JS_OUTPUT_LEN: usize = 1_000_000;
 const MAX_TIMEOUT_SECS: u64 = 300;
 const MAX_SELECTOR_LEN: usize = 1_000;
 
+/// Output format requested by the MCP `fetch` tool.
 #[derive(Debug, Default, serde::Deserialize, schemars::JsonSchema)]
 #[serde(rename_all = "lowercase")]
 pub(super) enum OutputFormat {
@@ -24,6 +25,7 @@ pub(super) enum OutputFormat {
     AccessibilityTree,
 }
 
+/// Parameters for the MCP `fetch` tool.
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 pub(super) struct FetchParams {
     #[schemars(description = "URL to fetch (http/https only)")]
@@ -40,6 +42,7 @@ pub(super) struct FetchParams {
     selector: Option<String>,
 }
 
+/// Parameters for the MCP `screenshot` tool.
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 pub(super) struct ScreenshotParams {
     #[schemars(description = "URL to capture (http/https only)")]
@@ -48,6 +51,7 @@ pub(super) struct ScreenshotParams {
     timeout: Option<u64>,
 }
 
+/// Parameters for the MCP `execute_js` tool.
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 pub(super) struct ExecuteJsParams {
     #[schemars(description = "URL to load before executing JS")]
@@ -58,6 +62,7 @@ pub(super) struct ExecuteJsParams {
     timeout: Option<u64>,
 }
 
+/// MCP handler that exposes servo-fetch's tools.
 #[derive(Debug, Clone)]
 pub(crate) struct ServoMcp {
     #[allow(dead_code)] // accessed by tool_router macro
@@ -66,6 +71,7 @@ pub(crate) struct ServoMcp {
 
 #[tool_router]
 impl ServoMcp {
+    /// Construct a new MCP handler with the tool router wired up.
     pub(crate) fn new() -> Self {
         Self {
             tool_router: Self::tool_router(),
@@ -88,8 +94,8 @@ impl ServoMcp {
             ));
         }
 
-        let need_a11y = matches!(p.format, Some(OutputFormat::AccessibilityTree));
-        let page = tools::fetch_page(&url, timeout, false, need_a11y, None).await?;
+        let include_a11y = matches!(p.format, Some(OutputFormat::AccessibilityTree));
+        let page = tools::fetch_page(&url, timeout, crate::bridge::FetchMode::Content { include_a11y }).await?;
         let full = if let Some(ref pdf_bytes) = page.pdf_data {
             servo_fetch::extract::extract_pdf(pdf_bytes)
         } else {
@@ -129,13 +135,19 @@ impl ServoMcp {
         let url = tools::validated_url(&p.url)?;
         let timeout = p.timeout.unwrap_or(30).clamp(1, MAX_TIMEOUT_SECS);
 
-        let page = tools::fetch_page(&url, timeout, false, false, Some(&p.expression)).await?;
+        let page = tools::fetch_page(
+            &url,
+            timeout,
+            crate::bridge::FetchMode::ExecuteJs {
+                expression: p.expression,
+            },
+        )
+        .await?;
         let mut result = page.js_result.unwrap_or_default();
         if result.len() > MAX_JS_OUTPUT_LEN {
             result.truncate(tools::floor_char_boundary(&result, MAX_JS_OUTPUT_LEN));
             result.push_str("\n<output truncated>");
         }
-        // Append console messages if any were captured.
         if !page.console_messages.is_empty() {
             result.push_str("\n\n--- console output ---\n");
             for msg in &page.console_messages {

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -8,28 +8,25 @@ use crate::bridge;
 use crate::net;
 use servo_fetch::extract::{self, ExtractInput};
 
+/// Validate a URL and return it in canonical form as a string.
 pub(super) fn validated_url(url: &str) -> Result<String, ErrorData> {
     net::validate_url(url)
         .map(|u| u.to_string())
         .map_err(|e| ErrorData::invalid_params(format!("{e:#}"), None))
 }
 
+/// Run a Servo fetch on the blocking thread pool.
 pub(super) async fn fetch_page(
     url: &str,
     timeout: u64,
-    screenshot: bool,
-    need_a11y: bool,
-    js: Option<&str>,
+    mode: bridge::FetchMode,
 ) -> Result<bridge::ServoPage, ErrorData> {
     let url = url.to_string();
-    let js = js.map(String::from);
     tokio::task::spawn_blocking(move || {
-        bridge::fetch_page(&bridge::FetchOptions {
+        bridge::fetch_page(bridge::FetchOptions {
             url: &url,
             timeout_secs: timeout,
-            screenshot,
-            accessibility_tree: need_a11y,
-            js: js.as_deref(),
+            mode,
         })
     })
     .await
@@ -37,6 +34,7 @@ pub(super) async fn fetch_page(
     .map_err(|e| ErrorData::internal_error(format!("{e:#}"), None))
 }
 
+/// Run Readability-based extraction on a fetched page, as Markdown or JSON.
 pub(super) fn extract(
     page: &bridge::ServoPage,
     url: &str,
@@ -55,8 +53,9 @@ pub(super) fn extract(
     .map_err(|e| ErrorData::internal_error(e.to_string(), None))
 }
 
+/// Render the page and return its screenshot as a base64 PNG MCP content.
 pub(super) async fn take_screenshot(url: &str, timeout: u64) -> Result<CallToolResult, ErrorData> {
-    let page = fetch_page(url, timeout, true, false, None).await?;
+    let page = fetch_page(url, timeout, bridge::FetchMode::Screenshot).await?;
     let img = page
         .screenshot
         .ok_or_else(|| ErrorData::internal_error("screenshot capture failed", None))?;
@@ -71,6 +70,8 @@ pub(super) async fn take_screenshot(url: &str, timeout: u64) -> Result<CallToolR
     )]))
 }
 
+/// Return a char-aligned slice of `content` and a truncation notice when
+/// the slice does not cover the full content.
 pub(super) fn paginate(content: &str, start: usize, max_len: usize) -> String {
     let max_len = max_len.max(1);
     let total = content.len();
@@ -87,6 +88,7 @@ pub(super) fn paginate(content: &str, start: usize, max_len: usize) -> String {
     }
 }
 
+/// Return the nearest UTF-8 char boundary `<= index`.
 pub(super) fn floor_char_boundary(s: &str, index: usize) -> usize {
     if index >= s.len() {
         return s.len();

--- a/src/net.rs
+++ b/src/net.rs
@@ -72,10 +72,9 @@ fn is_private_ipv6(ip: &std::net::Ipv6Addr) -> bool {
 
 /// Validate and sanitize a URL for fetching.
 ///
-/// # Security
-///
-/// This performs string-based host validation only. It does not resolve DNS,
-/// so DNS rebinding attacks are not mitigated at this layer.
+/// Only `http`/`https` schemes are accepted, embedded credentials are stripped,
+/// and hosts that resolve to private or reserved addresses are rejected. DNS is
+/// not resolved, so DNS rebinding attacks remain possible downstream.
 pub(crate) fn validate_url(input: &str) -> anyhow::Result<url::Url> {
     use anyhow::{Context as _, bail};
 

--- a/src/sanitize.rs
+++ b/src/sanitize.rs
@@ -6,8 +6,6 @@ const CSI_MAX_LEN: u16 = 256;
 const STRING_SEQ_MAX_LEN: u16 = 4096;
 
 /// Strip control characters and ANSI escape sequences, preserving printable text.
-///
-/// Returns `Cow::Borrowed` when the input is already clean (no allocation).
 #[must_use]
 pub fn sanitize(input: &str) -> Cow<'_, str> {
     let needs_sanitize = input


### PR DESCRIPTION
## Summary

Two related cleanups motivated by `#[expect(clippy::too_many_arguments)]` on `handle_request` and by the number of positional bool arguments threaded through `tools::fetch_page`.

## Test Plan

```
cargo fmt --check           # clean
cargo clippy --lib --bin servo-fetch --tests --no-deps  # 0 warnings
cargo test --lib            # 34 passed (was 31; 3 new tests in layout.rs cover Role / Position deserialization)
```

## Checklist

- [x] `cargo clippy` passes with zero warnings
- [x] `cargo test` passes
- [x] `cargo fmt --check` passes
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it