### PR TITLE
chore: bump version to 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6416,7 +6416,7 @@ dependencies = [
 
 [[package]]
 name = "servo-fetch"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "servo-fetch"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 description = "A browser engine in a binary. Fetch, render, and extract web content powered by Servo."
 license = "MIT"


### PR DESCRIPTION
## Summary

Bump version to 0.5.0.

## Checklist

- [x] `cargo clippy` passes with zero warnings
- [x] `cargo test` passes
- [x] `cargo fmt --check` passes
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it