### PR TITLE
feat: add full-page screenshot support

### DIFF
--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -11,8 +11,8 @@ use dpi::PhysicalSize;
 use euclid::{Box2D, Point2D};
 use image::RgbaImage;
 use servo::{
-    ConsoleLogLevel, JSValue, LoadStatus, NavigationRequest, Preferences, RenderingContext, ServoBuilder,
-    SoftwareRenderingContext, UserContentManager, WebView, WebViewBuilder, WebViewDelegate,
+    ConsoleLogLevel, DevicePixel, JSValue, LoadStatus, NavigationRequest, Preferences, RenderingContext, ServoBuilder,
+    SoftwareRenderingContext, UserContentManager, WebView, WebViewBuilder, WebViewDelegate, WebViewRect,
 };
 
 use servo_fetch::layout;
@@ -194,15 +194,19 @@ pub(crate) struct FetchOptions<'a> {
 pub(crate) enum FetchMode {
     /// Capture HTML, inner text, and layout metadata for Readability extraction.
     Content { include_a11y: bool },
-    /// Render a PNG screenshot of the viewport.
-    Screenshot,
+    /// Render a PNG screenshot.
+    Screenshot { full_page: bool },
     /// Evaluate the given JavaScript expression and return its result.
     ExecuteJs { expression: String },
 }
 
 impl FetchMode {
     fn take_screenshot(&self) -> bool {
-        matches!(self, Self::Screenshot)
+        matches!(self, Self::Screenshot { .. })
+    }
+
+    fn full_page(&self) -> bool {
+        matches!(self, Self::Screenshot { full_page: true })
     }
 
     fn needs_accessibility_tree(&self) -> bool {
@@ -254,7 +258,10 @@ pub(crate) fn fetch_page(opts: FetchOptions<'_>) -> Result<ServoPage> {
         .map_err(|_| anyhow!("Servo engine crashed while processing this page. Try a different URL."))?
 }
 
-#[expect(clippy::needless_pass_by_value)]
+#[expect(
+    clippy::needless_pass_by_value,
+    reason = "the thread owns the Receiver for its lifetime"
+)]
 fn servo_thread(rx: mpsc::Receiver<FetchRequest>) {
     let (rc_ctx, servo) = match build_servo() {
         Ok(pair) => pair,
@@ -298,7 +305,7 @@ fn servo_thread(rx: mpsc::Receiver<FetchRequest>) {
             webview.set_accessibility_active(true);
         }
 
-        let result = handle_request(&servo, &webview, &rc_ctx, &delegate, &req);
+        let result = handle_request(&servo, &webview, &delegate, &req);
         drop(webview);
         let _ = req.reply.send(result);
     }
@@ -307,7 +314,6 @@ fn servo_thread(rx: mpsc::Receiver<FetchRequest>) {
 fn handle_request(
     servo: &servo::Servo,
     webview: &WebView,
-    rc_ctx: &Rc<SoftwareRenderingContext>,
     delegate: &Delegate,
     req: &FetchRequest,
 ) -> Result<ServoPage> {
@@ -319,13 +325,8 @@ fn handle_request(
     let inner_text = eval_js(servo, webview, "document.body.innerText").ok();
     let layout_json = eval_js(servo, webview, LAYOUT_JS).ok();
 
-    #[expect(clippy::cast_possible_wrap)]
     let screenshot = if req.mode.take_screenshot() {
-        let rect = Box2D::new(
-            Point2D::new(0, 0),
-            Point2D::new(layout::VIEWPORT_WIDTH as i32, layout::VIEWPORT_HEIGHT as i32),
-        );
-        rc_ctx.read_to_image(rect)
+        capture_screenshot(servo, webview, req.mode.full_page(), req.timeout_secs)
     } else {
         None
     };
@@ -426,6 +427,147 @@ fn wait_for_ready_state(servo: &servo::Servo, webview: &WebView, deadline: Insta
         std::thread::sleep(SPIN_INTERVAL);
     }
     eprintln!("warning: document did not finish loading; content may be incomplete");
+}
+
+/// Capture a PNG screenshot of the page, temporarily resizing the viewport
+/// to the full content size when `full_page` is set.
+fn capture_screenshot(
+    servo: &servo::Servo,
+    webview: &WebView,
+    full_page: bool,
+    timeout_secs: u64,
+) -> Option<RgbaImage> {
+    /// 16,384 matches the GPU texture limit on most modern
+    /// hardware and caps the RGBA framebuffer at ~1 GB.
+    const MAX_PIXELS: u32 = 16_384;
+
+    let viewport = PhysicalSize::new(layout::VIEWPORT_WIDTH, layout::VIEWPORT_HEIGHT);
+
+    if !full_page {
+        return take_screenshot(servo, webview, None, timeout_secs);
+    }
+
+    let Some(measured) = measure_full_page(servo, webview) else {
+        eprintln!("warning: failed to measure full page size; falling back to viewport screenshot");
+        return take_screenshot(servo, webview, None, timeout_secs);
+    };
+
+    let Some(resized) = resolve_full_page_size(measured, viewport, MAX_PIXELS) else {
+        // Content already fits in the viewport; skip the resize round-trip.
+        return take_screenshot(servo, webview, None, timeout_secs);
+    };
+
+    if resized != measured {
+        eprintln!(
+            "warning: full-page dimensions clamped to {}x{} (content was {}x{})",
+            resized.width, resized.height, measured.width, measured.height
+        );
+    }
+
+    // Resize the viewport for capture, restoring it via a guard so the engine
+    // stays usable even if `take_screenshot` panics or times out.
+    let _restore = ViewportRestore {
+        webview,
+        size: viewport,
+    };
+    webview.resize(resized);
+    take_screenshot(servo, webview, Some(device_rect(resized)), timeout_secs)
+}
+
+/// RAII guard that restores the `WebView`'s viewport size on drop.
+struct ViewportRestore<'a> {
+    webview: &'a WebView,
+    size: PhysicalSize<u32>,
+}
+
+impl Drop for ViewportRestore<'_> {
+    fn drop(&mut self) {
+        self.webview.resize(self.size);
+    }
+}
+
+/// Invoke `WebView::take_screenshot` synchronously by spinning the event loop
+/// until the callback fires or the deadline elapses.
+fn take_screenshot(
+    servo: &servo::Servo,
+    webview: &WebView,
+    rect: Option<WebViewRect>,
+    timeout_secs: u64,
+) -> Option<RgbaImage> {
+    let result: Rc<RefCell<Option<Result<RgbaImage, servo::ScreenshotCaptureError>>>> = Rc::new(RefCell::new(None));
+    let cb_result = result.clone();
+    webview.take_screenshot(rect, move |r| {
+        *cb_result.borrow_mut() = Some(r);
+    });
+
+    let deadline = Instant::now() + Duration::from_secs(timeout_secs);
+    loop {
+        servo.spin_event_loop();
+        if let Some(outcome) = result.borrow_mut().take() {
+            return outcome
+                .inspect_err(|e| eprintln!("warning: screenshot capture failed: {e:?}"))
+                .ok();
+        }
+        if Instant::now() > deadline {
+            eprintln!("warning: screenshot capture timed out after {timeout_secs}s");
+            return None;
+        }
+        std::thread::sleep(SPIN_INTERVAL);
+    }
+}
+
+#[expect(clippy::cast_precision_loss, reason = "dimensions stay well below 2^23")]
+fn device_rect(size: PhysicalSize<u32>) -> WebViewRect {
+    let rect = Box2D::<f32, DevicePixel>::new(
+        Point2D::new(0.0, 0.0),
+        Point2D::new(size.width as f32, size.height as f32),
+    );
+    WebViewRect::Device(rect)
+}
+
+fn resolve_full_page_size(
+    measured: PhysicalSize<u32>,
+    viewport: PhysicalSize<u32>,
+    max_pixels: u32,
+) -> Option<PhysicalSize<u32>> {
+    if measured.width <= viewport.width && measured.height <= viewport.height {
+        return None;
+    }
+    Some(PhysicalSize::new(
+        measured.width.clamp(viewport.width, max_pixels),
+        measured.height.clamp(viewport.height, max_pixels),
+    ))
+}
+
+/// Read the full scrollable content size via JS, saturating at [`u32::MAX`].
+fn measure_full_page(servo: &servo::Servo, webview: &WebView) -> Option<PhysicalSize<u32>> {
+    const SIZE_JS: &str = r"
+        JSON.stringify({
+            w: Math.max(document.body.scrollWidth, document.documentElement.scrollWidth),
+            h: Math.max(document.body.scrollHeight, document.documentElement.scrollHeight)
+        })
+    ";
+    #[derive(serde::Deserialize)]
+    struct Size {
+        w: f64,
+        h: f64,
+    }
+    let raw = eval_js(servo, webview, SIZE_JS).ok()?;
+    let size: Size = serde_json::from_str(&raw).ok()?;
+
+    #[expect(
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        reason = "saturating cast is the intended behavior"
+    )]
+    let width = size.w as u32;
+    #[expect(
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        reason = "saturating cast is the intended behavior"
+    )]
+    let height = size.h as u32;
+    Some(PhysicalSize::new(width, height))
 }
 
 fn eval_js(servo: &servo::Servo, webview: &WebView, script: &str) -> Result<String> {
@@ -559,10 +701,90 @@ mod tests {
         }
         assert!(jsvalue_to_json(&val).is_err());
     }
+
+    fn size(w: u32, h: u32) -> PhysicalSize<u32> {
+        PhysicalSize::new(w, h)
+    }
+
+    #[test]
+    fn fetch_mode_screenshot_flags() {
+        let vp = FetchMode::Screenshot { full_page: false };
+        assert!(vp.take_screenshot());
+        assert!(!vp.full_page());
+        assert!(!vp.needs_accessibility_tree());
+        assert!(vp.custom_js().is_none());
+
+        let fp = FetchMode::Screenshot { full_page: true };
+        assert!(fp.take_screenshot());
+        assert!(fp.full_page());
+    }
+
+    #[test]
+    fn fetch_mode_content_flags() {
+        let bare = FetchMode::Content { include_a11y: false };
+        assert!(!bare.take_screenshot());
+        assert!(!bare.full_page());
+        assert!(!bare.needs_accessibility_tree());
+        assert!(bare.custom_js().is_none());
+
+        let a11y = FetchMode::Content { include_a11y: true };
+        assert!(a11y.needs_accessibility_tree());
+    }
+
+    #[test]
+    fn fetch_mode_execute_js_flags() {
+        let js = FetchMode::ExecuteJs {
+            expression: "document.title".into(),
+        };
+        assert!(!js.take_screenshot());
+        assert!(!js.full_page());
+        assert!(!js.needs_accessibility_tree());
+        assert_eq!(js.custom_js(), Some("document.title"));
+    }
+
+    #[test]
+    fn resolve_full_page_skips_when_content_fits_viewport() {
+        let vp = size(1280, 800);
+        assert!(resolve_full_page_size(size(1000, 600), vp, 16_384).is_none());
+        assert!(resolve_full_page_size(size(1280, 800), vp, 16_384).is_none());
+    }
+
+    #[test]
+    fn resolve_full_page_expands_when_taller_than_viewport() {
+        let vp = size(1280, 800);
+        assert_eq!(
+            resolve_full_page_size(size(1280, 4000), vp, 16_384),
+            Some(size(1280, 4000)),
+        );
+    }
+
+    #[test]
+    fn resolve_full_page_clamps_to_max_pixels() {
+        let vp = size(1280, 800);
+        // Height exceeds the cap; width is left untouched.
+        assert_eq!(
+            resolve_full_page_size(size(1280, 50_000), vp, 16_384),
+            Some(size(1280, 16_384)),
+        );
+        // Both axes exceed the cap.
+        assert_eq!(
+            resolve_full_page_size(size(32_000, 50_000), vp, 16_384),
+            Some(size(16_384, 16_384)),
+        );
+    }
+
+    #[test]
+    fn resolve_full_page_never_shrinks_below_viewport() {
+        let vp = size(1280, 800);
+        // Narrow content must still fill the viewport width.
+        assert_eq!(
+            resolve_full_page_size(size(400, 4000), vp, 16_384),
+            Some(size(1280, 4000)),
+        );
+    }
 }
 
 // macOS's Apple Silicon OpenGL driver writes noise to fd 2 via fprintf.
-// Temporarily redirect fd 2 → /dev/null using POSIX dup/dup2 save-restore.
 #[cfg(unix)]
 mod stderr_guard {
     use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, OwnedFd};

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -32,6 +32,10 @@ pub(crate) struct Cli {
     #[arg(long, value_name = "FILE", conflicts_with_all = ["json", "js"])]
     pub screenshot: Option<String>,
 
+    /// Capture the full scrollable page instead of just the viewport.
+    #[arg(long, requires = "screenshot")]
+    pub full_page: bool,
+
     /// Execute JavaScript and print the result
     #[arg(long, value_name = "EXPR", conflicts_with_all = ["json", "screenshot"])]
     pub js: Option<String>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -87,7 +87,9 @@ fn run(args: &cli::Cli) -> anyhow::Result<()> {
     }
 
     let mode = if args.screenshot.is_some() {
-        bridge::FetchMode::Screenshot
+        bridge::FetchMode::Screenshot {
+            full_page: args.full_page,
+        }
     } else if let Some(expr) = args.js.clone() {
         bridge::FetchMode::ExecuteJs { expression: expr }
     } else {

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -47,6 +47,8 @@ pub(super) struct FetchParams {
 pub(super) struct ScreenshotParams {
     #[schemars(description = "URL to capture (http/https only)")]
     url: String,
+    #[schemars(description = "Capture the full scrollable page instead of just the viewport. Default: false")]
+    full_page: Option<bool>,
     #[schemars(description = "Page load timeout in seconds. Default: 30")]
     timeout: Option<u64>,
 }
@@ -115,11 +117,13 @@ impl ServoMcp {
         ))]))
     }
 
-    #[tool(description = "Capture a PNG screenshot of a web page. Uses Servo's software renderer — no GPU required.")]
+    #[tool(
+        description = "Capture a PNG screenshot of a web page. Uses Servo's software renderer — no GPU required. Set `full_page` to capture the full scrollable content instead of just the viewport."
+    )]
     async fn screenshot(&self, Parameters(p): Parameters<ScreenshotParams>) -> Result<CallToolResult, ErrorData> {
         let url = tools::validated_url(&p.url)?;
         let timeout = p.timeout.unwrap_or(30).clamp(1, MAX_TIMEOUT_SECS);
-        tools::take_screenshot(&url, timeout).await
+        tools::take_screenshot(&url, timeout, p.full_page.unwrap_or(false)).await
     }
 
     #[tool(

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -54,8 +54,8 @@ pub(super) fn extract(
 }
 
 /// Render the page and return its screenshot as a base64 PNG MCP content.
-pub(super) async fn take_screenshot(url: &str, timeout: u64) -> Result<CallToolResult, ErrorData> {
-    let page = fetch_page(url, timeout, bridge::FetchMode::Screenshot).await?;
+pub(super) async fn take_screenshot(url: &str, timeout: u64, full_page: bool) -> Result<CallToolResult, ErrorData> {
+    let page = fetch_page(url, timeout, bridge::FetchMode::Screenshot { full_page }).await?;
     let img = page
         .screenshot
         .ok_or_else(|| ErrorData::internal_error("screenshot capture failed", None))?;


### PR DESCRIPTION
## Summary

Add a `--full-page` flag (CLI) and `full_page` parameter (MCP `screenshot` tool) that captures the full scrollable page instead of the default 1280×800 viewport.

## Test Plan

Manual checks with the release build:

| URL | Mode | Output | File size |
|---|---|---|---|
| `https://example.com` | `--screenshot ex.png` | 1280×800 | 44 KB |
| `https://amazon.co.jp` | `--screenshot vp.png` | 1280×800, Amazon homepage visible | 692 KB |
| `https://amazon.co.jp` | `--screenshot fp.png --full-page` | 1280×5525, scrollable content rendered top to bottom | 4.1 MB |

## Checklist

- [x] `cargo clippy` passes with zero warnings
- [x] `cargo test` passes
- [x] `cargo fmt --check` passes
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it