### PR TITLE
docs: document --full-page screenshot option

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ servo-fetch "https://example.com" --json
 # Screenshot — rendered to PNG without GPU
 servo-fetch "https://example.com" --screenshot page.png
 
+# Full-page screenshot (captures the entire scrollable page)
+servo-fetch "https://example.com" --screenshot page.png --full-page
+
 # Execute JavaScript in the page context
 servo-fetch "https://example.com" --js "document.title"
 
@@ -101,6 +104,7 @@ servo-fetch "https://example.com/report.pdf"
 | ---- | ----------- |
 | `--json` | Output as structured JSON |
 | `--screenshot <FILE>` | Save a PNG screenshot |
+| `--full-page` | Capture the full scrollable page (requires `--screenshot`) |
 | `--js <EXPR>` | Execute JavaScript and print the result |
 | `--selector <CSS>` | Extract a specific section by CSS selector |
 | `--raw <MODE>` | Output raw `html` or plain `text` (bypasses Readability) |


### PR DESCRIPTION
## Summary

Document the `--full-page` screenshot flag added in #57, before cutting v0.3.0.

## Test Plan

Markdown-only change. Rendered the diff locally and on GitHub.

## Checklist

- [x] `cargo clippy` passes with zero warnings
- [x] `cargo test` passes
- [x] `cargo fmt --check` passes
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it