### PR TITLE
chore: bump version to 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6388,7 +6388,7 @@ dependencies = [
 
 [[package]]
 name = "servo-fetch"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "servo-fetch"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 description = "A browser engine in a binary. Fetch, render, and extract web content powered by Servo."
 license = "MIT"

--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -541,7 +541,7 @@ fn build_servo(waker: FlagWaker) -> Result<(Rc<SoftwareRenderingContext>, servo:
         user_agent: std::env::var("SERVO_FETCH_USER_AGENT")
             .ok()
             .filter(|s| !s.is_empty())
-            .unwrap_or_else(|| "Mozilla/5.0 (compatible; servo-fetch/0.4)".into()),
+            .unwrap_or_else(|| format!("Mozilla/5.0 (compatible; servo-fetch/{})", env!("CARGO_PKG_VERSION"))),
         ..Preferences::default()
     };
 


### PR DESCRIPTION
## Summary

Bump version to 0.4.0 and derive UA from `CARGO_PKG_VERSION`.

## Checklist

- [x] `cargo clippy` passes with zero warnings
- [x] `cargo test` passes
- [x] `cargo fmt --check` passes
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it
