### PR TITLE
ci: add declarative label sync

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,6 @@
 name: Bug Report
 description: Report a bug in servo-fetch
-labels: [bug]
+labels: ["type: bug", "needs triage"]
 body:
   - type: textarea
     id: summary

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,6 @@
 name: Feature Request
 description: Suggest an idea for servo-fetch
-labels: [enhancement]
+labels: ["type: feature", "needs triage"]
 body:
   - type: textarea
     id: problem

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,61 @@
+# What kind of work? (aligned with Conventional Commits)
+- name: "type: bug"
+  color: d73a4a
+  description: "Something isn't working as documented"
+- name: "type: feature"
+  color: a2eeef
+  description: "New feature or capability (feat:)"
+- name: "type: docs"
+  color: 0075ca
+  description: "Documentation-only change (docs:)"
+- name: "type: refactor"
+  color: c5def5
+  description: "Internal refactor with no user-visible change (refactor:)"
+- name: "type: perf"
+  color: d4c5f9
+  description: "Performance improvement (perf:)"
+- name: "type: deps"
+  color: 0366d6
+  description: "Dependency updates (chore(deps):)"
+- name: "type: ci"
+  color: c2e0c6
+  description: "GitHub Actions, CI pipeline (ci:)"
+- name: "type: build"
+  color: c2e0c6
+  description: "Build system, release packaging (build:)"
+- name: "type: security"
+  color: b60205
+  description: "Security-sensitive change"
+
+# User-facing surface
+- name: "cli"
+  color: 1d76db
+  description: "CLI binary, subcommands, flags, installer"
+- name: "mcp"
+  color: 1d76db
+  description: "MCP server, protocol, tools"
+- name: "skill"
+  color: 1d76db
+  description: "Agent Skills package"
+
+# Status
+- name: "good first issue"
+  color: 7057ff
+  description: "Good for newcomers — well-scoped and approachable"
+- name: "help wanted"
+  color: 008672
+  description: "Extra attention or external contributors welcome"
+- name: "needs triage"
+  color: ededed
+  description: "Awaiting maintainer review and categorization"
+- name: "needs info"
+  color: fbca04
+  description: "Waiting for more information from the reporter"
+
+# Resolution
+- name: "duplicate"
+  color: cfd3d7
+  description: "Duplicate of another issue or PR"
+- name: "wontfix"
+  color: ffffff
+  description: "Will not be worked on — out of scope or rejected"

--- a/.github/scripts/sync-labels.sh
+++ b/.github/scripts/sync-labels.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if (( $# > 1 )); then
+  echo "Error: too many arguments: expected one of --dry-run|--apply|--help" >&2
+  exit 2
+fi
+
+DRY_RUN=
+case "${1:-}" in
+  --dry-run) DRY_RUN=1 ;;
+  --apply) DRY_RUN=0 ;;
+  ""|--help|-h)
+    cat >&2 <<'USAGE'
+Usage: sync-labels.sh <--dry-run|--apply>
+  --dry-run  preview changes without modifying labels
+  --apply    apply changes to the repository (writes to GitHub)
+
+Required env: GH_TOKEN, GH_REPO
+Optional env: LABELS_FILE (default: .github/labels.yml)
+USAGE
+    exit 2 ;;
+  *)
+    echo "Error: unknown argument: $1 (run --help for usage)" >&2
+    exit 2 ;;
+esac
+
+: "${GH_TOKEN:?GH_TOKEN must be set}"
+: "${GH_REPO:?GH_REPO must be set (owner/repo)}"
+
+readonly LABELS_FILE="${LABELS_FILE:-.github/labels.yml}"
+readonly MAX_LABELS=100 MAX_NAME_LEN=50 MAX_DESC_LEN=100
+
+command -v gh >/dev/null || { echo "Error: gh CLI not found" >&2; exit 1; }
+command -v yq >/dev/null || { echo "Error: yq not found" >&2; exit 1; }
+[[ -r "$LABELS_FILE" ]] || { echo "Error: cannot read ${LABELS_FILE}" >&2; exit 1; }
+
+kind=$(yq 'type' "$LABELS_FILE")
+if [[ "$kind" != "!!seq" ]]; then
+  echo "Error: ${LABELS_FILE} must be a YAML sequence (got ${kind})" >&2
+  exit 1
+fi
+
+total=$(yq 'length' "$LABELS_FILE")
+if ! [[ "$total" =~ ^[0-9]+$ ]] || (( total == 0 )); then
+  echo "Error: ${LABELS_FILE} is empty or malformed" >&2
+  exit 1
+fi
+if (( total > MAX_LABELS )); then
+  echo "Error: ${LABELS_FILE} declares ${total} labels (limit ${MAX_LABELS})" >&2
+  exit 1
+fi
+
+declare -A existing=()
+while IFS= read -r n; do
+  [[ -n "$n" ]] && existing["$n"]=1
+done < <(gh label list --limit 200 --json name --jq '.[].name')
+
+declare -A seen=()
+summary_file="${GITHUB_STEP_SUMMARY:-/dev/null}"
+{
+  echo "# Label sync report"
+  echo ""
+  echo "| Action | Label | Color |"
+  echo "| --- | --- | --- |"
+} >> "$summary_file"
+
+created=0 updated=0 skipped=0 index=-1
+
+while IFS=$'\t' read -r name color desc; do
+  index=$((index + 1))
+
+  if [[ -z "$name" || "$name" == "null" || "$name" == "~" ]]; then
+    echo "Error: label[${index}] has empty or null name" >&2
+    exit 1
+  fi
+  if (( ${#name} > MAX_NAME_LEN )); then
+    echo "Error: label name too long: '${name}' (${#name} chars, max ${MAX_NAME_LEN})" >&2
+    exit 1
+  fi
+  if [[ "$name" =~ [[:cntrl:]] ]]; then
+    echo "Error: label[${index}] name contains control characters" >&2
+    exit 1
+  fi
+  if (( ${#desc} > MAX_DESC_LEN )); then
+    echo "Error: label '${name}' description too long (${#desc} chars, max ${MAX_DESC_LEN})" >&2
+    exit 1
+  fi
+  if ! [[ "$color" =~ ^[0-9a-fA-F]{6}$ ]]; then
+    echo "Error: label '${name}' has invalid color '${color}'" >&2
+    exit 1
+  fi
+  if [[ -n "${seen[$name]:-}" ]]; then
+    echo "Error: duplicate label name in ${LABELS_FILE}: '${name}'" >&2
+    exit 1
+  fi
+  seen["$name"]=1
+
+  if [[ -n "${existing[$name]:-}" ]]; then
+    action="edit"
+  else
+    action="create"
+  fi
+
+  echo "[${action}] ${name} (#${color})"
+  echo "| ${action} | \`${name}\` | \`#${color}\` |" >> "$summary_file"
+
+  if (( DRY_RUN == 1 )); then
+    skipped=$((skipped + 1))
+    continue
+  fi
+
+  case "$action" in
+    create)
+      gh label create "$name" --color "$color" --description "$desc"
+      created=$((created + 1))
+      ;;
+    edit)
+      gh label edit "$name" --color "$color" --description "$desc"
+      updated=$((updated + 1))
+      ;;
+  esac
+done < <(yq -r '.[] | [.name, .color, (.description // "")] | @tsv' "$LABELS_FILE")
+
+{
+  echo ""
+  echo "**Totals:** created=${created}, updated=${updated}, skipped(dry-run)=${skipped}, declared=${total}"
+} >> "$summary_file"
+
+echo "Done: created=${created}, updated=${updated}, skipped=${skipped}, declared=${total}"

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -1,0 +1,44 @@
+name: Sync Labels
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/labels.yml'
+      - '.github/scripts/sync-labels.sh'
+      - '.github/workflows/sync-labels.yml'
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: "Preview changes without applying"
+        type: boolean
+        default: false
+
+permissions: {}
+
+concurrency:
+  group: sync-labels
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    name: Sync labels
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      issues: write # required by `gh label create/edit`
+    env:
+      GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}
+      MODE: ${{ inputs.dry-run && '--dry-run' || '--apply' }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          sparse-checkout: |
+            .github/labels.yml
+            .github/scripts/sync-labels.sh
+          sparse-checkout-cone-mode: false
+
+      - name: Sync labels
+        run: ./.github/scripts/sync-labels.sh "$MODE"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,18 @@ AI tools (e.g. Claude Code, Kiro) can be useful for generating code. However, yo
 - **Write PR descriptions and replies yourself.** Describe the change and reply to review comments in your own words. Do not paste AI output as a reply to maintainers. We may hide comments we believe are AI-generated.
 - **Disclose AI context when you quote it.** If you paste output from an AI tool into an issue or PR, put it in a `>` quote block and add your own commentary explaining why it is relevant.
 
+## Issue labels
+
+We use two label axes plus status:
+
+- **`type: *`** — what kind of work, aligned with [Conventional Commits](https://www.conventionalcommits.org/): `type: bug`, `type: feature`, `type: docs`, `type: refactor`, `type: perf`, `type: deps`, `type: ci`, `type: build`, `type: security`
+- **surface** — which user-facing interface: `cli`, `mcp`, `skill`
+- **status** — workflow state: `good first issue`, `help wanted`, `needs triage`, `needs info`
+
+Start with [`good first issue`](https://github.com/konippi/servo-fetch/labels/good%20first%20issue) if you are new to the project.
+
+Labels are declared in [`.github/labels.yml`](./.github/labels.yml) and synced by the `Sync Labels` workflow. To propose a new label, open a PR editing that file.
+
 ## Reporting bugs
 
 Please use the [bug report template](https://github.com/konippi/servo-fetch/issues/new?template=bug_report.yml) and include:


### PR DESCRIPTION
## Summary

Introduce `.github/labels.yml` as the source of truth for repository labels, synced to GitHub by a new workflow that calls the `gh` CLI directly — no third-party actions, `issues: write` scoped to a single job.

## Test Plan

Static analysis (all green):

- `actionlint`
- `shellcheck`
- `zizmor` (regular, pedantic, auditor personas)

## Checklist

- [x] `cargo clippy` passes with zero warnings _(N/A — no Rust code changed)_
- [x] `cargo test` passes _(N/A — no Rust code changed)_
- [x] `cargo fmt --check` passes _(N/A — no Rust code changed)_
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it