### PR TITLE
chore: add resource benchmarks and improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,18 @@ servo-fetch URL1 URL2 URL3                               # Parallel batch fetch
 - **Screenshots without GPU** — software renderer captures PNG/full-page screenshots anywhere
 - **Accessibility tree** — AccessKit integration with roles, names, and bounding boxes
 
+## Performance
+
+Parallel fetch — 4 URLs, JS executed, full CSS rendering:
+
+| Tool | Peak Memory | Time |
+| ---- | ----------- | ---- |
+| **servo-fetch** | **114 MB** | **1.5s** |
+| Playwright | 502 MB | 3.3s |
+| Puppeteer | 1065 MB | 4.3s |
+
+Same rendering capabilities, 4–9× less memory, 2–3× faster. [Methodology →](benchmarks/)
+
 ## Install
 
 ```bash
@@ -42,7 +54,9 @@ cargo install servo-fetch    # build from source
 
 ### Platform notes
 
-<details><summary><b>Linux</b> — runtime dependencies and headless setup</summary>
+<details>
+
+<summary><b>Linux</b> — runtime dependencies and headless setup</summary>
 
 The Linux binary dynamically links against system libraries. Install them with:
 
@@ -170,9 +184,9 @@ servo-fetch mcp --port 8080
 
 ### Tools
 
-#### `fetch`
+<details>
 
-Fetch a URL and extract readable content. Navbars, sidebars, and footers are stripped automatically using CSS layout analysis.
+<summary><b>fetch</b> — extract readable content from a URL</summary>
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
@@ -184,9 +198,11 @@ Fetch a URL and extract readable content. Navbars, sidebars, and footers are str
 | `settle_ms` | number? | Extra wait in ms after load event for SPAs (default 0, max 10000) |
 | `selector` | string? | CSS selector to extract a specific section |
 
-#### `batch_fetch`
+</details>
 
-Fetch multiple URLs in parallel. Results are returned as separate content entries in completion order.
+<details>
+
+<summary><b>batch_fetch</b> — fetch multiple URLs in parallel</summary>
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
@@ -197,9 +213,11 @@ Fetch multiple URLs in parallel. Results are returned as separate content entrie
 | `settle_ms` | number? | Extra wait in ms after load event (default 0, max 10000) |
 | `selector` | string? | CSS selector to extract a specific section |
 
-#### `screenshot`
+</details>
 
-Capture a PNG screenshot using Servo's software renderer — no GPU required.
+<details>
+
+<summary><b>screenshot</b> — capture a PNG screenshot (no GPU required)</summary>
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
@@ -208,9 +226,11 @@ Capture a PNG screenshot using Servo's software renderer — no GPU required.
 | `timeout` | number? | Page load timeout in seconds (default 30) |
 | `settle_ms` | number? | Extra wait in ms after load event (default 0, max 10000) |
 
-#### `execute_js`
+</details>
 
-Evaluate a JavaScript expression in a loaded page. Console messages are appended to the result.
+<details>
+
+<summary><b>execute_js</b> — evaluate JavaScript in a loaded page</summary>
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
@@ -218,6 +238,8 @@ Evaluate a JavaScript expression in a loaded page. Console messages are appended
 | `expression` | string | JavaScript expression to evaluate |
 | `timeout` | number? | Page load timeout in seconds (default 30) |
 | `settle_ms` | number? | Extra wait in ms after load event (default 0, max 10000) |
+
+</details>
 
 ## Agent Skills
 

--- a/benchmarks/.gitignore
+++ b/benchmarks/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,72 @@
+# Benchmarks
+
+Resource usage comparison of tools that execute JavaScript and render web pages.
+
+## Results
+
+### Single page (`https://example.com`)
+
+| Tool | Peak RSS | Time |
+| ---- | -------- | ---- |
+| curl (no JS) | 3 MB | 0.17s |
+| **servo-fetch** | **64 MB** | **0.47s** |
+| Playwright | 224 MB | 0.82s |
+| Puppeteer | 590 MB | 1.60s |
+
+### 4 pages parallel
+
+| Tool | Peak RSS | Time |
+| ---- | -------- | ---- |
+| **servo-fetch** | **114 MB** | **1.50s** |
+| Playwright | 502 MB | 3.26s |
+| Puppeteer | 1065 MB | 4.27s |
+
+### Key takeaways
+
+- **vs Playwright**: 3.5× less memory, 1.7–2.2× faster
+- **vs Puppeteer**: 9× less memory, 2.8–3.4× faster
+- **Per additional page**: servo-fetch ~17 MB, Playwright ~93 MB, Puppeteer ~158 MB
+
+## Methodology
+
+### Task
+
+All tools perform the same operation: navigate to a URL, wait for the `load` event (JavaScript executed), and extract `document.body.innerText`. For the parallel test, all URLs are fetched concurrently.
+
+### Memory measurement
+
+Peak RSS (Resident Set Size) of the entire process tree — the target process plus all its descendants. Chromium spawns separate renderer processes per page; all are included.
+
+We sample every 50ms using a recursive `pgrep -P` walk. See [`run_benchmark.sh`](run_benchmark.sh) for the implementation.
+
+On Linux, `smem` (PSS) would be more precise for shared memory. macOS does not expose PSS, so we use RSS. This slightly overcounts shared libraries in Chromium's multi-process architecture, but reflects actual system memory pressure (what the OOM killer sees).
+
+### Procedure
+
+1. **Warmup**: 1 run discarded (DNS cache, disk cache, JIT warmup)
+2. **Measurement**: 3 runs, median reported
+3. **Sampling**: process tree RSS polled every 50ms; peak value recorded
+4. **Timing**: wall-clock via `time.time()` delta
+
+### Test machine
+
+- **Hardware**: Apple M3 Pro, 18 GB RAM
+- **OS**: macOS (arm64)
+
+### Versions
+
+Run `./run_benchmark.sh` to see exact versions. The script auto-detects and prints all tool versions at the top of its output.
+
+## Reproduction
+
+```bash
+# 1. Build servo-fetch
+cargo build --release
+
+# 2. Install comparison tools
+cd benchmarks/playwright && npm install && npx playwright install chromium && cd ..
+cd puppeteer && npm install && cd ..
+
+# 3. Run
+./run_benchmark.sh
+```

--- a/benchmarks/playwright/fetch_parallel.js
+++ b/benchmarks/playwright/fetch_parallel.js
@@ -1,0 +1,19 @@
+// Playwright: load pages in parallel, extract innerText.
+const { chromium } = require("playwright");
+
+(async () => {
+  const urls = process.argv.slice(2);
+  if (!urls.length) process.exit(1);
+
+  const browser = await chromium.launch({ headless: true });
+  await Promise.all(
+    urls.map(async (url) => {
+      const page = await browser.newPage();
+      await page.goto(url, { waitUntil: "load" });
+      const text = await page.evaluate(() => document.body.innerText);
+      console.log(`[${url}] ${text.length} chars`);
+      await page.close();
+    })
+  );
+  await browser.close();
+})();

--- a/benchmarks/playwright/package.json
+++ b/benchmarks/playwright/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "dependencies": {
+    "playwright": "^1"
+  }
+}

--- a/benchmarks/puppeteer/fetch.js
+++ b/benchmarks/puppeteer/fetch.js
@@ -1,0 +1,19 @@
+// Puppeteer: load pages in parallel, extract innerText.
+const puppeteer = require("puppeteer");
+
+(async () => {
+  const urls = process.argv.slice(2);
+  if (!urls.length) process.exit(1);
+
+  const browser = await puppeteer.launch({ headless: true });
+  await Promise.all(
+    urls.map(async (url) => {
+      const page = await browser.newPage();
+      await page.goto(url, { waitUntil: "load" });
+      const text = await page.evaluate(() => document.body.innerText);
+      console.log(`[${url}] ${text.length} chars`);
+      await page.close();
+    })
+  );
+  await browser.close();
+})();

--- a/benchmarks/puppeteer/package.json
+++ b/benchmarks/puppeteer/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "dependencies": {
+    "puppeteer": "^24"
+  }
+}

--- a/benchmarks/run_benchmark.sh
+++ b/benchmarks/run_benchmark.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+# servo-fetch resource benchmark
+# Methodology: Peak RSS of process tree (50ms sampling), median of 3 runs, 1 warmup discarded.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SERVO="$SCRIPT_DIR/../target/release/servo-fetch"
+PW="$SCRIPT_DIR/playwright/fetch_parallel.js"
+PP="$SCRIPT_DIR/puppeteer/fetch.js"
+
+URL_1="https://example.com"
+URLS_4=(
+  "https://example.com"
+  "https://httpbin.org/html"
+  "https://www.iana.org/help/example-domains"
+  "https://info.cern.ch/hypertext/WWW/TheProject.html"
+)
+
+get_tree_rss() {
+  local pid="$1"
+  local total=0
+  local self_rss
+  self_rss=$(ps -o rss= -p "$pid" 2>/dev/null | tr -d ' ' || echo 0)
+  total=$((total + ${self_rss:-0}))
+  local child
+  for child in $(pgrep -P "$pid" 2>/dev/null); do
+    local child_rss
+    child_rss=$(get_tree_rss "$child")
+    total=$((total + child_rss))
+  done
+  echo "$total"
+}
+
+run_once() {
+  local max_rss=0
+  local start
+  start=$(python3 -c "import time; print(time.time())")
+
+  "$@" > /dev/null 2>&1 &
+  local pid=$!
+
+  local rss
+  while kill -0 "$pid" 2>/dev/null; do
+    rss=$(get_tree_rss "$pid")
+    [ "$rss" -gt "$max_rss" ] && max_rss=$rss
+    sleep 0.05
+  done
+  wait "$pid" 2>/dev/null || true
+
+  local end
+  end=$(python3 -c "import time; print(time.time())")
+  local elapsed
+  elapsed=$(python3 -c "print(f'{${end} - ${start}:.2f}')")
+
+  echo "$max_rss $elapsed"
+}
+
+measure() {
+  local label="$1"; shift
+
+  # Warmup
+  run_once "$@" > /dev/null
+
+  # 3 measured runs
+  local rss_vals=()
+  local time_vals=()
+  local _run result rss_val time_val
+  for _run in 1 2 3; do
+    result=$(run_once "$@")
+    rss_val=$(echo "$result" | awk '{print $1}')
+    time_val=$(echo "$result" | awk '{print $2}')
+    rss_vals+=("$rss_val")
+    time_vals+=("$time_val")
+  done
+
+  # Sort and take median (index 2 of 3)
+  local med_rss
+  med_rss=$(printf '%s\n' "${rss_vals[@]}" | sort -n | sed -n '2p')
+  local med_time
+  med_time=$(printf '%s\n' "${time_vals[@]}" | sort -n | sed -n '2p')
+  local rss_mb=$((med_rss / 1024))
+
+  echo "| $label | ${rss_mb} MB | ${med_time}s |"
+}
+
+echo "## servo-fetch Resource Benchmark"
+echo ""
+echo "- **Date**: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+echo "- **Machine**: $(uname -m), $(sysctl -n machdep.cpu.brand_string 2>/dev/null || uname -p)"
+echo "- **OS**: $(sw_vers -productName 2>/dev/null || uname -s) $(sw_vers -productVersion 2>/dev/null || uname -r)"
+echo "- **Method**: Peak RSS of process tree (50ms sampling), median of 3 runs, 1 warmup discarded"
+echo ""
+echo "### Versions"
+echo ""
+echo "- servo-fetch: $($SERVO --version 2>/dev/null || echo 'unknown')"
+echo "- Node.js: $(node --version)"
+echo "- Playwright: $(node -e "console.log(require('${SCRIPT_DIR}/playwright/node_modules/playwright/package.json').version)" 2>/dev/null || echo 'unknown')"
+echo "- Puppeteer: $(node -e "console.log(require('${SCRIPT_DIR}/puppeteer/node_modules/puppeteer/package.json').version)" 2>/dev/null || echo 'unknown')"
+echo ""
+echo "### Single page (\`$URL_1\`)"
+echo ""
+echo "| Tool | Peak RSS | Time |"
+echo "|------|----------|------|"
+measure "curl (no JS)" curl -s "$URL_1"
+measure "servo-fetch" "$SERVO" "$URL_1"
+measure "Playwright" node "$PW" "$URL_1"
+measure "Puppeteer" node "$PP" "$URL_1"
+echo ""
+echo "### 4 pages parallel"
+echo ""
+echo "| Tool | Peak RSS | Time |"
+echo "|------|----------|------|"
+measure "servo-fetch" "$SERVO" "${URLS_4[@]}"
+measure "Playwright" node "$PW" "${URLS_4[@]}"
+measure "Puppeteer" node "$PP" "${URLS_4[@]}"


### PR DESCRIPTION
## Summary

Add resource benchmarks and improve README.

### Results

#### Single page (`https://example.com`)

| Tool | Peak RSS | Time |
| ---- | -------- | ---- |
| curl (no JS) | 3 MB | 0.17s |
| **servo-fetch** | **64 MB** | **0.47s** |
| Playwright | 224 MB | 0.82s |
| Puppeteer | 590 MB | 1.60s |

#### 4 pages parallel

| Tool | Peak RSS | Time |
| ---- | -------- | ---- |
| **servo-fetch** | **114 MB** | **1.50s** |
| Playwright | 502 MB | 3.26s |
| Puppeteer | 1065 MB | 4.27s |

## Checklist

- [x] `cargo clippy` passes with zero warnings
- [x] `cargo test` passes
- [x] `cargo fmt --check` passes
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it
