### PR TITLE
Refactor/tracing observability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3961,6 +3961,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata 0.4.14",
+]
+
+[[package]]
 name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4287,6 +4296,15 @@ name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "num-bigint"
@@ -6443,6 +6461,8 @@ dependencies = [
  "servo",
  "thiserror 2.0.18",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
  "ureq",
  "url",
 ]
@@ -7529,6 +7549,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8129,6 +8158,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "tikv-jemalloc-sys"
 version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8395,6 +8433,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata 0.4.14",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -8738,6 +8806,12 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,8 @@ ureq = "3"
 globset = "0.4"
 psl = "2"
 rustls = { version = "0.23", default-features = false, features = ["aws-lc-rs"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "tracing-log"] }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/README.md
+++ b/README.md
@@ -148,6 +148,8 @@ servo-fetch crawl "https://docs.example.com" --include "/docs/**" --exclude "/do
 | `--raw <MODE>` | Output raw `html` or plain `text` (single URL only) |
 | `-t`, `--timeout <SECS>` | Page load timeout (default: 30) |
 | `--settle <MS>` | Extra wait after load event for SPAs (default: 0, max: 10000) |
+| `-v`, `--verbose` | Increase log verbosity (`-v` info, `-vv` debug, `-vvv` trace) |
+| `-q`, `--quiet` | Suppress all logs except errors |
 | `--help` | Show help |
 | `--version` | Show version |
 
@@ -298,6 +300,22 @@ npx skills add https://github.com/konippi/servo-fetch/tree/main/skills/servo-fet
 ## Security
 
 servo-fetch blocks all private and reserved IP ranges ([RFC 6890](https://datatracker.ietf.org/doc/html/rfc6890)), strips credentials from URLs, disables HTTP redirects to prevent SSRF bypass, and sanitizes all output against terminal escape injection ([CVE-2021-42574](https://www.cve.org/CVERecord?id=CVE-2021-42574)). See [SECURITY.md](./SECURITY.md) for details.
+
+## Logging
+
+Diagnostic messages go to stderr; stdout is reserved for the requested output (Markdown, JSON, PNG bytes) so pipes stay clean. The MCP stdio transport requires this.
+
+Control verbosity with flags or the `RUST_LOG` environment variable:
+
+```bash
+servo-fetch -v "https://example.com"                       # info and above
+servo-fetch -vv "https://example.com"                      # debug
+servo-fetch -q "https://example.com"                       # errors only
+RUST_LOG="servo_fetch=debug" servo-fetch "https://..."     # fine-grained override
+RUST_LOG="servo_fetch=trace,servo=debug" servo-fetch "..." # include Servo internals
+```
+
+`RUST_LOG` uses [`tracing-subscriber`'s directive syntax](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html) and always wins over CLI flags.
 
 ## Limitations
 

--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -180,7 +180,7 @@ impl WebViewDelegate for SharedDelegate {
         match navigation_request.url.host_str() {
             Some(host) if is_http && !crate::net::is_private_host(host) => navigation_request.allow(),
             _ => {
-                eprintln!("warning: blocked navigation to {}", navigation_request.url);
+                tracing::warn!(url = %navigation_request.url, "blocked navigation");
                 navigation_request.deny();
             }
         }
@@ -193,7 +193,7 @@ impl WebViewDelegate for SharedDelegate {
                 if nodes.len() >= MAX_A11Y_NODES && !nodes.contains_key(&id) {
                     if !state.a11y_truncated.get() {
                         state.a11y_truncated.set(true);
-                        eprintln!("warning: accessibility tree truncated at {MAX_A11Y_NODES} nodes");
+                        tracing::warn!(limit = MAX_A11Y_NODES, "accessibility tree truncated");
                     }
                     continue;
                 }
@@ -571,7 +571,7 @@ fn wait_for_ready_state(servo: &servo::Servo, webview: &WebView, deadline: Insta
         }
         wait_for_wake(FALLBACK_WAIT);
     }
-    eprintln!("warning: document did not finish loading; content may be incomplete");
+    tracing::warn!("document did not finish loading; content may be incomplete");
 }
 
 pub(crate) fn eval_js(servo: &servo::Servo, webview: &WebView, script: &str) -> Result<String> {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -58,6 +58,14 @@ pub(crate) struct Cli {
     /// Output raw HTML or plain text instead of Readability extraction
     #[arg(long, value_name = "MODE", value_enum, conflicts_with_all = ["json", "screenshot", "js", "selector"])]
     pub raw: Option<RawMode>,
+
+    /// Increase log verbosity (`-v` info, `-vv` debug, `-vvv` trace, `-vvvv` trace all crates)
+    #[arg(short = 'v', long, action = clap::ArgAction::Count, global = true, conflicts_with = "quiet")]
+    pub verbose: u8,
+
+    /// Suppress all logs except errors
+    #[arg(short = 'q', long, global = true)]
+    pub quiet: bool,
 }
 
 /// Raw output mode.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -59,7 +59,7 @@ pub(crate) struct Cli {
     #[arg(long, value_name = "MODE", value_enum, conflicts_with_all = ["json", "screenshot", "js", "selector"])]
     pub raw: Option<RawMode>,
 
-    /// Increase log verbosity (`-v` info, `-vv` debug, `-vvv` trace, `-vvvv` trace all crates)
+    /// Increase log verbosity (`-v` info, `-vv` debug, `-vvv` trace)
     #[arg(short = 'v', long, action = clap::ArgAction::Count, global = true, conflicts_with = "quiet")]
     pub verbose: u8,
 

--- a/src/command.rs
+++ b/src/command.rs
@@ -56,7 +56,7 @@ impl Screenshot<'_> {
             Some(ref img) => {
                 img.save(self.path)
                     .with_context(|| format!("failed to save screenshot to {}", self.path))?;
-                eprintln!("screenshot saved to {}", self.path);
+                tracing::info!(path = %self.path, "screenshot saved");
                 Ok(())
             }
             None => bail!("failed to capture screenshot — the page may not have rendered correctly"),

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -52,7 +52,7 @@ pub fn extract_pdf(data: &[u8]) -> String {
     match pdf_extract::extract_text_from_mem(data) {
         Ok(text) => text,
         Err(e) => {
-            eprintln!("warning: PDF text extraction failed: {e}");
+            tracing::warn!("PDF text extraction failed: {e}");
             String::new()
         }
     }
@@ -205,10 +205,7 @@ fn parse_article(html: &str, url: &str, layout_json: Option<&str>, inner_text: O
     let title = doc.select("title").text().to_string();
     let body_text = inner_text.filter(|s| !s.trim().is_empty()).map_or_else(
         || {
-            eprintln!(
-                "warning: could not extract content. \
-                 Try --js \"document.body.innerText\" for JS-heavy sites."
-            );
+            tracing::warn!(r#"could not extract content; try --js "document.body.innerText" for JS-heavy sites"#);
             String::new()
         },
         String::from,

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -52,7 +52,7 @@ pub fn extract_pdf(data: &[u8]) -> String {
     match pdf_extract::extract_text_from_mem(data) {
         Ok(text) => text,
         Err(e) => {
-            tracing::warn!("PDF text extraction failed: {e}");
+            tracing::warn!(error = %e, "PDF text extraction failed");
             String::new()
         }
     }

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,40 +1,23 @@
-//! Logging initialization for servo-fetch.
-//!
-//! Logs are always written to **stderr** so the MCP stdio transport can own
-//! stdout for JSON-RPC messages (the MCP specification mandates this). The
-//! filter is assembled from, in order of precedence: `RUST_LOG` if set, the
-//! CLI `-v`/`-q` flags, or a conservative default.
+//! Logging initialization.
 
 use std::io::IsTerminal as _;
 
-use tracing::level_filters::LevelFilter;
 use tracing_subscriber::EnvFilter;
 use tracing_subscriber::fmt::time::Uptime;
 
-/// Verbosity resolved from CLI flags.
-///
-/// Unlike a raw count this is an exhaustive enum so match arms can be
-/// verified at compile time and the `RUST_LOG` override story stays
-/// explicit.
+/// Verbosity resolved from `-v` count and `-q` flag.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum Verbosity {
-    /// `-q`/`--quiet`: only errors are shown.
     Quiet,
-    /// Default: warnings and errors from `servo_fetch`.
     #[default]
     Default,
-    /// `-v`: info and above from `servo_fetch`.
     Info,
-    /// `-vv`: debug and above from `servo_fetch`.
     Debug,
-    /// `-vvv`: trace and above from `servo_fetch`.
     Trace,
-    /// `-vvvv`: trace and above from every crate (Servo internals included).
     TraceAll,
 }
 
 impl Verbosity {
-    /// Resolve from `clap`'s `-v` count and `-q` flag.
     pub(crate) fn from_flags(verbose: u8, quiet: bool) -> Self {
         if quiet {
             return Self::Quiet;
@@ -48,8 +31,7 @@ impl Verbosity {
         }
     }
 
-    /// Default filter applied when `RUST_LOG` is unset.
-    fn default_filter(self) -> &'static str {
+    fn default_directive(self) -> &'static str {
         match self {
             Self::Quiet => "servo_fetch=error",
             Self::Default => "servo_fetch=warn",
@@ -60,51 +42,29 @@ impl Verbosity {
         }
     }
 
-    /// Whether to include a relative timestamp and target with each log line.
     fn detailed(self) -> bool {
         matches!(self, Self::Debug | Self::Trace | Self::TraceAll)
     }
 }
 
-/// Install a global `tracing` subscriber.
-///
-/// Must be called exactly once, early in `main`. Further calls are no-ops
-/// because we rely on `tracing`'s first-installer-wins semantics.
-///
-/// # Panics
-/// Never. An invalid `RUST_LOG` directive is reported to stderr and the
-/// resolved default filter is used instead, matching how `cargo` and `uv`
-/// behave.
+/// Install the global `tracing` subscriber.
 pub(crate) fn init(verbosity: Verbosity) {
     let filter = EnvFilter::builder()
-        .with_default_directive(LevelFilter::WARN.into())
-        .parse(verbosity.default_filter())
-        .expect("default_filter is a valid EnvFilter directive");
+        .with_default_directive(
+            verbosity
+                .default_directive()
+                .parse()
+                .expect("hardcoded directive is valid"),
+        )
+        .from_env_lossy();
 
-    // `RUST_LOG` takes priority over the CLI-derived default so operators can
-    // always override without recompiling or remembering our flag taxonomy.
-    let filter = match std::env::var("RUST_LOG") {
-        Ok(raw) if !raw.is_empty() => match EnvFilter::builder().parse(&raw) {
-            Ok(from_env) => from_env,
-            Err(err) => {
-                eprintln!("warning: invalid RUST_LOG={raw:?}: {err}; falling back to CLI defaults");
-                filter
-            }
-        },
-        _ => filter,
-    };
-
-    let ansi = std::io::stderr().is_terminal();
+    let ansi = std::io::stderr().is_terminal() && std::env::var_os("NO_COLOR").is_none();
     let builder = tracing_subscriber::fmt()
         .with_env_filter(filter)
         .with_writer(std::io::stderr)
         .with_ansi(ansi)
-        .with_level(true)
         .with_target(verbosity.detailed());
 
-    // `try_init` converts "already installed" into a silent no-op, which is
-    // the right default for library/test contexts that may set up their own
-    // subscriber first.
     if verbosity.detailed() {
         let _ = builder.with_timer(Uptime::default()).try_init();
     } else {
@@ -128,25 +88,40 @@ mod tests {
         assert_eq!(Verbosity::from_flags(2, false), Verbosity::Debug);
         assert_eq!(Verbosity::from_flags(3, false), Verbosity::Trace);
         assert_eq!(Verbosity::from_flags(4, false), Verbosity::TraceAll);
-        assert_eq!(Verbosity::from_flags(42, false), Verbosity::TraceAll);
+        assert_eq!(Verbosity::from_flags(u8::MAX, false), Verbosity::TraceAll);
     }
 
     #[test]
-    fn default_filter_is_warn() {
-        assert!(Verbosity::Default.default_filter().contains("warn"));
+    fn default_directive_is_warn() {
+        assert_eq!(Verbosity::Default.default_directive(), "servo_fetch=warn");
     }
 
     #[test]
     fn trace_all_opts_into_global_trace() {
-        assert_eq!(Verbosity::TraceAll.default_filter(), "trace");
+        assert_eq!(Verbosity::TraceAll.default_directive(), "trace");
     }
 
     #[test]
     fn detailed_only_for_debug_and_above() {
+        assert!(!Verbosity::Quiet.detailed());
         assert!(!Verbosity::Default.detailed());
         assert!(!Verbosity::Info.detailed());
         assert!(Verbosity::Debug.detailed());
         assert!(Verbosity::Trace.detailed());
         assert!(Verbosity::TraceAll.detailed());
+    }
+
+    #[test]
+    fn all_directives_parse() {
+        for v in [
+            Verbosity::Quiet,
+            Verbosity::Default,
+            Verbosity::Info,
+            Verbosity::Debug,
+            Verbosity::Trace,
+            Verbosity::TraceAll,
+        ] {
+            let _: tracing_subscriber::filter::Directive = v.default_directive().parse().unwrap();
+        }
     }
 }

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -58,7 +58,7 @@ pub(crate) fn init(verbosity: Verbosity) {
         )
         .from_env_lossy();
 
-    let ansi = std::io::stderr().is_terminal() && std::env::var_os("NO_COLOR").is_none();
+    let ansi = std::io::stderr().is_terminal() && std::env::var_os("NO_COLOR").is_none_or(|v| v.is_empty());
     let builder = tracing_subscriber::fmt()
         .with_env_filter(filter)
         .with_writer(std::io::stderr)

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -14,7 +14,6 @@ pub(crate) enum Verbosity {
     Info,
     Debug,
     Trace,
-    TraceAll,
 }
 
 impl Verbosity {
@@ -26,8 +25,7 @@ impl Verbosity {
             0 => Self::Default,
             1 => Self::Info,
             2 => Self::Debug,
-            3 => Self::Trace,
-            _ => Self::TraceAll,
+            _ => Self::Trace,
         }
     }
 
@@ -38,12 +36,11 @@ impl Verbosity {
             Self::Info => "servo_fetch=info",
             Self::Debug => "servo_fetch=debug",
             Self::Trace => "servo_fetch=trace",
-            Self::TraceAll => "trace",
         }
     }
 
     fn detailed(self) -> bool {
-        matches!(self, Self::Debug | Self::Trace | Self::TraceAll)
+        matches!(self, Self::Debug | Self::Trace)
     }
 }
 
@@ -87,8 +84,7 @@ mod tests {
         assert_eq!(Verbosity::from_flags(1, false), Verbosity::Info);
         assert_eq!(Verbosity::from_flags(2, false), Verbosity::Debug);
         assert_eq!(Verbosity::from_flags(3, false), Verbosity::Trace);
-        assert_eq!(Verbosity::from_flags(4, false), Verbosity::TraceAll);
-        assert_eq!(Verbosity::from_flags(u8::MAX, false), Verbosity::TraceAll);
+        assert_eq!(Verbosity::from_flags(u8::MAX, false), Verbosity::Trace);
     }
 
     #[test]
@@ -97,8 +93,8 @@ mod tests {
     }
 
     #[test]
-    fn trace_all_opts_into_global_trace() {
-        assert_eq!(Verbosity::TraceAll.default_directive(), "trace");
+    fn trace_stays_scoped_to_own_crate() {
+        assert_eq!(Verbosity::Trace.default_directive(), "servo_fetch=trace");
     }
 
     #[test]
@@ -108,7 +104,6 @@ mod tests {
         assert!(!Verbosity::Info.detailed());
         assert!(Verbosity::Debug.detailed());
         assert!(Verbosity::Trace.detailed());
-        assert!(Verbosity::TraceAll.detailed());
     }
 
     #[test]
@@ -119,7 +114,6 @@ mod tests {
             Verbosity::Info,
             Verbosity::Debug,
             Verbosity::Trace,
-            Verbosity::TraceAll,
         ] {
             let _: tracing_subscriber::filter::Directive = v.default_directive().parse().unwrap();
         }

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,0 +1,152 @@
+//! Logging initialization for servo-fetch.
+//!
+//! Logs are always written to **stderr** so the MCP stdio transport can own
+//! stdout for JSON-RPC messages (the MCP specification mandates this). The
+//! filter is assembled from, in order of precedence: `RUST_LOG` if set, the
+//! CLI `-v`/`-q` flags, or a conservative default.
+
+use std::io::IsTerminal as _;
+
+use tracing::level_filters::LevelFilter;
+use tracing_subscriber::EnvFilter;
+use tracing_subscriber::fmt::time::Uptime;
+
+/// Verbosity resolved from CLI flags.
+///
+/// Unlike a raw count this is an exhaustive enum so match arms can be
+/// verified at compile time and the `RUST_LOG` override story stays
+/// explicit.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Verbosity {
+    /// `-q`/`--quiet`: only errors are shown.
+    Quiet,
+    /// Default: warnings and errors from `servo_fetch`.
+    #[default]
+    Default,
+    /// `-v`: info and above from `servo_fetch`.
+    Info,
+    /// `-vv`: debug and above from `servo_fetch`.
+    Debug,
+    /// `-vvv`: trace and above from `servo_fetch`.
+    Trace,
+    /// `-vvvv`: trace and above from every crate (Servo internals included).
+    TraceAll,
+}
+
+impl Verbosity {
+    /// Resolve from `clap`'s `-v` count and `-q` flag.
+    pub(crate) fn from_flags(verbose: u8, quiet: bool) -> Self {
+        if quiet {
+            return Self::Quiet;
+        }
+        match verbose {
+            0 => Self::Default,
+            1 => Self::Info,
+            2 => Self::Debug,
+            3 => Self::Trace,
+            _ => Self::TraceAll,
+        }
+    }
+
+    /// Default filter applied when `RUST_LOG` is unset.
+    fn default_filter(self) -> &'static str {
+        match self {
+            Self::Quiet => "servo_fetch=error",
+            Self::Default => "servo_fetch=warn",
+            Self::Info => "servo_fetch=info",
+            Self::Debug => "servo_fetch=debug",
+            Self::Trace => "servo_fetch=trace",
+            Self::TraceAll => "trace",
+        }
+    }
+
+    /// Whether to include a relative timestamp and target with each log line.
+    fn detailed(self) -> bool {
+        matches!(self, Self::Debug | Self::Trace | Self::TraceAll)
+    }
+}
+
+/// Install a global `tracing` subscriber.
+///
+/// Must be called exactly once, early in `main`. Further calls are no-ops
+/// because we rely on `tracing`'s first-installer-wins semantics.
+///
+/// # Panics
+/// Never. An invalid `RUST_LOG` directive is reported to stderr and the
+/// resolved default filter is used instead, matching how `cargo` and `uv`
+/// behave.
+pub(crate) fn init(verbosity: Verbosity) {
+    let filter = EnvFilter::builder()
+        .with_default_directive(LevelFilter::WARN.into())
+        .parse(verbosity.default_filter())
+        .expect("default_filter is a valid EnvFilter directive");
+
+    // `RUST_LOG` takes priority over the CLI-derived default so operators can
+    // always override without recompiling or remembering our flag taxonomy.
+    let filter = match std::env::var("RUST_LOG") {
+        Ok(raw) if !raw.is_empty() => match EnvFilter::builder().parse(&raw) {
+            Ok(from_env) => from_env,
+            Err(err) => {
+                eprintln!("warning: invalid RUST_LOG={raw:?}: {err}; falling back to CLI defaults");
+                filter
+            }
+        },
+        _ => filter,
+    };
+
+    let ansi = std::io::stderr().is_terminal();
+    let builder = tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .with_writer(std::io::stderr)
+        .with_ansi(ansi)
+        .with_level(true)
+        .with_target(verbosity.detailed());
+
+    // `try_init` converts "already installed" into a silent no-op, which is
+    // the right default for library/test contexts that may set up their own
+    // subscriber first.
+    if verbosity.detailed() {
+        let _ = builder.with_timer(Uptime::default()).try_init();
+    } else {
+        let _ = builder.without_time().try_init();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn quiet_wins_over_verbose() {
+        assert_eq!(Verbosity::from_flags(3, true), Verbosity::Quiet);
+    }
+
+    #[test]
+    fn verbose_escalates() {
+        assert_eq!(Verbosity::from_flags(0, false), Verbosity::Default);
+        assert_eq!(Verbosity::from_flags(1, false), Verbosity::Info);
+        assert_eq!(Verbosity::from_flags(2, false), Verbosity::Debug);
+        assert_eq!(Verbosity::from_flags(3, false), Verbosity::Trace);
+        assert_eq!(Verbosity::from_flags(4, false), Verbosity::TraceAll);
+        assert_eq!(Verbosity::from_flags(42, false), Verbosity::TraceAll);
+    }
+
+    #[test]
+    fn default_filter_is_warn() {
+        assert!(Verbosity::Default.default_filter().contains("warn"));
+    }
+
+    #[test]
+    fn trace_all_opts_into_global_trace() {
+        assert_eq!(Verbosity::TraceAll.default_filter(), "trace");
+    }
+
+    #[test]
+    fn detailed_only_for_debug_and_above() {
+        assert!(!Verbosity::Default.detailed());
+        assert!(!Verbosity::Info.detailed());
+        assert!(Verbosity::Debug.detailed());
+        assert!(Verbosity::Trace.detailed());
+        assert!(Verbosity::TraceAll.detailed());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod bridge;
 mod cli;
 mod command;
 mod crawl;
+mod logging;
 mod mcp;
 mod net;
 mod pdf;
@@ -27,6 +28,7 @@ fn main() {
         .expect("Failed to install rustls crypto provider");
 
     let args = cli::Cli::parse();
+    logging::init(logging::Verbosity::from_flags(args.verbose, args.quiet));
 
     let code = match args.command {
         Some(cli::Command::Mcp { port }) => run_mcp(port),
@@ -61,7 +63,7 @@ fn run_mcp(port: Option<u16>) -> i32 {
     match rt.block_on(mcp::run(port)) {
         Ok(()) => 0,
         Err(e) => {
-            eprintln!("error: {e:#}");
+            tracing::error!("{e:#}");
             1
         }
     }
@@ -72,7 +74,7 @@ fn exit_code(result: anyhow::Result<()>) -> i32 {
         Ok(()) => 0,
         Err(err) if is_broken_pipe(&err) => 0,
         Err(err) => {
-            eprintln!("error: {err:#}");
+            tracing::error!("{err:#}");
             1
         }
     }
@@ -128,7 +130,10 @@ fn run_crawl(
                 crawl::CrawlStatus::Ok => "✓",
                 crawl::CrawlStatus::Error => "✗",
             };
-            eprintln!("[{completed}] {} {status}", result.url);
+            // Progress UI: stays on stderr as raw text, not a tracing event.
+            // `tracing` is for diagnostics (with level/target prefixes); interactive
+            // progress belongs to the UI layer and must remain prefix-free.
+            let _ = writeln!(std::io::stderr(), "[{completed}] {} {status}", result.url);
         }
     }));
 
@@ -186,7 +191,8 @@ async fn run_batch(args: &cli::Cli) -> anyhow::Result<()> {
     let is_tty = std::io::stderr().is_terminal();
     let total = urls.len();
     if is_tty {
-        eprintln!("Fetching {total} URLs...");
+        // Progress UI, not a diagnostic event.
+        let _ = writeln!(std::io::stderr(), "Fetching {total} URLs...");
     }
 
     let sem = Arc::new(Semaphore::new(4));
@@ -244,12 +250,12 @@ async fn run_batch(args: &cli::Cli) -> anyhow::Result<()> {
                     writeln!(std::io::stdout())?;
                 }
                 if is_tty {
-                    eprintln!("[{completed}/{total}] {url} ✓");
+                    let _ = writeln!(std::io::stderr(), "[{completed}/{total}] {url} ✓");
                 }
             }
             Err(e) => {
                 failures += 1;
-                eprintln!("error: {url}: {e:#}");
+                tracing::error!(url = %url, "{e:#}");
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -130,9 +130,7 @@ fn run_crawl(
                 crawl::CrawlStatus::Ok => "✓",
                 crawl::CrawlStatus::Error => "✗",
             };
-            // Progress UI: stays on stderr as raw text, not a tracing event.
-            // `tracing` is for diagnostics (with level/target prefixes); interactive
-            // progress belongs to the UI layer and must remain prefix-free.
+            // Progress UI: raw stderr, not a tracing event (prefix-free).
             let _ = writeln!(std::io::stderr(), "[{completed}] {} {status}", result.url);
         }
     }));

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -40,7 +40,7 @@ async fn run_http(port: u16) -> anyhow::Result<()> {
     let router = axum::Router::new().nest_service("/mcp", service);
     let addr = std::net::SocketAddr::from(([127, 0, 0, 1], port));
     let listener = tokio::net::TcpListener::bind(addr).await?;
-    eprintln!("MCP server listening on http://{addr}/mcp");
+    tracing::info!(%addr, "MCP server listening");
 
     axum::serve(listener, router)
         .with_graceful_shutdown(async {

--- a/src/net.rs
+++ b/src/net.rs
@@ -84,7 +84,7 @@ pub(crate) fn validate_url(input: &str) -> anyhow::Result<url::Url> {
         s => bail!("scheme '{s}' not allowed; only http:// and https:// are supported"),
     }
     if !parsed.username().is_empty() || parsed.password().is_some() {
-        eprintln!("warning: credentials stripped from URL");
+        tracing::warn!("credentials stripped from URL");
         let _ = parsed.set_username("");
         let _ = parsed.set_password(None);
     }

--- a/src/screenshot.rs
+++ b/src/screenshot.rs
@@ -91,7 +91,7 @@ fn take_screenshot(
         servo.spin_event_loop();
         if let Some(outcome) = result.borrow_mut().take() {
             return outcome
-                .inspect_err(|e| tracing::warn!("screenshot capture failed: {e:?}"))
+                .inspect_err(|e| tracing::warn!(error = ?e, "screenshot capture failed"))
                 .ok();
         }
         if Instant::now() > deadline {

--- a/src/screenshot.rs
+++ b/src/screenshot.rs
@@ -31,7 +31,7 @@ pub(crate) fn capture(
     }
 
     let Some(measured) = measure_full_page(servo, webview) else {
-        eprintln!("warning: failed to measure full page size; falling back to viewport screenshot");
+        tracing::warn!("failed to measure full page size; falling back to viewport screenshot");
         return take_screenshot(servo, webview, None, timeout_secs);
     };
 
@@ -41,9 +41,12 @@ pub(crate) fn capture(
     };
 
     if resized != measured {
-        eprintln!(
-            "warning: full-page dimensions clamped to {}x{} (content was {}x{})",
-            resized.width, resized.height, measured.width, measured.height
+        tracing::warn!(
+            clamped_w = resized.width,
+            clamped_h = resized.height,
+            measured_w = measured.width,
+            measured_h = measured.height,
+            "full-page dimensions clamped",
         );
     }
 
@@ -88,11 +91,11 @@ fn take_screenshot(
         servo.spin_event_loop();
         if let Some(outcome) = result.borrow_mut().take() {
             return outcome
-                .inspect_err(|e| eprintln!("warning: screenshot capture failed: {e:?}"))
+                .inspect_err(|e| tracing::warn!("screenshot capture failed: {e:?}"))
                 .ok();
         }
         if Instant::now() > deadline {
-            eprintln!("warning: screenshot capture timed out after {timeout_secs}s");
+            tracing::warn!(timeout_secs, "screenshot capture timed out");
             return None;
         }
         wait_for_wake(Duration::from_millis(10));


### PR DESCRIPTION
## Summary

Replace ad-hoc `eprintln!` calls with `tracing` + `tracing-subscriber` for diagnostic output. Logs are written to stderr via `EnvFilter` and `from_env_lossy()`, keeping stdout reserved for data output (Markdown, JSON, PNG) so the MCP stdio transport can own it for JSON-RPC.

The `Verbosity` enum maps `-v/-vv/-vvv/-vvvv` and `-q` to crate-scoped filters; `RUST_LOG` overrides them. `NO_COLOR` is honored per spec (non-empty disables ANSI). Progress UI (`Fetching...`, `[n/m] ✓`) stays as raw stderr writes because it must remain prefix-free.

## Test Plan

Verified on macOS (aarch64) with `cargo 1.95.0`:

- Default TTY → ANSI on, `WARN`/`ERROR` prefixed
- `-q` → only `ERROR`
- `-v`/`-vv` → info/debug with relative timestamp and target
- `RUST_LOG=servo_fetch=debug` overrides CLI flags
- Invalid `RUST_LOG` (e.g. `====`) → `from_env_lossy` warns and falls back
- `NO_COLOR=""` → ANSI stays on (spec compliant, empty is ignored)
- `NO_COLOR=1` → ANSI off
- Piped stderr (non-TTY) → ANSI off

## Checklist

- [x] `cargo clippy` passes with zero warnings
- [x] `cargo test` passes
- [x] `cargo fmt --check` passes
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it