### PR TITLE
feat: multi-WebView parallel fetch and batch support (#63)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6399,6 +6399,7 @@ dependencies = [
  "dom_smoothie",
  "dpi",
  "euclid 0.22.14",
+ "futures-util",
  "htmd",
  "image",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,7 @@ missing_panics_doc = "allow"
 assert_cmd = "2"
 predicates = "3"
 rmcp = { version = "1", features = ["client", "transport-io", "transport-child-process"] }
+futures-util = "0.3"
 
 [package.metadata.binstall]
 pkg-url = "{ repo }/releases/download/v{ version }/servo-fetch-v{ version }-{ target }.tar.gz"

--- a/README.md
+++ b/README.md
@@ -15,19 +15,17 @@ servo-fetch embeds the [Servo](https://servo.org/) browser engine into a single 
 servo-fetch "https://example.com"                        # Clean Markdown
 servo-fetch "https://example.com" --screenshot page.png  # PNG screenshot, no GPU needed
 servo-fetch "https://example.com" --js "document.title"  # Run JS in the page
+servo-fetch URL1 URL2 URL3                               # Parallel batch fetch
 ```
 
 ## Why servo-fetch
 
-**JavaScript execution is mandatory for the modern web.** Simple HTTP fetchers can't handle today's web. React, Vue, Next.js, and countless sites render content entirely with JavaScript. An HTTP GET returns an empty `<div id="root"></div>` — no article, no data, nothing useful. servo-fetch solves this by embedding a real browser engine. [Servo](https://servo.org/)'s SpiderMonkey executes JavaScript and its parallel CSS engine computes layout, just like a desktop browser — packaged in a single binary with no external dependencies.
-
-**CSS layout strips navigation noise.** Most extraction tools guess page structure from HTML tags alone. servo-fetch calls `getComputedStyle()` and `getBoundingClientRect()` inside the engine to detect fixed navbars, sidebars, and footers by their actual rendered position and size — then removes them before extraction. Common cookie banners and newsletter popups are also stripped via injected user stylesheets.
-
-**Screenshots without a GPU.** Servo's software renderer captures PNG screenshots without a display server or GPU. Full-page screenshots capture the entire scrollable content. No `xvfb-run` needed on macOS or Windows.
-
-**Accessibility tree with bounding boxes.** The page's accessibility tree is available via Servo's AccessKit integration. Each node includes its role, name, and bounding box — combining semantic structure with visual layout in a single output. Use `format: "accessibility_tree"` in the MCP fetch tool.
-
-**Main content via Readability.** After CSS-based noise removal, Mozilla's [Readability](https://github.com/mozilla/readability) algorithm extracts the main article. PDF URLs are auto-detected via `Content-Type` and extracted directly.
+- **Zero dependencies** — single binary, no Chrome, no Docker, no API key
+- **Real JS execution** — SpiderMonkey runs JavaScript, parallel CSS engine computes layout
+- **Layout-aware extraction** — strips navbars, sidebars, footers by actual rendered position, not HTML guessing
+- **Parallel batch fetch** — multiple URLs fetched concurrently, results stream as each completes
+- **Screenshots without GPU** — software renderer captures PNG/full-page screenshots anywhere
+- **Accessibility tree** — AccessKit integration with roles, names, and bounding boxes
 
 ## Install
 
@@ -90,6 +88,12 @@ servo-fetch "https://example.com"
 # Structured JSON
 servo-fetch "https://example.com" --json
 
+# Multiple URLs in parallel (Markdown with separators)
+servo-fetch "https://a.com" "https://b.com" "https://c.com"
+
+# Multiple URLs as NDJSON (one compact JSON per line)
+servo-fetch "https://a.com" "https://b.com" --json
+
 # Screenshot — rendered to PNG without GPU
 servo-fetch "https://example.com" --screenshot page.png
 
@@ -114,15 +118,18 @@ servo-fetch "https://example.com/report.pdf"
 
 | Flag | Description |
 | ---- | ----------- |
-| `--json` | Output as structured JSON |
-| `--screenshot <FILE>` | Save a PNG screenshot |
+| `--json` | Output as structured JSON (NDJSON when multiple URLs) |
+| `--screenshot <FILE>` | Save a PNG screenshot (single URL only) |
 | `--full-page` | Capture the full scrollable page (requires `--screenshot`) |
-| `--js <EXPR>` | Execute JavaScript and print the result |
+| `--js <EXPR>` | Execute JavaScript and print the result (single URL only) |
 | `--selector <CSS>` | Extract a specific section by CSS selector |
-| `--raw <MODE>` | Output raw `html` or plain `text` (bypasses Readability) |
+| `--raw <MODE>` | Output raw `html` or plain `text` (single URL only) |
 | `-t`, `--timeout <SECS>` | Page load timeout (default: 30) |
+| `--settle <MS>` | Extra wait after load event for SPAs (default: 0, max: 10000) |
 | `--help` | Show help |
 | `--version` | Show version |
+
+When multiple URLs are given, they are fetched in parallel. Results stream to stdout in completion order — Markdown with `--- URL ---` separators by default, or NDJSON with `--json`.
 
 ### JSON output
 
@@ -142,7 +149,7 @@ Fields marked `?` are omitted when not detected.
 
 ## MCP server
 
-servo-fetch includes a built-in MCP server with three tools — `fetch`, `screenshot`, and `execute_js` — over stdio or Streamable HTTP.
+servo-fetch includes a built-in MCP server with four tools — `fetch`, `batch_fetch`, `screenshot`, and `execute_js` — over stdio or Streamable HTTP.
 
 ```json
 {
@@ -174,6 +181,20 @@ Fetch a URL and extract readable content. Navbars, sidebars, and footers are str
 | `max_length` | number? | Max characters to return (default 5000) |
 | `start_index` | number? | Character offset for pagination (default 0) |
 | `timeout` | number? | Page load timeout in seconds (default 30) |
+| `settle_ms` | number? | Extra wait in ms after load event for SPAs (default 0, max 10000) |
+| `selector` | string? | CSS selector to extract a specific section |
+
+#### `batch_fetch`
+
+Fetch multiple URLs in parallel. Results are returned as separate content entries in completion order.
+
+| Parameter | Type | Description |
+| --------- | ---- | ----------- |
+| `urls` | string[] | URLs to fetch (http/https only, max 20) |
+| `format` | string? | `markdown` (default) or `json` |
+| `max_length` | number? | Max characters per URL result (default 5000) |
+| `timeout` | number? | Page load timeout in seconds per URL (default 30) |
+| `settle_ms` | number? | Extra wait in ms after load event (default 0, max 10000) |
 | `selector` | string? | CSS selector to extract a specific section |
 
 #### `screenshot`
@@ -185,6 +206,7 @@ Capture a PNG screenshot using Servo's software renderer — no GPU required.
 | `url` | string | URL to capture (http/https only) |
 | `full_page` | boolean? | Capture the full scrollable page (default false) |
 | `timeout` | number? | Page load timeout in seconds (default 30) |
+| `settle_ms` | number? | Extra wait in ms after load event (default 0, max 10000) |
 
 #### `execute_js`
 
@@ -195,6 +217,7 @@ Evaluate a JavaScript expression in a loaded page. Console messages are appended
 | `url` | string | URL to load before executing JS |
 | `expression` | string | JavaScript expression to evaluate |
 | `timeout` | number? | Page load timeout in seconds (default 30) |
+| `settle_ms` | number? | Extra wait in ms after load event (default 0, max 10000) |
 
 ## Agent Skills
 

--- a/skills/servo-fetch/SKILL.md
+++ b/skills/servo-fetch/SKILL.md
@@ -35,6 +35,7 @@ Parameters:
 - `max_length`: max characters to return (default 5000)
 - `start_index`: character offset for pagination
 - `timeout`: page load timeout in seconds (default 30)
+- `settle_ms`: extra wait in ms after load event for SPAs (default 0, max 10000)
 
 ```text
 fetch(url: "https://docs.rs/tokio", format: "markdown")
@@ -44,6 +45,24 @@ fetch(url: "https://example.com", format: "accessibility_tree")
 
 PDF URLs are auto-detected via Content-Type and extracted directly.
 
+### batch_fetch
+
+Fetch multiple URLs in parallel. Results are returned as separate content entries in completion order. Failed URLs are reported inline without aborting the batch.
+
+Parameters:
+
+- `urls` (required): array of URLs to fetch (http/https only, max 20)
+- `format`: `"markdown"` (default) or `"json"`
+- `selector`: CSS selector to extract a specific section
+- `max_length`: max characters per URL result (default 5000)
+- `timeout`: page load timeout in seconds per URL (default 30)
+- `settle_ms`: extra wait in ms after load event (default 0, max 10000)
+
+```text
+batch_fetch(urls: ["https://a.com", "https://b.com"], format: "markdown")
+batch_fetch(urls: ["https://a.com", "https://b.com"], format: "json", selector: "article")
+```
+
 ### screenshot
 
 Capture a PNG screenshot. Uses Servo's software renderer — works without GPU.
@@ -51,10 +70,13 @@ Capture a PNG screenshot. Uses Servo's software renderer — works without GPU.
 Parameters:
 
 - `url` (required): URL to capture
+- `full_page`: capture the full scrollable page (default false)
 - `timeout`: page load timeout in seconds (default 30)
+- `settle_ms`: extra wait in ms after load event (default 0, max 10000)
 
 ```text
 screenshot(url: "https://example.com")
+screenshot(url: "https://example.com", full_page: true)
 ```
 
 ### execute_js
@@ -66,6 +88,7 @@ Parameters:
 - `url` (required): URL to load
 - `expression` (required): JavaScript expression to evaluate
 - `timeout`: page load timeout in seconds (default 30)
+- `settle_ms`: extra wait in ms after load event (default 0, max 10000)
 
 ```text
 execute_js(url: "https://example.com", expression: "document.title")
@@ -77,12 +100,15 @@ execute_js(url: "https://example.com", expression: "[...document.querySelectorAl
 ```bash
 servo-fetch https://example.com                    # Markdown (default)
 servo-fetch https://example.com --json             # Structured JSON
+servo-fetch URL1 URL2 URL3                         # Parallel batch (Markdown with separators)
+servo-fetch URL1 URL2 --json                       # Parallel batch (NDJSON)
 servo-fetch https://example.com --screenshot out.png
 servo-fetch https://example.com --js "document.title"
 servo-fetch https://example.com --selector article
 servo-fetch https://example.com --raw html         # Raw HTML
 servo-fetch https://example.com --raw text         # Plain text
 servo-fetch https://example.com -t 60              # Custom timeout
+servo-fetch https://example.com --settle 500       # Extra wait for SPAs
 ```
 
 ## Gotchas

--- a/skills/servo-fetch/references/guide.md
+++ b/skills/servo-fetch/references/guide.md
@@ -14,6 +14,23 @@ Fetch the next chunk:
 fetch(url: "https://...", start_index: 5000)
 ```
 
+## Batch fetching
+
+Use `batch_fetch` to fetch multiple URLs in a single call. Results stream back in completion order — faster pages arrive first.
+
+```text
+batch_fetch(urls: ["https://a.com", "https://b.com", "https://c.com"])
+```
+
+Each URL becomes a separate content entry in the response. Failed URLs are reported inline (prefixed with `[error]`) without aborting the batch.
+
+CLI equivalent:
+
+```bash
+servo-fetch https://a.com https://b.com https://c.com          # Markdown
+servo-fetch https://a.com https://b.com https://c.com --json   # NDJSON
+```
+
 ## Format selection
 
 | Goal | Format |

--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -1,29 +1,29 @@
-//! Servo engine bridge — persistent Servo thread with channel-based communication.
+//! Servo engine bridge.
 
 use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
 use std::rc::Rc;
-use std::sync::mpsc;
+use std::sync::{Arc, Condvar, Mutex, mpsc};
 use std::time::{Duration, Instant};
 
 use anyhow::{Result, anyhow};
 use dpi::PhysicalSize;
 use image::RgbaImage;
 use servo::{
-    ConsoleLogLevel, JSValue, LoadStatus, NavigationRequest, Preferences, RenderingContext, ServoBuilder,
-    SoftwareRenderingContext, UserContentManager, WebView, WebViewBuilder, WebViewDelegate,
+    ConsoleLogLevel, EventLoopWaker, JSValue, LoadStatus, NavigationRequest, Preferences, RenderingContext,
+    ServoBuilder, SoftwareRenderingContext, UserContentManager, WebView, WebViewBuilder, WebViewDelegate, WebViewId,
 };
 
 use servo_fetch::layout;
 
 const JS_EVAL_TIMEOUT: Duration = Duration::from_secs(10);
-const SETTLE_DURATION: Duration = Duration::from_millis(500);
-pub(crate) const SPIN_INTERVAL: Duration = Duration::from_millis(10);
+/// Max wait before we re-check time-based conditions.
+pub(crate) const FALLBACK_WAIT: Duration = Duration::from_millis(5);
 const LAYOUT_JS: &str = include_str!("js/layout.js");
-const MAX_PDF_BYTES: u64 = 50 * 1024 * 1024;
 const MAX_CONSOLE_MESSAGES: usize = 100;
+const MAX_CONSOLE_MESSAGE_LEN: usize = 4096;
+const MAX_A11Y_NODES: usize = 100_000;
 
-/// CSS injected as a user stylesheet to strip common noise elements.
 const NOISE_REMOVAL_CSS: &str = "\
 [aria-label*=\"cookie\" i], [aria-label*=\"consent\" i], \
 [class*=\"cookie-banner\" i], [class*=\"cookie-consent\" i], \
@@ -31,11 +31,90 @@ const NOISE_REMOVAL_CSS: &str = "\
 [class*=\"newsletter-popup\" i], [class*=\"subscribe-modal\" i] \
 { display: none !important; }";
 
-struct Delegate {
-    loaded: Rc<Cell<bool>>,
-    pdf_data: Rc<RefCell<Option<Vec<u8>>>>,
-    a11y_nodes: Rc<RefCell<HashMap<servo::accesskit::NodeId, servo::accesskit::Node>>>,
-    console_messages: Rc<RefCell<Vec<ConsoleMessage>>>,
+/// Shared wake signal — `notify_all` signals, `wait_and_take` consumes.
+#[derive(Default)]
+pub(crate) struct WakeFlag {
+    flag: Mutex<bool>,
+    cv: Condvar,
+}
+
+impl WakeFlag {
+    /// Block up to `timeout` for a signal, then clear the flag atomically.
+    fn wait_and_take(&self, timeout: Duration) -> bool {
+        let mut guard = self.flag.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        if !*guard {
+            let (next, _) = self
+                .cv
+                .wait_timeout(guard, timeout)
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            guard = next;
+        }
+        std::mem::replace(&mut *guard, false)
+    }
+
+    fn signal(&self) {
+        *self.flag.lock().unwrap_or_else(std::sync::PoisonError::into_inner) = true;
+        self.cv.notify_all();
+    }
+}
+
+#[derive(Clone)]
+struct FlagWaker(Arc<WakeFlag>);
+
+impl EventLoopWaker for FlagWaker {
+    fn clone_box(&self) -> Box<dyn EventLoopWaker> {
+        Box::new(self.clone())
+    }
+
+    fn wake(&self) {
+        self.0.signal();
+    }
+}
+
+thread_local! {
+    /// Wake flag owned by `servo_thread`; exposed for `spin_loop` helpers.
+    static WAKE: RefCell<Option<Arc<WakeFlag>>> = const { RefCell::new(None) };
+}
+
+/// Block up to `timeout` for the next Servo wake.
+pub(crate) fn wait_for_wake(timeout: Duration) {
+    WAKE.with(|slot| {
+        if let Some(flag) = slot.borrow().as_ref() {
+            flag.wait_and_take(timeout);
+        } else {
+            std::thread::sleep(timeout);
+        }
+    });
+}
+
+#[derive(Default)]
+struct WebViewState {
+    loaded_at: Cell<Option<Instant>>,
+    a11y_truncated: Cell<bool>,
+    a11y_nodes: RefCell<HashMap<servo::accesskit::NodeId, servo::accesskit::Node>>,
+    console_messages: RefCell<Vec<ConsoleMessage>>,
+}
+
+#[derive(Default)]
+struct SharedDelegate {
+    states: RefCell<HashMap<WebViewId, Rc<WebViewState>>>,
+}
+
+impl SharedDelegate {
+    fn register(&self, id: WebViewId) -> Rc<WebViewState> {
+        let state = Rc::new(WebViewState::default());
+        self.states.borrow_mut().insert(id, state.clone());
+        state
+    }
+
+    fn remove(&self, id: WebViewId) -> Option<Rc<WebViewState>> {
+        self.states.borrow_mut().remove(&id)
+    }
+
+    fn with_state<R>(&self, id: WebViewId, f: impl FnOnce(&WebViewState) -> R) -> Option<R> {
+        let state = self.states.borrow().get(&id).cloned();
+        state.map(|s| f(&s))
+    }
 }
 
 /// A captured console message from the page.
@@ -70,10 +149,25 @@ impl std::fmt::Display for ConsoleLevel {
     }
 }
 
-impl WebViewDelegate for Delegate {
-    fn notify_load_status_changed(&self, _webview: WebView, status: LoadStatus) {
+impl From<ConsoleLogLevel> for ConsoleLevel {
+    fn from(level: ConsoleLogLevel) -> Self {
+        match level {
+            ConsoleLogLevel::Log => Self::Log,
+            ConsoleLogLevel::Debug => Self::Debug,
+            ConsoleLogLevel::Info => Self::Info,
+            ConsoleLogLevel::Warn => Self::Warn,
+            ConsoleLogLevel::Error => Self::Error,
+            ConsoleLogLevel::Trace => Self::Trace,
+        }
+    }
+}
+
+impl WebViewDelegate for SharedDelegate {
+    fn notify_load_status_changed(&self, webview: WebView, status: LoadStatus) {
         if status == LoadStatus::Complete {
-            self.loaded.set(true);
+            self.with_state(webview.id(), |s| {
+                s.loaded_at.set(Some(Instant::now()));
+            });
         }
     }
 
@@ -92,80 +186,40 @@ impl WebViewDelegate for Delegate {
         }
     }
 
-    fn notify_accessibility_tree_update(&self, _webview: WebView, tree_update: servo::accesskit::TreeUpdate) {
-        // TreeUpdate is incremental — merge nodes into a single map to build the full tree.
-        let mut nodes = self.a11y_nodes.borrow_mut();
-        for (id, node) in tree_update.nodes {
-            nodes.insert(id, node);
-        }
-    }
-
-    fn show_console_message(&self, _webview: WebView, level: ConsoleLogLevel, message: String) {
-        let mut msgs = self.console_messages.borrow_mut();
-        if msgs.len() < MAX_CONSOLE_MESSAGES {
-            let level = match level {
-                ConsoleLogLevel::Log => ConsoleLevel::Log,
-                ConsoleLogLevel::Debug => ConsoleLevel::Debug,
-                ConsoleLogLevel::Info => ConsoleLevel::Info,
-                ConsoleLogLevel::Warn => ConsoleLevel::Warn,
-                ConsoleLogLevel::Error => ConsoleLevel::Error,
-                ConsoleLogLevel::Trace => ConsoleLevel::Trace,
-            };
-            msgs.push(ConsoleMessage { level, message });
-        }
-    }
-
-    fn load_web_resource(&self, _webview: WebView, load: servo::WebResourceLoad) {
-        let request = load.request();
-        if !request.is_for_main_frame {
-            return;
-        }
-
-        let url = request.url.clone();
-
-        // SSRF check: validate the host before making any request.
-        if let Some(host) = url.host_str() {
-            if crate::net::is_private_host(host) {
-                return;
+    fn notify_accessibility_tree_update(&self, webview: WebView, tree_update: servo::accesskit::TreeUpdate) {
+        self.with_state(webview.id(), |state| {
+            let mut nodes = state.a11y_nodes.borrow_mut();
+            for (id, node) in tree_update.nodes {
+                if nodes.len() >= MAX_A11Y_NODES && !nodes.contains_key(&id) {
+                    if !state.a11y_truncated.get() {
+                        state.a11y_truncated.set(true);
+                        eprintln!("warning: accessibility tree truncated at {MAX_A11Y_NODES} nodes");
+                    }
+                    continue;
+                }
+                nodes.insert(id, node);
             }
-        }
+        });
+    }
 
-        // HEAD first to check Content-Type; no redirects to prevent SSRF.
-        let agent = ureq::Agent::new_with_config(
-            ureq::config::Config::builder()
-                .max_redirects(0)
-                .timeout_global(Some(Duration::from_secs(15)))
-                .build(),
-        );
-        let Ok(head_resp) = agent.head(url.as_str()).call() else {
-            return;
-        };
-
-        let is_pdf = head_resp
-            .headers()
-            .get("content-type")
-            .and_then(|v| v.to_str().ok())
-            .is_some_and(|ct| ct.to_ascii_lowercase().starts_with("application/pdf"));
-
-        if !is_pdf {
-            return; // Let Servo handle non-PDF responses normally.
-        }
-
-        // Fetch the PDF body with a size limit.
-        let Ok(get_resp) = agent.get(url.as_str()).call() else {
-            return;
-        };
-        let Ok(bytes) = get_resp.into_body().with_config().limit(MAX_PDF_BYTES).read_to_vec() else {
-            return;
-        };
-
-        *self.pdf_data.borrow_mut() = Some(bytes);
-
-        // Send empty HTML so Servo completes loading.
-        let resp = servo::WebResourceResponse::new(url);
-        let mut intercepted = load.intercept(resp);
-        intercepted.send_body_data(b"<html><body></body></html>".to_vec());
-        intercepted.finish();
+    fn show_console_message(&self, webview: WebView, level: ConsoleLogLevel, message: String) {
+        self.with_state(webview.id(), |state| {
+            let mut msgs = state.console_messages.borrow_mut();
+            if msgs.len() < MAX_CONSOLE_MESSAGES {
+                let message = if message.len() > MAX_CONSOLE_MESSAGE_LEN {
+                    let mut s = message;
+                    s.truncate(servo_fetch::sanitize::floor_char_boundary(&s, MAX_CONSOLE_MESSAGE_LEN));
+                    s.push_str("… (truncated)");
+                    s
+                } else {
+                    message
+                };
+                msgs.push(ConsoleMessage {
+                    level: level.into(),
+                    message,
+                });
+            }
+        });
     }
 }
 
@@ -177,7 +231,6 @@ pub(crate) struct ServoPage {
     pub layout_json: Option<String>,
     pub screenshot: Option<RgbaImage>,
     pub js_result: Option<String>,
-    pub pdf_data: Option<Vec<u8>>,
     pub accessibility_tree: Option<String>,
     pub console_messages: Vec<ConsoleMessage>,
 }
@@ -186,159 +239,265 @@ pub(crate) struct ServoPage {
 pub(crate) struct FetchOptions<'a> {
     pub url: &'a str,
     pub timeout_secs: u64,
+    /// Extra wait after Servo fires `LoadStatus::Complete`.
+    pub settle_ms: u64,
     pub mode: FetchMode,
 }
 
 /// What to do once the page has loaded. Variants are mutually exclusive.
 pub(crate) enum FetchMode {
-    /// Capture HTML, inner text, and layout metadata for Readability extraction.
     Content { include_a11y: bool },
-    /// Render a PNG screenshot.
     Screenshot { full_page: bool },
-    /// Evaluate the given JavaScript expression and return its result.
     ExecuteJs { expression: String },
-}
-
-impl FetchMode {
-    fn take_screenshot(&self) -> bool {
-        matches!(self, Self::Screenshot { .. })
-    }
-
-    fn full_page(&self) -> bool {
-        matches!(self, Self::Screenshot { full_page: true })
-    }
-
-    fn needs_accessibility_tree(&self) -> bool {
-        matches!(self, Self::Content { include_a11y: true })
-    }
-
-    fn custom_js(&self) -> Option<&str> {
-        match self {
-            Self::ExecuteJs { expression } => Some(expression.as_str()),
-            _ => None,
-        }
-    }
 }
 
 struct FetchRequest {
     url: String,
     timeout_secs: u64,
+    settle_ms: u64,
     mode: FetchMode,
     reply: mpsc::Sender<Result<ServoPage>>,
 }
 
+struct PendingFetch {
+    webview: WebView,
+    request: FetchRequest,
+    deadline: Instant,
+    state: Rc<WebViewState>,
+    dedicated_ctx: Option<Rc<SoftwareRenderingContext>>,
+}
+
+struct Engine {
+    requests: mpsc::SyncSender<FetchRequest>,
+    wake: Arc<WakeFlag>,
+}
+
+/// Servo engine — lives for the process lifetime. Shutdown is via process exit.
+static ENGINE: std::sync::OnceLock<Engine> = std::sync::OnceLock::new();
+
 /// Fetch a page via Servo. First call spawns a persistent Servo thread.
 pub(crate) fn fetch_page(opts: FetchOptions<'_>) -> Result<ServoPage> {
-    static SENDER: std::sync::OnceLock<mpsc::Sender<FetchRequest>> = std::sync::OnceLock::new();
+    /// Max outstanding requests queued toward the engine.
+    const PENDING_CAPACITY: usize = 64;
 
-    let sender = SENDER.get_or_init(|| {
-        let (tx, rx) = mpsc::channel::<FetchRequest>();
+    let engine = ENGINE.get_or_init(|| {
+        let (tx, rx) = mpsc::sync_channel::<FetchRequest>(PENDING_CAPACITY);
+        let wake = Arc::new(WakeFlag::default());
+        let wake_for_thread = wake.clone();
         std::thread::Builder::new()
             .name("servo-engine".into())
-            .spawn(move || {
-                servo_thread(rx);
-            })
+            .spawn(move || servo_thread(rx, wake_for_thread))
             .expect("failed to spawn servo thread");
-        tx
+        Engine { requests: tx, wake }
     });
 
     let (reply_tx, reply_rx) = mpsc::channel();
-    sender
+    let deadline =
+        Duration::from_secs(opts.timeout_secs) + Duration::from_millis(opts.settle_ms) + Duration::from_secs(2);
+    engine
+        .requests
         .send(FetchRequest {
             url: opts.url.to_string(),
             timeout_secs: opts.timeout_secs,
+            settle_ms: opts.settle_ms,
             mode: opts.mode,
             reply: reply_tx,
         })
         .map_err(|_| anyhow!("Servo engine is not running (it may have crashed on a previous request)"))?;
+    // Nudge the engine so it checks the request queue even if it was idle.
+    engine.wake.signal();
 
-    reply_rx
-        .recv()
-        .map_err(|_| anyhow!("Servo engine crashed while processing this page. Try a different URL."))?
+    match reply_rx.recv_timeout(deadline) {
+        Ok(result) => result,
+        Err(mpsc::RecvTimeoutError::Timeout) => {
+            Err(anyhow!("Servo engine did not respond within {}s", deadline.as_secs()))
+        }
+        Err(mpsc::RecvTimeoutError::Disconnected) => Err(anyhow!("Servo engine crashed while processing this page")),
+    }
 }
 
 #[expect(
     clippy::needless_pass_by_value,
-    reason = "the thread owns the Receiver for its lifetime"
+    reason = "the thread owns its receiver for its lifetime"
 )]
-fn servo_thread(rx: mpsc::Receiver<FetchRequest>) {
-    let (rc_ctx, servo) = match build_servo() {
+fn servo_thread(request_rx: mpsc::Receiver<FetchRequest>, wake: Arc<WakeFlag>) {
+    let (rc_ctx, servo) = match build_servo(FlagWaker(wake.clone())) {
         Ok(pair) => pair,
         Err(e) => {
-            if let Ok(req) = rx.recv() {
+            if let Ok(req) = request_rx.recv() {
                 let _ = req.reply.send(Err(e.context("Servo initialization failed")));
             }
             return;
         }
     };
 
-    while let Ok(req) = rx.recv() {
-        let rc_dyn: Rc<dyn RenderingContext> = rc_ctx.clone();
-        let delegate = Rc::new(Delegate {
-            loaded: Rc::new(Cell::new(false)),
-            pdf_data: Rc::new(RefCell::new(None)),
-            a11y_nodes: Rc::new(RefCell::new(HashMap::new())),
-            console_messages: Rc::new(RefCell::new(Vec::new())),
-        });
+    WAKE.with(|slot| *slot.borrow_mut() = Some(wake.clone()));
 
-        let parsed_url = match url::Url::parse(&req.url) {
-            Ok(u) => u,
-            Err(e) => {
-                let _ = req.reply.send(Err(anyhow!("bad url: {e}")));
-                continue;
-            }
-        };
+    let delegate = Rc::new(SharedDelegate::default());
+    let ucm = Rc::new(UserContentManager::new(&servo));
+    ucm.add_stylesheet(Rc::new(create_noise_removal_stylesheet()));
 
-        // Set up user stylesheets for noise removal.
-        let ucm = Rc::new(UserContentManager::new(&servo));
-        ucm.add_stylesheet(Rc::new(create_noise_removal_stylesheet()));
+    let mut pending: HashMap<WebViewId, PendingFetch> = HashMap::new();
 
-        let webview = WebViewBuilder::new(&servo, rc_dyn)
-            .url(parsed_url)
-            .delegate(delegate.clone())
-            .user_content_manager(ucm)
-            .build();
-
-        // Collect the a11y tree only when requested — building it is expensive.
-        if req.mode.needs_accessibility_tree() {
-            webview.set_accessibility_active(true);
+    loop {
+        while let Ok(req) = request_rx.try_recv() {
+            accept_request(&servo, &rc_ctx, &delegate, &ucm, req, &mut pending);
         }
 
-        let result = handle_request(&servo, &webview, &delegate, &req);
-        drop(webview);
-        let _ = req.reply.send(result);
+        if pending.is_empty() {
+            // Idle: block until a new request nudges us or the channel hangs up.
+            match request_rx.recv() {
+                Ok(req) => accept_request(&servo, &rc_ctx, &delegate, &ucm, req, &mut pending),
+                Err(_) => return,
+            }
+            continue;
+        }
+
+        servo.spin_event_loop();
+        harvest(&servo, &delegate, &mut pending);
+
+        if !pending.is_empty() {
+            // Wait for Servo to wake us or the next pending deadline, whichever is sooner.
+            let now = Instant::now();
+            let next = pending
+                .values()
+                .map(|p| {
+                    p.state
+                        .loaded_at
+                        .get()
+                        .map_or(p.deadline, |t| t + Duration::from_millis(p.request.settle_ms))
+                })
+                .min()
+                .map_or(FALLBACK_WAIT, |t| t.saturating_duration_since(now).min(FALLBACK_WAIT));
+            wake.wait_and_take(next);
+        }
     }
 }
 
-fn handle_request(
+fn accept_request(
     servo: &servo::Servo,
-    webview: &WebView,
-    delegate: &Delegate,
-    req: &FetchRequest,
-) -> Result<ServoPage> {
-    let deadline = Instant::now() + Duration::from_secs(req.timeout_secs);
-    spin_until(servo, &delegate.loaded, deadline, req.timeout_secs)?;
-    wait_for_ready_state(servo, webview, deadline);
+    rc_ctx: &Rc<SoftwareRenderingContext>,
+    delegate: &Rc<SharedDelegate>,
+    ucm: &Rc<UserContentManager>,
+    req: FetchRequest,
+    pending: &mut HashMap<WebViewId, PendingFetch>,
+) {
+    match start_fetch(servo, rc_ctx, delegate, ucm, req) {
+        Ok(p) => {
+            pending.insert(p.webview.id(), p);
+        }
+        Err((req, err)) => {
+            let _ = req.reply.send(Err(err));
+        }
+    }
+}
 
-    let html = eval_js(servo, webview, "document.documentElement.outerHTML")?;
-    let inner_text = eval_js(servo, webview, "document.body.innerText").ok();
-    let layout_json = eval_js(servo, webview, LAYOUT_JS).ok();
+fn harvest(servo: &servo::Servo, delegate: &Rc<SharedDelegate>, pending: &mut HashMap<WebViewId, PendingFetch>) {
+    let now = Instant::now();
+    let finished: Vec<WebViewId> = pending
+        .iter()
+        .filter_map(|(id, p)| {
+            let settled = p
+                .state
+                .loaded_at
+                .get()
+                .is_some_and(|t| now.duration_since(t) >= Duration::from_millis(p.request.settle_ms));
+            (settled || now > p.deadline).then_some(*id)
+        })
+        .collect();
 
-    let screenshot = if req.mode.take_screenshot() {
-        crate::screenshot::capture(servo, webview, req.mode.full_page(), req.timeout_secs)
+    for id in finished {
+        let Some(p) = pending.remove(&id) else { continue };
+        let result = finish_fetch(servo, &p);
+        delegate.remove(id);
+        drop(p.webview);
+        let _ = p.request.reply.send(result);
+    }
+}
+
+fn start_fetch(
+    servo: &servo::Servo,
+    rc_ctx: &Rc<SoftwareRenderingContext>,
+    delegate: &Rc<SharedDelegate>,
+    ucm: &Rc<UserContentManager>,
+    req: FetchRequest,
+) -> std::result::Result<PendingFetch, (FetchRequest, anyhow::Error)> {
+    let parsed_url = match url::Url::parse(&req.url) {
+        Ok(u) => u,
+        Err(e) => return Err((req, anyhow!("bad url: {e}"))),
+    };
+
+    let dedicated_ctx = if matches!(req.mode, FetchMode::Screenshot { .. }) {
+        let size = PhysicalSize::new(layout::VIEWPORT_WIDTH, layout::VIEWPORT_HEIGHT);
+        match SoftwareRenderingContext::new(size) {
+            Ok(ctx) => {
+                if let Err(e) = ctx.make_current() {
+                    return Err((req, anyhow!("failed to make screenshot context current: {e:?}")));
+                }
+                Some(Rc::new(ctx))
+            }
+            Err(e) => return Err((req, anyhow!("failed to create screenshot context: {e:?}"))),
+        }
     } else {
         None
     };
 
-    let js_result = req
-        .mode
-        .custom_js()
-        .map(|expr| eval_js(servo, webview, expr))
-        .transpose()?;
+    let rc_dyn: Rc<dyn RenderingContext> = match dedicated_ctx.as_ref() {
+        Some(ctx) => ctx.clone(),
+        None => rc_ctx.clone(),
+    };
 
-    // Serialize the merged accessibility tree, masking password field values.
+    let delegate_dyn: Rc<dyn WebViewDelegate> = delegate.clone();
+    let webview = WebViewBuilder::new(servo, rc_dyn)
+        .url(parsed_url)
+        .delegate(delegate_dyn)
+        .user_content_manager(ucm.clone())
+        .build();
+
+    if matches!(req.mode, FetchMode::Content { include_a11y: true }) {
+        webview.set_accessibility_active(true);
+    }
+
+    let state = delegate.register(webview.id());
+    let deadline = Instant::now() + Duration::from_secs(req.timeout_secs);
+    Ok(PendingFetch {
+        webview,
+        request: req,
+        deadline,
+        state,
+        dedicated_ctx,
+    })
+}
+
+fn finish_fetch(servo: &servo::Servo, p: &PendingFetch) -> Result<ServoPage> {
+    if p.state.loaded_at.get().is_none() && Instant::now() > p.deadline {
+        return Err(anyhow!(
+            "page load timed out after {timeout}s (try increasing --timeout)",
+            timeout = p.request.timeout_secs,
+        ));
+    }
+
+    if let Some(ref ctx) = p.dedicated_ctx {
+        let _ = ctx.make_current();
+    }
+
+    wait_for_ready_state(servo, &p.webview, p.deadline);
+
+    let html = eval_js(servo, &p.webview, "document.documentElement.outerHTML")?;
+    let inner_text = eval_js(servo, &p.webview, "document.body.innerText").ok();
+    let layout_json = eval_js(servo, &p.webview, LAYOUT_JS).ok();
+
+    let (screenshot, js_result) = match &p.request.mode {
+        FetchMode::Screenshot { full_page } => (
+            crate::screenshot::capture(servo, &p.webview, *full_page, p.request.timeout_secs),
+            None,
+        ),
+        FetchMode::ExecuteJs { expression } => (None, Some(eval_js(servo, &p.webview, expression)?)),
+        FetchMode::Content { .. } => (None, None),
+    };
+
     let accessibility_tree = {
-        let mut nodes = delegate.a11y_nodes.borrow_mut();
+        let mut nodes = p.state.a11y_nodes.borrow_mut();
         if nodes.is_empty() {
             None
         } else {
@@ -357,13 +516,12 @@ fn handle_request(
         layout_json,
         screenshot,
         js_result,
-        pdf_data: delegate.pdf_data.borrow_mut().take(),
         accessibility_tree,
-        console_messages: delegate.console_messages.borrow_mut().drain(..).collect(),
+        console_messages: p.state.console_messages.borrow_mut().drain(..).collect(),
     })
 }
 
-fn build_servo() -> Result<(Rc<SoftwareRenderingContext>, servo::Servo)> {
+fn build_servo(waker: FlagWaker) -> Result<(Rc<SoftwareRenderingContext>, servo::Servo)> {
     let size = PhysicalSize::new(layout::VIEWPORT_WIDTH, layout::VIEWPORT_HEIGHT);
     let ctx = {
         let _guard = stderr_guard::StderrGuard::suppress();
@@ -380,11 +538,18 @@ fn build_servo() -> Result<(Rc<SoftwareRenderingContext>, servo::Servo)> {
         dom_webxr_enabled: false,
         dom_serviceworker_enabled: false,
         dom_bluetooth_enabled: false,
+        user_agent: std::env::var("SERVO_FETCH_USER_AGENT")
+            .ok()
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| "Mozilla/5.0 (compatible; servo-fetch/0.4)".into()),
         ..Preferences::default()
     };
 
     let rc = Rc::new(ctx);
-    let servo = ServoBuilder::default().preferences(prefs).build();
+    let servo = ServoBuilder::default()
+        .preferences(prefs)
+        .event_loop_waker(Box::new(waker))
+        .build();
     Ok((rc, servo))
 }
 
@@ -393,37 +558,18 @@ fn create_noise_removal_stylesheet() -> servo::user_contents::UserStyleSheet {
     servo::user_contents::UserStyleSheet::new(NOISE_REMOVAL_CSS.to_string(), url)
 }
 
-fn spin_until(servo: &servo::Servo, condition: &Cell<bool>, deadline: Instant, timeout_secs: u64) -> Result<()> {
-    while !condition.get() {
-        if Instant::now() > deadline {
-            return Err(anyhow!(
-                "page load timed out after {timeout_secs}s (try increasing --timeout)"
-            ));
-        }
-        servo.spin_event_loop();
-        std::thread::sleep(SPIN_INTERVAL);
-    }
-    let settle_end = Instant::now() + SETTLE_DURATION;
-    while Instant::now() < settle_end {
-        servo.spin_event_loop();
-        std::thread::sleep(SPIN_INTERVAL);
-    }
-    Ok(())
-}
-
-/// Wait for `document.readyState` to reach `"complete"`, or the deadline elapses.
+/// Wait for `document.readyState` to reach `"complete"`.
 ///
-/// TODO(upstream): Servo's `LoadStatus::Complete` fires before the DOM is fully
-/// parsed on pages with heavy inline scripts (e.g. amazon.co.jp); see
-/// servo/servo#41972. Drop this function once upstream fires `LoadStatus::Complete`
-/// at `document.readyState == "complete"` — `spin_until` would then suffice.
+/// TODO(upstream): Servo's `LoadStatus::Complete` fires before the DOM is
+/// fully parsed on pages with heavy inline scripts (e.g. amazon.co.jp); see
+/// servo/servo#41972.
 fn wait_for_ready_state(servo: &servo::Servo, webview: &WebView, deadline: Instant) {
     while Instant::now() < deadline {
         servo.spin_event_loop();
         if matches!(eval_js(servo, webview, "document.readyState"), Ok(s) if s == "complete") {
             return;
         }
-        std::thread::sleep(SPIN_INTERVAL);
+        wait_for_wake(FALLBACK_WAIT);
     }
     eprintln!("warning: document did not finish loading; content may be incomplete");
 }
@@ -453,7 +599,7 @@ pub(crate) fn eval_js(servo: &servo::Servo, webview: &WebView, script: &str) -> 
         if Instant::now() > deadline {
             return Err(anyhow!("timeout waiting for JS evaluation"));
         }
-        std::thread::sleep(SPIN_INTERVAL);
+        wait_for_wake(FALLBACK_WAIT);
     }
 }
 
@@ -495,6 +641,9 @@ mod tests {
     #[test]
     fn console_level_display() {
         assert_eq!(ConsoleLevel::Log.to_string(), "log");
+        assert_eq!(ConsoleLevel::Debug.to_string(), "debug");
+        assert_eq!(ConsoleLevel::Info.to_string(), "info");
+        assert_eq!(ConsoleLevel::Warn.to_string(), "warn");
         assert_eq!(ConsoleLevel::Error.to_string(), "error");
         assert_eq!(ConsoleLevel::Trace.to_string(), "trace");
     }
@@ -521,7 +670,9 @@ mod tests {
         let page = ServoPage::default();
         assert!(page.html.is_empty());
         assert!(page.inner_text.is_none());
+        assert!(page.layout_json.is_none());
         assert!(page.screenshot.is_none());
+        assert!(page.js_result.is_none());
         assert!(page.accessibility_tree.is_none());
         assert!(page.console_messages.is_empty());
     }
@@ -561,39 +712,90 @@ mod tests {
     }
 
     #[test]
-    fn fetch_mode_screenshot_flags() {
-        let vp = FetchMode::Screenshot { full_page: false };
-        assert!(vp.take_screenshot());
-        assert!(!vp.full_page());
-        assert!(!vp.needs_accessibility_tree());
-        assert!(vp.custom_js().is_none());
-
-        let fp = FetchMode::Screenshot { full_page: true };
-        assert!(fp.take_screenshot());
-        assert!(fp.full_page());
+    fn wake_flag_signal_releases_waiter() {
+        let wake = Arc::new(WakeFlag::default());
+        let w = wake.clone();
+        let handle = std::thread::spawn(move || w.wait_and_take(Duration::from_secs(5)));
+        std::thread::sleep(Duration::from_millis(10));
+        wake.signal();
+        assert!(handle.join().unwrap(), "waiter should observe the signal");
     }
 
     #[test]
-    fn fetch_mode_content_flags() {
-        let bare = FetchMode::Content { include_a11y: false };
-        assert!(!bare.take_screenshot());
-        assert!(!bare.full_page());
-        assert!(!bare.needs_accessibility_tree());
-        assert!(bare.custom_js().is_none());
-
-        let a11y = FetchMode::Content { include_a11y: true };
-        assert!(a11y.needs_accessibility_tree());
+    fn wake_flag_wait_and_take_clears() {
+        let wake = WakeFlag::default();
+        wake.signal();
+        assert!(wake.wait_and_take(Duration::from_millis(10)));
+        assert!(!wake.wait_and_take(Duration::from_millis(10)));
     }
 
     #[test]
-    fn fetch_mode_execute_js_flags() {
-        let js = FetchMode::ExecuteJs {
-            expression: "document.title".into(),
-        };
-        assert!(!js.take_screenshot());
-        assert!(!js.full_page());
-        assert!(!js.needs_accessibility_tree());
-        assert_eq!(js.custom_js(), Some("document.title"));
+    fn wake_flag_timeout_returns_false() {
+        let wake = WakeFlag::default();
+        assert!(
+            !wake.wait_and_take(Duration::from_millis(1)),
+            "should return false on timeout"
+        );
+    }
+
+    #[test]
+    fn console_level_from_servo() {
+        assert!(matches!(ConsoleLevel::from(ConsoleLogLevel::Log), ConsoleLevel::Log));
+        assert!(matches!(
+            ConsoleLevel::from(ConsoleLogLevel::Debug),
+            ConsoleLevel::Debug
+        ));
+        assert!(matches!(ConsoleLevel::from(ConsoleLogLevel::Info), ConsoleLevel::Info));
+        assert!(matches!(ConsoleLevel::from(ConsoleLogLevel::Warn), ConsoleLevel::Warn));
+        assert!(matches!(
+            ConsoleLevel::from(ConsoleLogLevel::Error),
+            ConsoleLevel::Error
+        ));
+        assert!(matches!(
+            ConsoleLevel::from(ConsoleLogLevel::Trace),
+            ConsoleLevel::Trace
+        ));
+    }
+
+    #[test]
+    fn jsvalue_to_json_element_variants() {
+        assert_eq!(
+            jsvalue_to_json(&JSValue::Element("div".into())).unwrap(),
+            serde_json::json!("div")
+        );
+        assert_eq!(
+            jsvalue_to_json(&JSValue::ShadowRoot("sr".into())).unwrap(),
+            serde_json::json!("sr")
+        );
+        assert_eq!(
+            jsvalue_to_json(&JSValue::Frame("f".into())).unwrap(),
+            serde_json::json!("f")
+        );
+        assert_eq!(
+            jsvalue_to_json(&JSValue::Window("w".into())).unwrap(),
+            serde_json::json!("w")
+        );
+    }
+
+    #[test]
+    fn jsvalue_to_json_object() {
+        let mut map = HashMap::new();
+        map.insert("key".to_string(), JSValue::Number(1.0));
+        let val = JSValue::Object(map);
+        let result = jsvalue_to_json(&val).unwrap();
+        assert_eq!(result, serde_json::json!({"key": 1.0}));
+    }
+
+    #[test]
+    fn webview_state_default() {
+        let state = WebViewState::default();
+        assert!(state.loaded_at.get().is_none(), "loaded_at should be None");
+        assert!(!state.a11y_truncated.get(), "a11y_truncated should be false");
+        assert!(state.a11y_nodes.borrow().is_empty(), "a11y_nodes should be empty");
+        assert!(
+            state.console_messages.borrow().is_empty(),
+            "console_messages should be empty"
+        );
     }
 }
 
@@ -602,7 +804,6 @@ mod tests {
 mod stderr_guard {
     use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, OwnedFd};
 
-    /// RAII guard: suppresses stderr on creation, restores on drop.
     pub(crate) struct StderrGuard {
         saved_fd: Option<OwnedFd>,
     }
@@ -610,7 +811,6 @@ mod stderr_guard {
     impl StderrGuard {
         #[allow(unsafe_code)]
         pub(crate) fn suppress() -> Self {
-            // SAFETY: dup/dup2/fcntl/close are standard POSIX calls.
             let saved = unsafe { libc::dup(2) };
             if saved < 0 {
                 return Self { saved_fd: None };

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -11,6 +11,8 @@ use clap::Parser;
 Examples:
   servo-fetch https://example.com              Readable Markdown (default)
   servo-fetch https://example.com --json       Structured JSON
+  servo-fetch URL1 URL2 URL3                   Parallel batch fetch
+  servo-fetch URL1 URL2 --json                 Parallel batch (NDJSON)
   servo-fetch https://example.com --screenshot page.png
   servo-fetch https://example.com --js \"document.title\"
   servo-fetch https://example.com -t 60        Custom timeout (seconds)
@@ -21,14 +23,15 @@ pub(crate) struct Cli {
     #[command(subcommand)]
     pub command: Option<Command>,
 
-    /// URL to fetch
-    pub url: Option<String>,
+    /// URLs to fetch (one or more)
+    #[arg(num_args = 1..)]
+    pub urls: Vec<String>,
 
-    /// Output as structured JSON
+    /// Output as structured JSON (NDJSON when multiple URLs)
     #[arg(long, conflicts_with_all = ["screenshot", "js"])]
     pub json: bool,
 
-    /// Save screenshot as PNG
+    /// Save screenshot as PNG (single URL only)
     #[arg(long, value_name = "FILE", conflicts_with_all = ["json", "js"])]
     pub screenshot: Option<String>,
 
@@ -36,13 +39,17 @@ pub(crate) struct Cli {
     #[arg(long, requires = "screenshot")]
     pub full_page: bool,
 
-    /// Execute JavaScript and print the result
+    /// Execute JavaScript and print the result (single URL only)
     #[arg(long, value_name = "EXPR", conflicts_with_all = ["json", "screenshot"])]
     pub js: Option<String>,
 
     /// Timeout in seconds for page load
     #[arg(short = 't', long, default_value_t = 30, value_parser = clap::value_parser!(u64).range(1..), value_name = "SECS")]
     pub timeout: u64,
+
+    /// Extra wait in ms after the `load` event, for SPAs that keep hydrating.
+    #[arg(long, default_value_t = 0, value_parser = clap::value_parser!(u64).range(0..=10_000), value_name = "MS")]
+    pub settle: u64,
 
     /// CSS selector to extract a specific section
     #[arg(long, value_name = "CSS")]
@@ -167,5 +174,32 @@ mod cli_tests {
             .assert()
             .failure()
             .stderr(predicate::str::contains("cannot be used with"));
+    }
+
+    #[test]
+    fn settle_rejects_out_of_range() {
+        servo_fetch()
+            .args(["--settle", "10001", "https://example.com"])
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains("invalid value"));
+    }
+
+    #[test]
+    fn raw_conflicts_with_json() {
+        servo_fetch()
+            .args(["--raw", "html", "--json", "https://example.com"])
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains("cannot be used with"));
+    }
+
+    #[test]
+    fn full_page_requires_screenshot() {
+        servo_fetch()
+            .args(["--full-page", "https://example.com"])
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains("--screenshot"));
     }
 }

--- a/src/command.rs
+++ b/src/command.rs
@@ -143,4 +143,38 @@ mod tests {
         };
         assert!(cmd.execute().is_ok());
     }
+
+    #[test]
+    fn raw_html_produces_output() {
+        let page = mock_page("<html><body><p>raw</p></body></html>");
+        let cmd = Raw {
+            page: &page,
+            mode: &crate::cli::RawMode::Html,
+        };
+        assert!(cmd.execute().is_ok());
+    }
+
+    #[test]
+    fn raw_text_with_inner_text() {
+        let page = ServoPage {
+            html: String::new(),
+            inner_text: Some("plain text".into()),
+            ..ServoPage::default()
+        };
+        let cmd = Raw {
+            page: &page,
+            mode: &crate::cli::RawMode::Text,
+        };
+        assert!(cmd.execute().is_ok());
+    }
+
+    #[test]
+    fn raw_text_without_inner_text() {
+        let page = mock_page("<html></html>");
+        let cmd = Raw {
+            page: &page,
+            mode: &crate::cli::RawMode::Text,
+        };
+        assert!(cmd.execute().is_ok());
+    }
 }

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -331,4 +331,11 @@ mod tests {
         assert_eq!(input.inner_text, Some("hello"));
         assert_eq!(input.selector, Some("article"));
     }
+
+    #[test]
+    fn clean_markdown_no_trailing_newline() {
+        let input = "line1\nline2";
+        let result = clean_markdown(input);
+        assert_eq!(result, "line1\nline2\n");
+    }
 }

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -191,4 +191,16 @@ mod tests {
             serde_json::from_str(r#"{"tag":"DIV","role":null,"w":100.0,"h":50.0,"position":"absolute"}"#).unwrap();
         assert_eq!(el.position, Position::Other);
     }
+
+    #[test]
+    fn navigation_role_sidebar() {
+        let sels = selectors_to_strip(&[el("NAV", 250.0, 800.0, Position::Other, Some(Role::Navigation))]);
+        assert_eq!(sels, vec!["nav[role=\"navigation\"]"]);
+    }
+
+    #[test]
+    fn empty_elements_returns_empty() {
+        let sels = selectors_to_strip(&[]);
+        assert!(sels.is_empty());
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod cli;
 mod command;
 mod mcp;
 mod net;
+mod pdf;
 mod screenshot;
 
 use std::io::{IsTerminal, Write as _};
@@ -75,16 +76,130 @@ fn flush_and_exit(code: i32) -> ! {
 }
 
 fn run(args: &cli::Cli) -> anyhow::Result<()> {
-    let url_str = args
-        .url
-        .as_deref()
-        .ok_or_else(|| anyhow::anyhow!("URL is required. Run with --help for usage."))?;
+    if args.urls.is_empty() {
+        anyhow::bail!("URL is required. Run with --help for usage.");
+    }
+
+    if args.urls.len() > 1 {
+        if args.screenshot.is_some() || args.js.is_some() || args.raw.is_some() {
+            anyhow::bail!("--screenshot, --js, and --raw are not supported with multiple URLs");
+        }
+        let rt = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
+        return rt.block_on(run_batch(args));
+    }
+
+    run_single(args)
+}
+
+async fn run_batch(args: &cli::Cli) -> anyhow::Result<()> {
+    use std::sync::Arc;
+    use tokio::sync::Semaphore;
+
+    let urls: Vec<url::Url> = args
+        .urls
+        .iter()
+        .map(|s| cli::validate_url(s))
+        .collect::<anyhow::Result<Vec<_>>>()?;
+
+    let is_tty = std::io::stderr().is_terminal();
+    let total = urls.len();
+    if is_tty {
+        eprintln!("Fetching {total} URLs...");
+    }
+
+    let sem = Arc::new(Semaphore::new(4));
+    let (tx, mut rx) = tokio::sync::mpsc::channel::<(String, anyhow::Result<bridge::ServoPage>)>(total);
+
+    for url in &urls {
+        let permit = sem.clone().acquire_owned().await?;
+        let tx = tx.clone();
+        let url_str = url.to_string();
+        let timeout = args.timeout;
+        let settle = args.settle;
+        tokio::task::spawn_blocking(move || {
+            let result = bridge::fetch_page(bridge::FetchOptions {
+                url: &url_str,
+                timeout_secs: timeout,
+                settle_ms: settle,
+                mode: bridge::FetchMode::Content { include_a11y: false },
+            });
+            let _ = tx.blocking_send((url_str, result));
+            drop(permit);
+        });
+    }
+    drop(tx);
+
+    let mut completed = 0usize;
+    let mut failures = 0usize;
+    let json = args.json;
+    let selector = args.selector.as_deref();
+
+    while let Some((url, result)) = rx.recv().await {
+        completed += 1;
+        match result {
+            Ok(page) => {
+                if json {
+                    let input = servo_fetch::extract::ExtractInput::new(&page.html, &url)
+                        .with_layout_json(page.layout_json.as_deref())
+                        .with_inner_text(page.inner_text.as_deref())
+                        .with_selector(selector);
+                    let pretty = servo_fetch::extract::extract_json(&input).unwrap_or_default();
+                    // NDJSON: compact single-line JSON per URL
+                    if let Ok(val) = serde_json::from_str::<serde_json::Value>(&pretty) {
+                        let compact = serde_json::to_string(&val).unwrap_or(pretty);
+                        writeln!(std::io::stdout(), "{}", servo_fetch::sanitize::sanitize(&compact))?;
+                    } else {
+                        writeln!(std::io::stdout(), "{}", servo_fetch::sanitize::sanitize(&pretty))?;
+                    }
+                } else {
+                    writeln!(std::io::stdout(), "--- {url} ---")?;
+                    let input = servo_fetch::extract::ExtractInput::new(&page.html, &url)
+                        .with_layout_json(page.layout_json.as_deref())
+                        .with_inner_text(page.inner_text.as_deref())
+                        .with_selector(selector);
+                    let out = servo_fetch::extract::extract_text(&input).unwrap_or_default();
+                    write!(std::io::stdout(), "{}", servo_fetch::sanitize::sanitize(&out))?;
+                    writeln!(std::io::stdout())?;
+                }
+                if is_tty {
+                    eprintln!("[{completed}/{total}] {url} ✓");
+                }
+            }
+            Err(e) => {
+                failures += 1;
+                eprintln!("error: {url}: {e:#}");
+            }
+        }
+    }
+
+    if failures == total {
+        anyhow::bail!("all {total} URLs failed");
+    }
+    Ok(())
+}
+
+fn run_single(args: &cli::Cli) -> anyhow::Result<()> {
+    let url_str = &args.urls[0];
     let url = cli::validate_url(url_str)?;
 
     let is_tty = std::io::stderr().is_terminal();
     if is_tty {
         eprint!("Fetching {url}...");
         let _ = std::io::Write::flush(&mut std::io::stderr());
+    }
+
+    let is_content_mode = args.screenshot.is_none() && args.js.is_none();
+
+    // PDF probe skips modes where Servo rendering is the point.
+    if is_content_mode {
+        if let Some(pdf_bytes) = pdf::probe(url.as_str(), args.timeout) {
+            if is_tty {
+                eprint!("\r\x1b[K");
+            }
+            let text = servo_fetch::extract::extract_pdf(&pdf_bytes);
+            write!(std::io::stdout(), "{}", servo_fetch::sanitize::sanitize(&text))?;
+            return Ok(());
+        }
     }
 
     let mode = if args.screenshot.is_some() {
@@ -99,6 +214,7 @@ fn run(args: &cli::Cli) -> anyhow::Result<()> {
     let page = bridge::fetch_page(bridge::FetchOptions {
         url: url.as_str(),
         timeout_secs: args.timeout,
+        settle_ms: args.settle,
         mode,
     });
 
@@ -107,12 +223,6 @@ fn run(args: &cli::Cli) -> anyhow::Result<()> {
     }
 
     let page = page?;
-
-    if let Some(ref pdf_bytes) = page.pdf_data {
-        let text = servo_fetch::extract::extract_pdf(pdf_bytes);
-        write!(std::io::stdout(), "{}", servo_fetch::sanitize::sanitize(&text))?;
-        return Ok(());
-    }
 
     if let Some(ref result) = page.js_result {
         command::JsEval { result }.execute()?;

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -11,6 +11,8 @@ const MAX_JS_LEN: usize = 10_000;
 const MAX_JS_OUTPUT_LEN: usize = 1_000_000;
 const MAX_TIMEOUT_SECS: u64 = 300;
 const MAX_SELECTOR_LEN: usize = 1_000;
+const MAX_SETTLE_MS: u64 = 10_000;
+const MAX_BATCH_URLS: usize = 20;
 
 /// Output format requested by the MCP `fetch` tool.
 #[derive(Debug, Default, serde::Deserialize, schemars::JsonSchema)]
@@ -38,6 +40,10 @@ pub(super) struct FetchParams {
     start_index: Option<usize>,
     #[schemars(description = "Page load timeout in seconds. Default: 30")]
     timeout: Option<u64>,
+    #[schemars(
+        description = "Extra wait in ms after the `load` event, for SPAs that keep hydrating. Default: 0. Max: 10000."
+    )]
+    settle_ms: Option<u64>,
     #[schemars(description = "CSS selector to extract a specific section instead of full-page Readability extraction")]
     selector: Option<String>,
 }
@@ -51,6 +57,8 @@ pub(super) struct ScreenshotParams {
     full_page: Option<bool>,
     #[schemars(description = "Page load timeout in seconds. Default: 30")]
     timeout: Option<u64>,
+    #[schemars(description = "Extra wait in ms after the `load` event. Default: 0. Max: 10000.")]
+    settle_ms: Option<u64>,
 }
 
 /// Parameters for the MCP `execute_js` tool.
@@ -62,6 +70,34 @@ pub(super) struct ExecuteJsParams {
     expression: String,
     #[schemars(description = "Page load timeout in seconds. Default: 30")]
     timeout: Option<u64>,
+    #[schemars(description = "Extra wait in ms after the `load` event. Default: 0. Max: 10000.")]
+    settle_ms: Option<u64>,
+}
+
+/// Parameters for the MCP `batch_fetch` tool.
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub(super) struct BatchFetchParams {
+    #[schemars(description = "URLs to fetch (http/https only). Max 20.")]
+    urls: Vec<String>,
+    #[schemars(description = "Output format: markdown (default) or json")]
+    format: Option<BatchFormat>,
+    #[schemars(description = "Max characters per URL result. Default: 5000")]
+    max_length: Option<usize>,
+    #[schemars(description = "Page load timeout in seconds (per URL). Default: 30")]
+    timeout: Option<u64>,
+    #[schemars(description = "Extra wait in ms after the `load` event. Default: 0. Max: 10000.")]
+    settle_ms: Option<u64>,
+    #[schemars(description = "CSS selector to extract a specific section")]
+    selector: Option<String>,
+}
+
+/// Output format for `batch_fetch`.
+#[derive(Debug, Default, serde::Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub(super) enum BatchFormat {
+    #[default]
+    Markdown,
+    Json,
 }
 
 /// MCP handler that exposes servo-fetch's tools.
@@ -86,6 +122,7 @@ impl ServoMcp {
     async fn fetch(&self, Parameters(p): Parameters<FetchParams>) -> Result<CallToolResult, ErrorData> {
         let url = tools::validated_url(&p.url)?;
         let timeout = p.timeout.unwrap_or(30).clamp(1, MAX_TIMEOUT_SECS);
+        let settle_ms = p.settle_ms.unwrap_or(0).min(MAX_SETTLE_MS);
         let max_len = p.max_length.unwrap_or(5000);
         let start = p.start_index.unwrap_or(0);
 
@@ -97,10 +134,18 @@ impl ServoMcp {
         }
 
         let include_a11y = matches!(p.format, Some(OutputFormat::AccessibilityTree));
-        let page = tools::fetch_page(&url, timeout, crate::bridge::FetchMode::Content { include_a11y }).await?;
-        let full = if let Some(ref pdf_bytes) = page.pdf_data {
-            servo_fetch::extract::extract_pdf(pdf_bytes)
+
+        // Probe PDFs before the Servo thread so one slow HEAD never stalls concurrent WebViews.
+        let full = if let Some(pdf_bytes) = tools::probe_pdf(&url, timeout).await {
+            servo_fetch::extract::extract_pdf(&pdf_bytes)
         } else {
+            let page = tools::fetch_page(
+                &url,
+                timeout,
+                settle_ms,
+                crate::bridge::FetchMode::Content { include_a11y },
+            )
+            .await?;
             let fmt = p.format.unwrap_or_default();
             match fmt {
                 OutputFormat::Html => page.html,
@@ -123,7 +168,8 @@ impl ServoMcp {
     async fn screenshot(&self, Parameters(p): Parameters<ScreenshotParams>) -> Result<CallToolResult, ErrorData> {
         let url = tools::validated_url(&p.url)?;
         let timeout = p.timeout.unwrap_or(30).clamp(1, MAX_TIMEOUT_SECS);
-        tools::take_screenshot(&url, timeout, p.full_page.unwrap_or(false)).await
+        let settle_ms = p.settle_ms.unwrap_or(0).min(MAX_SETTLE_MS);
+        tools::take_screenshot(&url, timeout, settle_ms, p.full_page.unwrap_or(false)).await
     }
 
     #[tool(
@@ -138,10 +184,12 @@ impl ServoMcp {
         }
         let url = tools::validated_url(&p.url)?;
         let timeout = p.timeout.unwrap_or(30).clamp(1, MAX_TIMEOUT_SECS);
+        let settle_ms = p.settle_ms.unwrap_or(0).min(MAX_SETTLE_MS);
 
         let page = tools::fetch_page(
             &url,
             timeout,
+            settle_ms,
             crate::bridge::FetchMode::ExecuteJs {
                 expression: p.expression,
             },
@@ -149,7 +197,7 @@ impl ServoMcp {
         .await?;
         let mut result = page.js_result.unwrap_or_default();
         if result.len() > MAX_JS_OUTPUT_LEN {
-            result.truncate(tools::floor_char_boundary(&result, MAX_JS_OUTPUT_LEN));
+            result.truncate(servo_fetch::sanitize::floor_char_boundary(&result, MAX_JS_OUTPUT_LEN));
             result.push_str("\n<output truncated>");
         }
         if !page.console_messages.is_empty() {
@@ -162,6 +210,44 @@ impl ServoMcp {
         Ok(CallToolResult::success(vec![Content::text(
             servo_fetch::sanitize::sanitize(&result).into_owned(),
         )]))
+    }
+
+    #[tool(
+        description = "Fetch multiple URLs in parallel and extract readable content. Results are returned as separate content entries, one per URL, in completion order. Failed URLs are reported inline without aborting the batch."
+    )]
+    async fn batch_fetch(&self, Parameters(p): Parameters<BatchFetchParams>) -> Result<CallToolResult, ErrorData> {
+        if p.urls.is_empty() {
+            return Err(ErrorData::invalid_params("urls must not be empty", None));
+        }
+        if p.urls.len() > MAX_BATCH_URLS {
+            return Err(ErrorData::invalid_params(
+                format!("urls exceeds {MAX_BATCH_URLS} URL limit"),
+                None,
+            ));
+        }
+        if p.selector.as_ref().is_some_and(|s| s.len() > MAX_SELECTOR_LEN) {
+            return Err(ErrorData::invalid_params(
+                format!("selector exceeds {MAX_SELECTOR_LEN} character limit"),
+                None,
+            ));
+        }
+
+        let timeout = p.timeout.unwrap_or(30).clamp(1, MAX_TIMEOUT_SECS);
+        let settle_ms = p.settle_ms.unwrap_or(0).min(MAX_SETTLE_MS);
+        let max_len = p.max_length.unwrap_or(5000);
+        let json = matches!(p.format, Some(BatchFormat::Json));
+
+        let validated: Vec<String> = p
+            .urls
+            .iter()
+            .map(|u| tools::validated_url(u))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let results =
+            tools::batch_fetch_pages(&validated, timeout, settle_ms, json, p.selector.as_deref(), max_len).await;
+
+        let contents: Vec<Content> = results.into_iter().map(|(_url, text)| Content::text(text)).collect();
+        Ok(CallToolResult::success(contents))
     }
 }
 
@@ -242,5 +328,56 @@ mod tests {
     fn execute_js_params_requires_both() {
         assert!(serde_json::from_str::<ExecuteJsParams>(r#"{"url":"https://example.com"}"#).is_err());
         assert!(serde_json::from_str::<ExecuteJsParams>(r#"{"expression":"1+1"}"#).is_err());
+    }
+
+    #[test]
+    fn output_format_accessibility_tree() {
+        let at: OutputFormat = serde_json::from_str("\"accessibility_tree\"").unwrap();
+        assert!(matches!(at, OutputFormat::AccessibilityTree));
+    }
+
+    #[test]
+    fn fetch_params_with_settle_ms() {
+        let p: FetchParams = serde_json::from_str(r#"{"url":"https://example.com","settle_ms":500}"#).unwrap();
+        assert_eq!(p.settle_ms, Some(500));
+    }
+
+    #[test]
+    fn screenshot_params_all_fields() {
+        let p: ScreenshotParams =
+            serde_json::from_str(r#"{"url":"https://example.com","full_page":true,"timeout":60,"settle_ms":1000}"#)
+                .unwrap();
+        assert_eq!(p.full_page, Some(true));
+        assert_eq!(p.timeout, Some(60));
+        assert_eq!(p.settle_ms, Some(1000));
+    }
+
+    #[test]
+    fn execute_js_params_all_fields() {
+        let p: ExecuteJsParams =
+            serde_json::from_str(r#"{"url":"https://example.com","expression":"1+1","timeout":10,"settle_ms":200}"#)
+                .unwrap();
+        assert_eq!(p.timeout, Some(10));
+        assert_eq!(p.settle_ms, Some(200));
+    }
+
+    #[test]
+    fn batch_fetch_params_requires_urls() {
+        assert!(serde_json::from_str::<BatchFetchParams>("{}").is_err());
+    }
+
+    #[test]
+    fn batch_fetch_params_accepts_minimal() {
+        let p: BatchFetchParams = serde_json::from_str(r#"{"urls":["https://example.com"]}"#).unwrap();
+        assert_eq!(p.urls.len(), 1);
+        assert!(p.format.is_none());
+    }
+
+    #[test]
+    fn batch_format_deserializes() {
+        let md: BatchFormat = serde_json::from_str("\"markdown\"").unwrap();
+        assert!(matches!(md, BatchFormat::Markdown));
+        let json: BatchFormat = serde_json::from_str("\"json\"").unwrap();
+        assert!(matches!(json, BatchFormat::Json));
     }
 }

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1,12 +1,33 @@
 //! Shared helpers for MCP tool implementations.
 
+use std::sync::OnceLock;
+
 use base64::Engine as _;
 use rmcp::ErrorData;
 use rmcp::model::{CallToolResult, Content};
+use tokio::sync::Semaphore;
 
 use crate::bridge;
 use crate::net;
 use servo_fetch::extract::{self, ExtractInput};
+
+/// Upper bound on the number of Servo fetches processed concurrently.
+const DEFAULT_MAX_CONCURRENT_FETCHES: usize = 4;
+
+/// Hard ceiling on concurrency regardless of env override.
+const MAX_ALLOWED_CONCURRENCY: usize = 16;
+
+fn fetch_semaphore() -> &'static Semaphore {
+    static SEMAPHORE: OnceLock<Semaphore> = OnceLock::new();
+    SEMAPHORE.get_or_init(|| {
+        let limit = std::env::var("SERVO_FETCH_MAX_CONCURRENCY")
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            .filter(|n| *n > 0)
+            .map_or(DEFAULT_MAX_CONCURRENT_FETCHES, |n| n.min(MAX_ALLOWED_CONCURRENCY));
+        Semaphore::new(limit)
+    })
+}
 
 /// Validate a URL and return it in canonical form as a string.
 pub(super) fn validated_url(url: &str) -> Result<String, ErrorData> {
@@ -15,23 +36,102 @@ pub(super) fn validated_url(url: &str) -> Result<String, ErrorData> {
         .map_err(|e| ErrorData::invalid_params(format!("{e:#}"), None))
 }
 
-/// Run a Servo fetch on the blocking thread pool.
+/// Run a Servo fetch on the blocking thread pool, gated by a semaphore so a
+/// burst of concurrent tool calls does not create unbounded live `WebView`s.
 pub(super) async fn fetch_page(
     url: &str,
     timeout: u64,
+    settle_ms: u64,
     mode: bridge::FetchMode,
 ) -> Result<bridge::ServoPage, ErrorData> {
+    let _permit = fetch_semaphore()
+        .acquire()
+        .await
+        .map_err(|e| ErrorData::internal_error(format!("fetch semaphore closed: {e}"), None))?;
+
     let url = url.to_string();
     tokio::task::spawn_blocking(move || {
         bridge::fetch_page(bridge::FetchOptions {
             url: &url,
             timeout_secs: timeout,
+            settle_ms,
             mode,
         })
     })
     .await
     .map_err(|e| ErrorData::internal_error(e.to_string(), None))?
     .map_err(|e| ErrorData::internal_error(format!("{e:#}"), None))
+}
+
+pub(super) async fn probe_pdf(url: &str, timeout: u64) -> Option<Vec<u8>> {
+    let url = url.to_string();
+    tokio::task::spawn_blocking(move || crate::pdf::probe(&url, timeout))
+        .await
+        .ok()
+        .flatten()
+}
+
+/// Fetch multiple URLs in parallel, returning `(url, rendered_text)` pairs in completion order.
+pub(super) async fn batch_fetch_pages(
+    urls: &[String],
+    timeout: u64,
+    settle_ms: u64,
+    json: bool,
+    selector: Option<&str>,
+    max_len: usize,
+) -> Vec<(String, String)> {
+    let (tx, mut rx) = tokio::sync::mpsc::channel(urls.len().max(1));
+
+    for url in urls {
+        let permit = fetch_semaphore().acquire().await.ok();
+        let tx = tx.clone();
+        let url = url.clone();
+        let selector = selector.map(String::from);
+        tokio::task::spawn_blocking(move || {
+            let text = fetch_and_render(&url, timeout, settle_ms, json, selector.as_deref(), max_len);
+            let _ = tx.blocking_send((url, text));
+            drop(permit);
+        });
+    }
+    drop(tx);
+
+    let mut results = Vec::with_capacity(urls.len());
+    while let Some(pair) = rx.recv().await {
+        results.push(pair);
+    }
+    results
+}
+
+fn fetch_and_render(
+    url: &str,
+    timeout: u64,
+    settle_ms: u64,
+    json: bool,
+    selector: Option<&str>,
+    max_len: usize,
+) -> String {
+    let page = match bridge::fetch_page(bridge::FetchOptions {
+        url,
+        timeout_secs: timeout,
+        settle_ms,
+        mode: bridge::FetchMode::Content { include_a11y: false },
+    }) {
+        Ok(p) => p,
+        Err(e) => return format!("[error] {e:#}"),
+    };
+
+    let input = ExtractInput::new(&page.html, url)
+        .with_layout_json(page.layout_json.as_deref())
+        .with_inner_text(page.inner_text.as_deref())
+        .with_selector(selector);
+
+    let full = if json {
+        extract::extract_json(&input).unwrap_or_default()
+    } else {
+        extract::extract_text(&input).unwrap_or_default()
+    };
+
+    paginate(&servo_fetch::sanitize::sanitize(&full), 0, max_len)
 }
 
 /// Run Readability-based extraction on a fetched page, as Markdown or JSON.
@@ -54,8 +154,13 @@ pub(super) fn extract(
 }
 
 /// Render the page and return its screenshot as a base64 PNG MCP content.
-pub(super) async fn take_screenshot(url: &str, timeout: u64, full_page: bool) -> Result<CallToolResult, ErrorData> {
-    let page = fetch_page(url, timeout, bridge::FetchMode::Screenshot { full_page }).await?;
+pub(super) async fn take_screenshot(
+    url: &str,
+    timeout: u64,
+    settle_ms: u64,
+    full_page: bool,
+) -> Result<CallToolResult, ErrorData> {
+    let page = fetch_page(url, timeout, settle_ms, bridge::FetchMode::Screenshot { full_page }).await?;
     let img = page
         .screenshot
         .ok_or_else(|| ErrorData::internal_error("screenshot capture failed", None))?;
@@ -73,6 +178,8 @@ pub(super) async fn take_screenshot(url: &str, timeout: u64, full_page: bool) ->
 /// Return a char-aligned slice of `content` and a truncation notice when
 /// the slice does not cover the full content.
 pub(super) fn paginate(content: &str, start: usize, max_len: usize) -> String {
+    use servo_fetch::sanitize::floor_char_boundary;
+
     let max_len = max_len.max(1);
     let total = content.len();
     let start = floor_char_boundary(content, start);
@@ -86,18 +193,6 @@ pub(super) fn paginate(content: &str, start: usize, max_len: usize) -> String {
     } else {
         chunk.to_string()
     }
-}
-
-/// Return the nearest UTF-8 char boundary `<= index`.
-pub(super) fn floor_char_boundary(s: &str, index: usize) -> usize {
-    if index >= s.len() {
-        return s.len();
-    }
-    let mut i = index;
-    while i > 0 && !s.is_char_boundary(i) {
-        i -= 1;
-    }
-    i
 }
 
 #[cfg(test)]
@@ -128,33 +223,7 @@ mod tests {
 
     #[test]
     fn paginate_multibyte_boundary() {
-        // 2-byte chars: "ĵƥ" = [0xC4 0xB5][0xC6 0xA5] = 4 bytes
-        assert_eq!(floor_char_boundary("ĵƥ", 0), 0); // start of ĵ
-        assert_eq!(floor_char_boundary("ĵƥ", 1), 0); // inside ĵ
-        assert_eq!(floor_char_boundary("ĵƥ", 2), 2); // start of ƥ
-        assert_eq!(floor_char_boundary("ĵƥ", 3), 2); // inside ƥ
-        assert_eq!(floor_char_boundary("ĵƥ", 4), 4); // end
-
-        // 3-byte chars: "日本語" = [E6 97 A5][E6 9C AC][E8 AA 9E] = 9 bytes
-        assert_eq!(floor_char_boundary("日本語", 0), 0); // start of 日
-        assert_eq!(floor_char_boundary("日本語", 1), 0); // inside 日
-        assert_eq!(floor_char_boundary("日本語", 2), 0); // inside 日
-        assert_eq!(floor_char_boundary("日本語", 3), 3); // start of 本
-        assert_eq!(floor_char_boundary("日本語", 4), 3); // inside 本
-        assert_eq!(floor_char_boundary("日本語", 5), 3); // inside 本
-        assert_eq!(floor_char_boundary("日本語", 6), 6); // start of 語
-        assert_eq!(floor_char_boundary("日本語", 7), 6); // inside 語
-        assert_eq!(floor_char_boundary("日本語", 8), 6); // inside 語
-        assert_eq!(floor_char_boundary("日本語", 9), 9); // end
-
-        // 4-byte chars: "🦀" = [F0 9F A6 80] = 4 bytes
-        assert_eq!(floor_char_boundary("🦀", 0), 0); // start of 🦀
-        assert_eq!(floor_char_boundary("🦀", 1), 0); // inside 🦀
-        assert_eq!(floor_char_boundary("🦀", 2), 0); // inside 🦀
-        assert_eq!(floor_char_boundary("🦀", 3), 0); // inside 🦀
-        assert_eq!(floor_char_boundary("🦀", 4), 4); // end
-
-        // paginate must produce valid UTF-8 at the boundary
+        // paginate must produce valid UTF-8 at the byte boundary.
         let result = paginate("日本語", 0, 4);
         assert!(result.starts_with("日"));
     }
@@ -167,5 +236,23 @@ mod tests {
     #[test]
     fn accepts_public_url() {
         assert!(validated_url("https://example.com").is_ok());
+    }
+
+    #[test]
+    fn paginate_max_len_zero_clamped() {
+        let r = paginate("hello", 0, 0);
+        assert!(r.starts_with('h'), "max_len=0 should clamp to 1");
+    }
+
+    #[test]
+    fn paginate_start_mid_multibyte() {
+        // start=1 is inside the first 3-byte char "日"; should snap to 0
+        let r = paginate("日本語", 1, 100);
+        assert!(r.starts_with("日"), "should snap to char boundary");
+    }
+
+    #[test]
+    fn rejects_file_scheme() {
+        assert!(validated_url("file:///etc/passwd").is_err());
     }
 }

--- a/src/net.rs
+++ b/src/net.rs
@@ -157,4 +157,40 @@ mod tests {
         assert!(!is_private_host("1.1.1.1"));
         assert!(!is_private_host("example.com"));
     }
+
+    #[test]
+    fn blocks_zero_address() {
+        assert!(is_private_host("0.0.0.0"));
+    }
+
+    #[test]
+    fn blocks_localhost_case_insensitive() {
+        assert!(is_private_host("LOCALHOST"));
+        assert!(is_private_host("Localhost"));
+    }
+
+    #[test]
+    fn blocks_broadcast() {
+        assert!(is_private_host("255.255.255.255"));
+    }
+
+    #[test]
+    fn blocks_reserved_240() {
+        assert!(is_private_host("240.0.0.1"));
+    }
+
+    #[test]
+    fn blocks_teredo() {
+        assert!(is_private_host("2001::1"));
+    }
+
+    #[test]
+    fn blocks_6to4() {
+        assert!(is_private_host("2002::1"));
+    }
+
+    #[test]
+    fn validate_url_empty_string() {
+        assert!(validate_url("").is_err());
+    }
 }

--- a/src/pdf.rs
+++ b/src/pdf.rs
@@ -1,0 +1,96 @@
+//! PDF detection and retrieval, run before Servo so PDF handling never
+//! blocks concurrent `WebView`s in the engine queue.
+
+use std::time::Duration;
+
+use anyhow::{Context as _, Result};
+
+const MAX_PDF_BYTES: u64 = 50 * 1024 * 1024;
+const HEAD_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Return PDF bytes when the resource is a PDF, `None` otherwise.
+pub(crate) fn probe(url: &str, timeout_secs: u64) -> Option<Vec<u8>> {
+    crate::net::validate_url(url).ok()?;
+    if !looks_like_pdf_url(url) {
+        return None;
+    }
+    let overall = Duration::from_secs(timeout_secs);
+    if !head_is_pdf(url, HEAD_TIMEOUT.min(overall)) {
+        return None;
+    }
+    fetch_bytes(url, overall).ok()
+}
+
+fn looks_like_pdf_url(url: &str) -> bool {
+    let Ok(parsed) = url::Url::parse(url) else {
+        return false;
+    };
+    parsed.path().rsplit('/').next().is_some_and(|last| {
+        last.rsplit_once('.')
+            .is_some_and(|(_, ext)| ext.eq_ignore_ascii_case("pdf"))
+    })
+}
+
+fn head_is_pdf(url: &str, timeout: Duration) -> bool {
+    let Ok(resp) = build_agent(timeout).head(url).call() else {
+        return false;
+    };
+    resp.headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .is_some_and(|ct| ct.to_ascii_lowercase().starts_with("application/pdf"))
+}
+
+fn fetch_bytes(url: &str, timeout: Duration) -> Result<Vec<u8>> {
+    build_agent(timeout)
+        .get(url)
+        .call()
+        .with_context(|| format!("PDF GET failed for {url}"))?
+        .into_body()
+        .with_config()
+        .limit(MAX_PDF_BYTES)
+        .read_to_vec()
+        .context("PDF body read failed")
+}
+
+fn build_agent(timeout: Duration) -> ureq::Agent {
+    ureq::Agent::new_with_config(
+        ureq::config::Config::builder()
+            .max_redirects(0)
+            .timeout_global(Some(timeout))
+            .build(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn url_suffix_detection() {
+        assert!(looks_like_pdf_url("https://example.com/foo.pdf"));
+        assert!(looks_like_pdf_url("https://example.com/FOO.PDF"));
+        assert!(looks_like_pdf_url("https://example.com/a/b/c.pdf?x=1#anchor"));
+        assert!(!looks_like_pdf_url("https://example.com/"));
+        assert!(!looks_like_pdf_url("https://example.com/page.html"));
+        assert!(!looks_like_pdf_url("https://example.com/download?id=123"));
+        assert!(!looks_like_pdf_url("not a url"));
+    }
+
+    #[test]
+    fn probe_skips_non_pdf_urls_without_network() {
+        // No network traffic because suffix check fails first.
+        assert!(probe("https://example.com/page.html", 1).is_none());
+    }
+
+    #[test]
+    fn probe_returns_none_for_unresolvable_host() {
+        // Suffix matches, HEAD fails quickly.
+        assert!(probe("http://invalid.invalid/foo.pdf", 1).is_none());
+    }
+
+    #[test]
+    fn probe_rejects_private_ip_pdf() {
+        assert!(probe("http://127.0.0.1/report.pdf", 1).is_none());
+    }
+}

--- a/src/sanitize.rs
+++ b/src/sanitize.rs
@@ -28,6 +28,20 @@ pub fn sanitize(input: &str) -> Cow<'_, str> {
     Cow::Owned(out)
 }
 
+/// Return the nearest UTF-8 char boundary `<= index`, so `String::truncate`
+/// never panics on a multibyte boundary.
+#[must_use]
+pub fn floor_char_boundary(s: &str, index: usize) -> usize {
+    if index >= s.len() {
+        return s.len();
+    }
+    let mut i = index;
+    while i > 0 && !s.is_char_boundary(i) {
+        i -= 1;
+    }
+    i
+}
+
 fn is_bidi_control(c: char) -> bool {
     matches!(c, '\u{202A}'..='\u{202E}' | '\u{2066}'..='\u{2069}' | '\u{200F}' | '\u{200E}')
 }
@@ -165,5 +179,32 @@ mod tests {
     fn strips_bidi_override_characters() {
         // CVE-2021-42574: BiDi overrides can reorder displayed text.
         assert_eq!(sanitize("a\u{202A}b\u{202E}c\u{2066}d\u{200F}e"), "abcde");
+    }
+
+    #[test]
+    fn floor_char_boundary_ascii() {
+        assert_eq!(floor_char_boundary("hello", 3), 3);
+        assert_eq!(floor_char_boundary("abc", 100), 3);
+    }
+
+    #[test]
+    fn floor_char_boundary_multibyte() {
+        // 3-byte chars: "日本語"
+        assert_eq!(floor_char_boundary("日本語", 0), 0);
+        assert_eq!(floor_char_boundary("日本語", 4), 3);
+        assert_eq!(floor_char_boundary("日本語", 9), 9);
+        // 4-byte char: "🦀"
+        assert_eq!(floor_char_boundary("🦀x", 2), 0);
+        assert_eq!(floor_char_boundary("🦀x", 4), 4);
+    }
+
+    #[test]
+    fn floor_char_boundary_zero() {
+        assert_eq!(floor_char_boundary("hello", 0), 0);
+    }
+
+    #[test]
+    fn sanitize_mixed_ascii_escape_unicode() {
+        assert_eq!(sanitize("hello\x1b[31m世界\x00!"), "hello世界!");
     }
 }

--- a/src/screenshot.rs
+++ b/src/screenshot.rs
@@ -9,7 +9,7 @@ use euclid::{Box2D, Point2D};
 use image::RgbaImage;
 use servo::{DevicePixel, WebView, WebViewRect};
 
-use crate::bridge::{SPIN_INTERVAL, eval_js};
+use crate::bridge::{eval_js, wait_for_wake};
 use servo_fetch::layout;
 
 /// Capture a PNG screenshot of the page, temporarily resizing the viewport
@@ -95,7 +95,7 @@ fn take_screenshot(
             eprintln!("warning: screenshot capture timed out after {timeout_secs}s");
             return None;
         }
-        std::thread::sleep(SPIN_INTERVAL);
+        wait_for_wake(Duration::from_millis(10));
     }
 }
 

--- a/tests/extract.rs
+++ b/tests/extract.rs
@@ -105,3 +105,23 @@ fn selector_no_match_returns_empty() {
     let text = extract::extract_text(&input).unwrap();
     assert!(text.is_empty());
 }
+
+#[test]
+fn extract_json_selector_includes_url() {
+    let html = fixture("article.html");
+    let input = ExtractInput::new(&html, "https://example.com/page").with_selector(Some("article"));
+    let json = extract::extract_json(&input).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&json).expect("valid JSON");
+    assert_eq!(parsed["url"].as_str(), Some("https://example.com/page"));
+}
+
+#[test]
+fn extract_text_with_layout_and_selector() {
+    let html = fixture("article.html");
+    let layout = r#"[{"tag":"NAV","role":null,"w":1280,"h":50,"position":"fixed"}]"#;
+    let input = ExtractInput::new(&html, "https://example.com")
+        .with_layout_json(Some(layout))
+        .with_selector(Some("article"));
+    let text = extract::extract_text(&input).unwrap();
+    assert!(text.contains("Test Article Title"));
+}

--- a/tests/mcp.rs
+++ b/tests/mcp.rs
@@ -27,13 +27,14 @@ async fn initialize_returns_server_info() {
 }
 
 #[tokio::test]
-async fn list_tools_returns_three_tools() {
+async fn list_tools_returns_expected_tools() {
     let client = connect().await;
     let tools = client.list_tools(None).await.unwrap();
 
-    assert_eq!(tools.tools.len(), 3);
+    assert_eq!(tools.tools.len(), 4);
     let names: Vec<&str> = tools.tools.iter().map(|t| t.name.as_ref()).collect();
     assert!(names.contains(&"fetch"));
+    assert!(names.contains(&"batch_fetch"));
     assert!(names.contains(&"screenshot"));
     assert!(names.contains(&"execute_js"));
 }
@@ -104,4 +105,56 @@ async fn execute_js_returns_title() {
         .await
         .unwrap();
     assert!(!result.content.is_empty());
+}
+
+#[tokio::test]
+async fn fetch_rejects_metadata_ip_in_pdf_probe() {
+    let client = connect().await;
+    // AWS metadata endpoint disguised as a PDF URL — must be blocked by validate_url.
+    let result = client
+        .call_tool(call_params(
+            "fetch",
+            &serde_json::json!({"url": "http://169.254.169.254/latest/meta-data/foo.pdf"}),
+        ))
+        .await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn batch_fetch_rejects_empty_urls() {
+    let client = connect().await;
+    let result = client
+        .call_tool(call_params("batch_fetch", &serde_json::json!({"urls": []})))
+        .await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn batch_fetch_rejects_private_ip() {
+    let client = connect().await;
+    let result = client
+        .call_tool(call_params(
+            "batch_fetch",
+            &serde_json::json!({"urls": ["http://127.0.0.1/"]}),
+        ))
+        .await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+#[ignore = "requires Servo + network"]
+async fn batch_fetch_returns_multiple_results() {
+    let client = connect().await;
+    let result = client
+        .call_tool(call_params(
+            "batch_fetch",
+            &serde_json::json!({
+                "urls": ["https://example.com", "https://www.iana.org/help/example-domains"],
+                "max_length": 500,
+                "timeout": 60
+            }),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(result.content.len(), 2, "should return one content entry per URL");
 }

--- a/tests/parallel.rs
+++ b/tests/parallel.rs
@@ -1,0 +1,86 @@
+//! Cross-contamination and concurrent rendering integration tests.
+
+use rmcp::ServiceExt;
+use rmcp::transport::TokioChildProcess;
+
+async fn connect() -> rmcp::service::RunningService<rmcp::RoleClient, impl rmcp::service::Service<rmcp::RoleClient>> {
+    let mut cmd = tokio::process::Command::new(env!("CARGO_BIN_EXE_servo-fetch"));
+    cmd.arg("mcp");
+    let transport = TokioChildProcess::new(cmd).unwrap();
+    ().serve(transport).await.expect("MCP handshake failed")
+}
+
+fn call_params(name: &str, args: &serde_json::Value) -> rmcp::model::CallToolRequestParams {
+    let mut params = rmcp::model::CallToolRequestParams::default();
+    params.name = String::from(name).into();
+    params.arguments = Some(args.as_object().unwrap().clone());
+    params
+}
+
+#[tokio::test]
+#[ignore = "requires Servo + network"]
+async fn parallel_fetches_do_not_cross_contaminate() {
+    // Two public test URLs with distinct, stable content markers.
+    const URLS: &[(&str, &str)] = &[
+        ("https://example.com", "Example Domain"),
+        ("https://example.org", "Example Domain"),
+    ];
+
+    let client = connect().await;
+    let calls = URLS.iter().map(|(url, _)| {
+        client.call_tool(call_params(
+            "fetch",
+            &serde_json::json!({ "url": url, "max_length": 2000, "timeout": 60 }),
+        ))
+    });
+    let results = futures_util::future::join_all(calls).await;
+
+    for ((url, marker), result) in URLS.iter().zip(results) {
+        let r = result.unwrap_or_else(|e| panic!("fetch {url} failed: {e}"));
+        let text = r
+            .content
+            .iter()
+            .filter_map(|c| c.as_text())
+            .map(|t| t.text.as_str())
+            .collect::<String>();
+        assert!(
+            text.contains(marker),
+            "response for {url} missing marker {marker:?}; got: {text}"
+        );
+    }
+}
+
+#[tokio::test]
+#[ignore = "requires Servo + network"]
+async fn concurrent_full_page_screenshots_are_distinct() {
+    // Stress the dedicated `SoftwareRenderingContext`: each PNG must be unique.
+    // All URLs must render visually distinct pages.
+    const URLS: &[&str] = &[
+        "https://example.com",
+        "https://www.iana.org/help/example-domains",
+        "https://httpbin.org/html",
+    ];
+
+    let client = connect().await;
+    let calls = URLS.iter().map(|url| {
+        client.call_tool(call_params(
+            "screenshot",
+            &serde_json::json!({ "url": url, "full_page": true, "timeout": 60 }),
+        ))
+    });
+    let results = futures_util::future::join_all(calls).await;
+
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+    for (url, result) in URLS.iter().zip(results) {
+        let r = result.unwrap_or_else(|e| panic!("screenshot {url} failed: {e}"));
+        let png_b64 = r
+            .content
+            .iter()
+            .find_map(|c| c.as_image().map(|i| i.data.clone()))
+            .unwrap_or_else(|| panic!("no image content for {url}"));
+        assert!(
+            seen.insert(png_b64),
+            "duplicate screenshot for {url}; framebuffer likely leaked across WebViews"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Rewrite the Servo engine bridge to run multiple WebViews concurrently within a single Servo instance. Add batch fetch support to both CLI (multiple positional URLs) and MCP (batch_fetch tool).

## Test Plan

**Platform**: macOS (aarch64-apple-darwin)

### Automated tests (all pass)

```
cargo test --lib --bin servo-fetch --test extract --test mcp  # 149 tests pass
cargo test --test parallel -- --ignored                       # 2 network tests pass
cargo test --test cli -- --ignored                            # 5 network tests pass
```

### Manual verification

| Scenario | Command | Result |
|----------|---------|--------|
| Single fetch (no regression) | `servo-fetch "https://example.com"` | ✓ Markdown output |
| Single JSON | `servo-fetch "https://example.com" --json` | ✓ Valid JSON |
| Single screenshot | `servo-fetch "https://example.com" --screenshot /tmp/s.png` | ✓ 1280x800 PNG |
| JS eval | `servo-fetch "https://example.com" --js "document.title"` | ✓ "Example Domain" |
| PDF extraction | `servo-fetch "https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf"` | ✓ "Dummy PDF file" |
| Batch Markdown | `servo-fetch "https://example.com" "https://httpbin.org/html"` | ✓ Two sections with `--- URL ---` separators |
| Batch NDJSON | `servo-fetch --json "https://example.com" "https://httpbin.org/html"` | ✓ Two compact JSON lines |
| Settle flag | `servo-fetch --settle 500 "https://example.com"` | ✓ Output after extra 500ms wait |
| SSRF block (metadata PDF) | `servo-fetch "http://169.254.169.254/latest/meta-data/foo.pdf"` | ✓ Rejected |
| User-Agent override | `SERVO_FETCH_USER_AGENT="MyBot/1.0" servo-fetch "https://httpbin.org/user-agent" --js "document.body.innerText"` | ✓ Shows "MyBot/1.0" |
| Batch partial failure | `servo-fetch "https://example.com" "http://invalid.invalid"` | ✓ First succeeds, second errors on stderr |
| Screenshot + multiple URLs | `servo-fetch --screenshot x.png "https://a.com" "https://b.com"` | ✓ Error: not supported with multiple URLs |

## Checklist

- [x] `cargo clippy` passes with zero warnings
- [x] `cargo test` passes
- [x] `cargo fmt --check` passes
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it
