### PR TITLE
refactor(main): thin dispatch with structured CLI args

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -6,23 +6,26 @@ use clap::Parser;
 #[command(
     name = "servo-fetch",
     version,
-    about = "A browser engine in a binary — fetch, render, and extract web content.",
-    after_help = "\
-Examples:
-  servo-fetch https://example.com              Readable Markdown (default)
-  servo-fetch https://example.com --json       Structured JSON
-  servo-fetch URL1 URL2 URL3                   Parallel batch fetch
-  servo-fetch URL1 URL2 --json                 Parallel batch (NDJSON)
-  servo-fetch https://example.com --screenshot page.png
-  servo-fetch https://example.com --js \"document.title\"
-  servo-fetch https://example.com -t 60        Custom timeout (seconds)
-  servo-fetch https://example.com --selector article  Extract specific section
-  servo-fetch mcp                              Start MCP server (stdio)"
+    about = "A browser engine in a binary — fetch, render, and extract web content."
 )]
 pub(crate) struct Cli {
     #[command(subcommand)]
     pub command: Option<Command>,
 
+    #[command(flatten)]
+    pub fetch: FetchArgs,
+
+    /// Increase log verbosity (`-v` info, `-vv` debug, `-vvv` trace)
+    #[arg(short = 'v', long, action = clap::ArgAction::Count, global = true, conflicts_with = "quiet")]
+    pub verbose: u8,
+
+    /// Suppress all logs except errors
+    #[arg(short = 'q', long, global = true)]
+    pub quiet: bool,
+}
+
+#[derive(clap::Args, Debug)]
+pub(crate) struct FetchArgs {
     /// URLs to fetch (one or more)
     #[arg(num_args = 1..)]
     pub urls: Vec<String>,
@@ -58,14 +61,6 @@ pub(crate) struct Cli {
     /// Output raw HTML or plain text instead of Readability extraction
     #[arg(long, value_name = "MODE", value_enum, conflicts_with_all = ["json", "screenshot", "js", "selector"])]
     pub raw: Option<RawMode>,
-
-    /// Increase log verbosity (`-v` info, `-vv` debug, `-vvv` trace)
-    #[arg(short = 'v', long, action = clap::ArgAction::Count, global = true, conflicts_with = "quiet")]
-    pub verbose: u8,
-
-    /// Suppress all logs except errors
-    #[arg(short = 'q', long, global = true)]
-    pub quiet: bool,
 }
 
 /// Raw output mode.
@@ -81,51 +76,56 @@ pub(crate) enum RawMode {
 #[derive(clap::Subcommand)]
 pub(crate) enum Command {
     /// Start MCP server (stdio transport by default, or HTTP with --port)
-    Mcp {
-        /// Port for Streamable HTTP transport. Omit for stdio.
-        #[arg(long, value_name = "PORT")]
-        port: Option<u16>,
-    },
+    Mcp(McpArgs),
     /// Crawl a website by following links (BFS). Respects robots.txt.
-    Crawl {
-        /// Starting URL to crawl
-        url: String,
-
-        /// Maximum number of pages to crawl
-        #[arg(long, default_value_t = 50, value_name = "N")]
-        limit: usize,
-
-        /// Maximum link depth from the seed URL
-        #[arg(long, default_value_t = 3, value_name = "N")]
-        max_depth: usize,
-
-        /// URL path glob patterns to include (e.g. "/docs/**")
-        #[arg(long, value_name = "GLOB")]
-        include: Vec<String>,
-
-        /// URL path glob patterns to exclude (e.g. "/docs/archive/**")
-        #[arg(long, value_name = "GLOB")]
-        exclude: Vec<String>,
-
-        /// Output as NDJSON
-        #[arg(long)]
-        json: bool,
-
-        /// CSS selector to extract a specific section per page
-        #[arg(long, value_name = "CSS")]
-        selector: Option<String>,
-
-        /// Timeout in seconds per page
-        #[arg(short = 't', long, default_value_t = 30, value_parser = clap::value_parser!(u64).range(1..), value_name = "SECS")]
-        timeout: u64,
-
-        /// Extra wait in ms after load event per page
-        #[arg(long, default_value_t = 0, value_parser = clap::value_parser!(u64).range(0..=10_000), value_name = "MS")]
-        settle: u64,
-    },
+    Crawl(CrawlArgs),
 }
 
-/// Validate and sanitize a URL for fetching. Forwards to [`crate::net::validate_url`].
+#[derive(clap::Args, Debug)]
+pub(crate) struct McpArgs {
+    /// Port for Streamable HTTP transport. Omit for stdio.
+    #[arg(long, value_name = "PORT")]
+    pub port: Option<u16>,
+}
+
+#[derive(clap::Args, Debug)]
+pub(crate) struct CrawlArgs {
+    /// Starting URL to crawl
+    pub url: String,
+
+    /// Maximum number of pages to crawl
+    #[arg(long, default_value_t = 50, value_name = "N")]
+    pub limit: usize,
+
+    /// Maximum link depth from the seed URL
+    #[arg(long, default_value_t = 3, value_name = "N")]
+    pub max_depth: usize,
+
+    /// URL path glob patterns to include (e.g. "/docs/**")
+    #[arg(long, value_name = "GLOB")]
+    pub include: Vec<String>,
+
+    /// URL path glob patterns to exclude (e.g. "/docs/archive/**")
+    #[arg(long, value_name = "GLOB")]
+    pub exclude: Vec<String>,
+
+    /// Output as NDJSON
+    #[arg(long)]
+    pub json: bool,
+
+    /// CSS selector to extract a specific section per page
+    #[arg(long, value_name = "CSS")]
+    pub selector: Option<String>,
+
+    /// Timeout in seconds per page
+    #[arg(short = 't', long, default_value_t = 30, value_parser = clap::value_parser!(u64).range(1..), value_name = "SECS")]
+    pub timeout: u64,
+
+    /// Extra wait in ms after load event per page
+    #[arg(long, default_value_t = 0, value_parser = clap::value_parser!(u64).range(0..=10_000), value_name = "MS")]
+    pub settle: u64,
+}
+
 pub(crate) fn validate_url(input: &str) -> anyhow::Result<url::Url> {
     crate::net::validate_url(input)
 }
@@ -175,7 +175,6 @@ mod tests {
 
     #[test]
     fn rejects_hex_ip() {
-        // url::Url::parse normalizes 0x7f000001 → 127.0.0.1
         assert!(validate_url("http://0x7f000001/").is_err());
     }
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,0 +1,3 @@
+pub(crate) mod crawl;
+pub(crate) mod fetch;
+pub(crate) mod mcp;

--- a/src/commands/crawl.rs
+++ b/src/commands/crawl.rs
@@ -1,0 +1,42 @@
+//! Crawl subcommand — BFS website crawler.
+
+use std::io::Write as _;
+
+use crate::cli::{self, CrawlArgs};
+use crate::progress::Progress;
+use crate::{crawl, runtime};
+
+/// Crawl a site starting from `args.url` and stream NDJSON results to stdout.
+pub(crate) fn run(args: &CrawlArgs) -> anyhow::Result<()> {
+    let opts = build_options(args)?;
+    let progress = Progress::new();
+    let mut completed = 0usize;
+
+    runtime::block_on(crawl::run(opts, |result| {
+        completed += 1;
+        let line = serde_json::to_string(result).expect("CrawlPageResult is always serializable");
+        let _ = writeln!(std::io::stdout(), "{}", servo_fetch::sanitize::sanitize(&line));
+        let ok = matches!(result.status, crawl::CrawlStatus::Ok);
+        progress.item_done(completed, None, &result.url, ok);
+    }))?;
+
+    Ok(())
+}
+
+fn build_options(args: &CrawlArgs) -> anyhow::Result<crawl::CrawlOptions> {
+    Ok(crawl::CrawlOptions {
+        seed: cli::validate_url(&args.url)?,
+        limit: args.limit,
+        max_depth: args.max_depth,
+        timeout_secs: args.timeout,
+        settle_ms: args.settle,
+        include: (!args.include.is_empty())
+            .then(|| crawl::build_globset(&args.include))
+            .transpose()?,
+        exclude: (!args.exclude.is_empty())
+            .then(|| crawl::build_globset(&args.exclude))
+            .transpose()?,
+        selector: args.selector.clone(),
+        json: args.json,
+    })
+}

--- a/src/commands/fetch.rs
+++ b/src/commands/fetch.rs
@@ -1,0 +1,157 @@
+//! Default fetch command — single URL, batch, and PDF probe.
+
+use std::io::Write as _;
+use std::sync::Arc;
+
+use anyhow::{Result, bail};
+use tokio::sync::{Semaphore, mpsc};
+
+use crate::bridge::{self, FetchMode, FetchOptions, ServoPage};
+use crate::cli::{self, FetchArgs};
+use crate::progress::Progress;
+use crate::{output, pdf, runtime};
+
+const MAX_CONCURRENT_FETCHES: usize = 4;
+
+/// Fetch one or more URLs and write the rendered output to stdout.
+pub(crate) fn run(args: &FetchArgs) -> Result<()> {
+    match args.urls.as_slice() {
+        [] => bail!("URL is required. Run with --help for usage."),
+        [one] => run_single(args, one),
+        many => {
+            if args.screenshot.is_some() || args.js.is_some() || args.raw.is_some() {
+                bail!("--screenshot, --js, and --raw are not supported with multiple URLs");
+            }
+            runtime::block_on(run_batch(args, many))?
+        }
+    }
+}
+
+fn run_single(args: &FetchArgs, url_str: &str) -> Result<()> {
+    let url = cli::validate_url(url_str)?;
+    let progress = Progress::new();
+    progress.ticker(&format!("Fetching {url}..."));
+
+    if is_content_mode(args)
+        && let Some(bytes) = pdf::probe(url.as_str(), args.timeout)
+    {
+        progress.clear();
+        let text = servo_fetch::extract::extract_pdf(&bytes);
+        write!(std::io::stdout(), "{}", servo_fetch::sanitize::sanitize(&text))?;
+        return Ok(());
+    }
+
+    let page = bridge::fetch_page(FetchOptions {
+        url: url.as_str(),
+        timeout_secs: args.timeout,
+        settle_ms: args.settle,
+        mode: fetch_mode(args),
+    });
+    progress.clear();
+    let page = page?;
+    dispatch_output(args, &page, url.as_str())
+}
+
+async fn run_batch(args: &FetchArgs, urls: &[String]) -> Result<()> {
+    let urls: Vec<url::Url> = urls.iter().map(|s| cli::validate_url(s)).collect::<Result<_>>()?;
+    let total = urls.len();
+    let progress = Progress::new();
+    progress.header(&format!("Fetching {total} URLs..."));
+
+    let sem = Arc::new(Semaphore::new(MAX_CONCURRENT_FETCHES));
+    let (tx, mut rx) = mpsc::channel::<(String, Result<ServoPage>)>(total);
+
+    for url in &urls {
+        let _permit = sem.clone().acquire_owned().await?;
+        let tx = tx.clone();
+        let url_str = url.to_string();
+        let timeout = args.timeout;
+        let settle = args.settle;
+        tokio::task::spawn_blocking(move || {
+            let result = bridge::fetch_page(FetchOptions {
+                url: &url_str,
+                timeout_secs: timeout,
+                settle_ms: settle,
+                mode: FetchMode::Content { include_a11y: false },
+            });
+            let _ = tx.blocking_send((url_str, result));
+        });
+    }
+    drop(tx);
+
+    let mut completed = 0usize;
+    let mut failures = 0usize;
+    while let Some((url, result)) = rx.recv().await {
+        completed += 1;
+        match result {
+            Ok(page) => {
+                batch_emit(args, &page, &url)?;
+                progress.item_done(completed, Some(total), &url, true);
+            }
+            Err(err) => {
+                failures += 1;
+                tracing::error!(url = %url, "{err:#}");
+            }
+        }
+    }
+
+    if failures == total {
+        bail!("all {total} URLs failed");
+    }
+    Ok(())
+}
+
+fn batch_emit(args: &FetchArgs, page: &ServoPage, url: &str) -> Result<()> {
+    if args.json {
+        output::Json {
+            page,
+            url,
+            selector: args.selector.as_deref(),
+        }
+        .execute_compact()
+    } else {
+        writeln!(std::io::stdout(), "--- {url} ---")?;
+        output::Markdown {
+            page,
+            url,
+            selector: args.selector.as_deref(),
+        }
+        .execute()?;
+        writeln!(std::io::stdout())?;
+        Ok(())
+    }
+}
+
+fn dispatch_output(args: &FetchArgs, page: &ServoPage, url: &str) -> Result<()> {
+    if let Some(result) = page.js_result.as_deref() {
+        return output::JsEval { result }.execute();
+    }
+    if let Some(path) = args.screenshot.as_deref() {
+        return output::Screenshot { page, path }.execute();
+    }
+    if let Some(mode) = args.raw.as_ref() {
+        return output::Raw { page, mode }.execute();
+    }
+    let selector = args.selector.as_deref();
+    if args.json {
+        output::Json { page, url, selector }.execute()
+    } else {
+        output::Markdown { page, url, selector }.execute()
+    }
+}
+
+fn is_content_mode(args: &FetchArgs) -> bool {
+    args.screenshot.is_none() && args.js.is_none()
+}
+
+fn fetch_mode(args: &FetchArgs) -> FetchMode {
+    if args.screenshot.is_some() {
+        FetchMode::Screenshot {
+            full_page: args.full_page,
+        }
+    } else if let Some(expr) = args.js.clone() {
+        FetchMode::ExecuteJs { expression: expr }
+    } else {
+        FetchMode::Content { include_a11y: false }
+    }
+}

--- a/src/commands/mcp.rs
+++ b/src/commands/mcp.rs
@@ -1,0 +1,9 @@
+//! MCP server subcommand.
+
+use crate::cli::McpArgs;
+use crate::{mcp, runtime};
+
+/// Start the MCP server (stdio or HTTP transport).
+pub(crate) fn run(args: &McpArgs) -> anyhow::Result<()> {
+    runtime::block_on(mcp::run(args.port))?
+}

--- a/src/exit.rs
+++ b/src/exit.rs
@@ -1,0 +1,70 @@
+//! Process exit lifecycle.
+
+use std::io::Write as _;
+
+pub(crate) fn exit_code(result: anyhow::Result<()>) -> i32 {
+    match result {
+        Ok(()) => 0,
+        Err(err) if is_broken_pipe(&err) => 0,
+        Err(err) => {
+            tracing::error!("{err:#}");
+            1
+        }
+    }
+}
+
+fn is_broken_pipe(err: &anyhow::Error) -> bool {
+    err.chain().any(|cause| {
+        cause
+            .downcast_ref::<std::io::Error>()
+            .is_some_and(|e| e.kind() == std::io::ErrorKind::BrokenPipe)
+    })
+}
+
+/// Flush stdio and terminate. On Linux, uses `libc::_exit` to skip
+/// SpiderMonkey's static destructors that race on `pthread_mutex_destroy`.
+pub(crate) fn flush_and_exit(code: i32) -> ! {
+    let _ = std::io::stdout().flush();
+    let _ = std::io::stderr().flush();
+    #[cfg(target_os = "linux")]
+    #[allow(unsafe_code)]
+    unsafe {
+        libc::_exit(code);
+    }
+    #[cfg(not(target_os = "linux"))]
+    std::process::exit(code);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ok_is_zero() {
+        assert_eq!(exit_code(Ok(())), 0);
+    }
+
+    #[test]
+    fn broken_pipe_is_zero() {
+        let err = std::io::Error::new(std::io::ErrorKind::BrokenPipe, "pipe");
+        assert_eq!(exit_code(Err(anyhow::Error::new(err))), 0);
+    }
+
+    #[test]
+    fn other_error_is_one() {
+        assert_eq!(exit_code(Err(anyhow::anyhow!("boom"))), 1);
+    }
+
+    #[test]
+    fn broken_pipe_detected_through_chain() {
+        let io = std::io::Error::new(std::io::ErrorKind::BrokenPipe, "pipe");
+        let err = anyhow::Error::new(io).context("while writing");
+        assert!(is_broken_pipe(&err));
+    }
+
+    #[test]
+    fn non_broken_pipe_not_detected() {
+        let err = anyhow::anyhow!("something else");
+        assert!(!is_broken_pipe(&err));
+    }
+}

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -5,7 +5,6 @@ use std::io::IsTerminal as _;
 use tracing_subscriber::EnvFilter;
 use tracing_subscriber::fmt::time::Uptime;
 
-/// Verbosity resolved from `-v` count and `-q` flag.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum Verbosity {
     Quiet,
@@ -44,7 +43,6 @@ impl Verbosity {
     }
 }
 
-/// Install the global `tracing` subscriber.
 pub(crate) fn init(verbosity: Verbosity) {
     let filter = EnvFilter::builder()
         .with_default_directive(

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,338 +4,47 @@
 
 mod bridge;
 mod cli;
-mod command;
+mod commands;
 mod crawl;
+mod exit;
 mod logging;
 mod mcp;
 mod net;
+mod output;
 mod pdf;
+mod progress;
+mod runtime;
 mod screenshot;
-
-use std::io::{IsTerminal, Write as _};
 
 use clap::Parser;
 
-fn main() {
+use crate::cli::{Cli, Command};
+
+fn main() -> ! {
+    install_process_defaults();
+
+    let args = Cli::parse();
+    logging::init(logging::Verbosity::from_flags(args.verbose, args.quiet));
+
+    let code = exit::exit_code(dispatch(&args));
+    exit::flush_and_exit(code);
+}
+
+fn dispatch(args: &Cli) -> anyhow::Result<()> {
+    match &args.command {
+        Some(Command::Mcp(mcp)) => commands::mcp::run(mcp),
+        Some(Command::Crawl(crawl)) => commands::crawl::run(crawl),
+        None => commands::fetch::run(&args.fetch),
+    }
+}
+
+fn install_process_defaults() {
     #[cfg(unix)]
     #[allow(unsafe_code)]
     unsafe {
         libc::signal(libc::SIGPIPE, libc::SIG_DFL);
     }
-
     rustls::crypto::aws_lc_rs::default_provider()
         .install_default()
-        .expect("Failed to install rustls crypto provider");
-
-    let args = cli::Cli::parse();
-    logging::init(logging::Verbosity::from_flags(args.verbose, args.quiet));
-
-    let code = match args.command {
-        Some(cli::Command::Mcp { port }) => run_mcp(port),
-        Some(cli::Command::Crawl {
-            ref url,
-            limit,
-            max_depth,
-            ref include,
-            ref exclude,
-            json,
-            ref selector,
-            timeout,
-            settle,
-        }) => exit_code(run_crawl(
-            url,
-            limit,
-            max_depth,
-            include,
-            exclude,
-            json,
-            selector.as_deref(),
-            timeout,
-            settle,
-        )),
-        None => exit_code(run(&args)),
-    };
-    flush_and_exit(code);
-}
-
-fn run_mcp(port: Option<u16>) -> i32 {
-    let rt = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
-    match rt.block_on(mcp::run(port)) {
-        Ok(()) => 0,
-        Err(e) => {
-            tracing::error!("{e:#}");
-            1
-        }
-    }
-}
-
-fn exit_code(result: anyhow::Result<()>) -> i32 {
-    match result {
-        Ok(()) => 0,
-        Err(err) if is_broken_pipe(&err) => 0,
-        Err(err) => {
-            tracing::error!("{err:#}");
-            1
-        }
-    }
-}
-
-#[expect(clippy::too_many_arguments, reason = "CLI dispatch, not a public API")]
-fn run_crawl(
-    url: &str,
-    limit: usize,
-    max_depth: usize,
-    include: &[String],
-    exclude: &[String],
-    json: bool,
-    selector: Option<&str>,
-    timeout: u64,
-    settle: u64,
-) -> anyhow::Result<()> {
-    let seed = cli::validate_url(url)?;
-    let include = if include.is_empty() {
-        None
-    } else {
-        Some(crawl::build_globset(include)?)
-    };
-    let exclude = if exclude.is_empty() {
-        None
-    } else {
-        Some(crawl::build_globset(exclude)?)
-    };
-
-    let is_tty = std::io::stderr().is_terminal();
-    let rt = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
-
-    let opts = crawl::CrawlOptions {
-        seed,
-        limit,
-        max_depth,
-        timeout_secs: timeout,
-        settle_ms: settle,
-        include,
-        exclude,
-        selector: selector.map(String::from),
-        json,
-    };
-
-    let mut completed = 0usize;
-    rt.block_on(crawl::run(opts, |result| {
-        completed += 1;
-        if let Ok(line) = serde_json::to_string(result) {
-            let _ = writeln!(std::io::stdout(), "{}", servo_fetch::sanitize::sanitize(&line));
-        }
-        if is_tty {
-            let status = match result.status {
-                crawl::CrawlStatus::Ok => "✓",
-                crawl::CrawlStatus::Error => "✗",
-            };
-            // Progress UI: raw stderr, not a tracing event (prefix-free).
-            let _ = writeln!(std::io::stderr(), "[{completed}] {} {status}", result.url);
-        }
-    }));
-
-    Ok(())
-}
-
-fn is_broken_pipe(err: &anyhow::Error) -> bool {
-    err.chain().any(|cause| {
-        cause
-            .downcast_ref::<std::io::Error>()
-            .is_some_and(|e| e.kind() == std::io::ErrorKind::BrokenPipe)
-    })
-}
-
-fn flush_and_exit(code: i32) -> ! {
-    let _ = std::io::stdout().flush();
-    let _ = std::io::stderr().flush();
-    // On Linux, SpiderMonkey's static destructors race on `pthread_mutex_destroy`
-    // during process exit, producing a post-exit SIGSEGV.
-    #[cfg(target_os = "linux")]
-    #[allow(unsafe_code)]
-    unsafe {
-        libc::_exit(code);
-    }
-    #[cfg(not(target_os = "linux"))]
-    std::process::exit(code);
-}
-
-fn run(args: &cli::Cli) -> anyhow::Result<()> {
-    if args.urls.is_empty() {
-        anyhow::bail!("URL is required. Run with --help for usage.");
-    }
-
-    if args.urls.len() > 1 {
-        if args.screenshot.is_some() || args.js.is_some() || args.raw.is_some() {
-            anyhow::bail!("--screenshot, --js, and --raw are not supported with multiple URLs");
-        }
-        let rt = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
-        return rt.block_on(run_batch(args));
-    }
-
-    run_single(args)
-}
-
-async fn run_batch(args: &cli::Cli) -> anyhow::Result<()> {
-    use std::sync::Arc;
-    use tokio::sync::Semaphore;
-
-    let urls: Vec<url::Url> = args
-        .urls
-        .iter()
-        .map(|s| cli::validate_url(s))
-        .collect::<anyhow::Result<Vec<_>>>()?;
-
-    let is_tty = std::io::stderr().is_terminal();
-    let total = urls.len();
-    if is_tty {
-        // Progress UI, not a diagnostic event.
-        let _ = writeln!(std::io::stderr(), "Fetching {total} URLs...");
-    }
-
-    let sem = Arc::new(Semaphore::new(4));
-    let (tx, mut rx) = tokio::sync::mpsc::channel::<(String, anyhow::Result<bridge::ServoPage>)>(total);
-
-    for url in &urls {
-        let permit = sem.clone().acquire_owned().await?;
-        let tx = tx.clone();
-        let url_str = url.to_string();
-        let timeout = args.timeout;
-        let settle = args.settle;
-        tokio::task::spawn_blocking(move || {
-            let result = bridge::fetch_page(bridge::FetchOptions {
-                url: &url_str,
-                timeout_secs: timeout,
-                settle_ms: settle,
-                mode: bridge::FetchMode::Content { include_a11y: false },
-            });
-            let _ = tx.blocking_send((url_str, result));
-            drop(permit);
-        });
-    }
-    drop(tx);
-
-    let mut completed = 0usize;
-    let mut failures = 0usize;
-    let json = args.json;
-    let selector = args.selector.as_deref();
-
-    while let Some((url, result)) = rx.recv().await {
-        completed += 1;
-        match result {
-            Ok(page) => {
-                if json {
-                    let input = servo_fetch::extract::ExtractInput::new(&page.html, &url)
-                        .with_layout_json(page.layout_json.as_deref())
-                        .with_inner_text(page.inner_text.as_deref())
-                        .with_selector(selector);
-                    let pretty = servo_fetch::extract::extract_json(&input).unwrap_or_default();
-                    // NDJSON: compact single-line JSON per URL
-                    if let Ok(val) = serde_json::from_str::<serde_json::Value>(&pretty) {
-                        let compact = serde_json::to_string(&val).unwrap_or(pretty);
-                        writeln!(std::io::stdout(), "{}", servo_fetch::sanitize::sanitize(&compact))?;
-                    } else {
-                        writeln!(std::io::stdout(), "{}", servo_fetch::sanitize::sanitize(&pretty))?;
-                    }
-                } else {
-                    writeln!(std::io::stdout(), "--- {url} ---")?;
-                    let input = servo_fetch::extract::ExtractInput::new(&page.html, &url)
-                        .with_layout_json(page.layout_json.as_deref())
-                        .with_inner_text(page.inner_text.as_deref())
-                        .with_selector(selector);
-                    let out = servo_fetch::extract::extract_text(&input).unwrap_or_default();
-                    write!(std::io::stdout(), "{}", servo_fetch::sanitize::sanitize(&out))?;
-                    writeln!(std::io::stdout())?;
-                }
-                if is_tty {
-                    let _ = writeln!(std::io::stderr(), "[{completed}/{total}] {url} ✓");
-                }
-            }
-            Err(e) => {
-                failures += 1;
-                tracing::error!(url = %url, "{e:#}");
-            }
-        }
-    }
-
-    if failures == total {
-        anyhow::bail!("all {total} URLs failed");
-    }
-    Ok(())
-}
-
-fn run_single(args: &cli::Cli) -> anyhow::Result<()> {
-    let url_str = &args.urls[0];
-    let url = cli::validate_url(url_str)?;
-
-    let is_tty = std::io::stderr().is_terminal();
-    if is_tty {
-        eprint!("Fetching {url}...");
-        let _ = std::io::Write::flush(&mut std::io::stderr());
-    }
-
-    let is_content_mode = args.screenshot.is_none() && args.js.is_none();
-
-    // PDF probe skips modes where Servo rendering is the point.
-    if is_content_mode {
-        if let Some(pdf_bytes) = pdf::probe(url.as_str(), args.timeout) {
-            if is_tty {
-                eprint!("\r\x1b[K");
-            }
-            let text = servo_fetch::extract::extract_pdf(&pdf_bytes);
-            write!(std::io::stdout(), "{}", servo_fetch::sanitize::sanitize(&text))?;
-            return Ok(());
-        }
-    }
-
-    let mode = if args.screenshot.is_some() {
-        bridge::FetchMode::Screenshot {
-            full_page: args.full_page,
-        }
-    } else if let Some(expr) = args.js.clone() {
-        bridge::FetchMode::ExecuteJs { expression: expr }
-    } else {
-        bridge::FetchMode::Content { include_a11y: false }
-    };
-    let page = bridge::fetch_page(bridge::FetchOptions {
-        url: url.as_str(),
-        timeout_secs: args.timeout,
-        settle_ms: args.settle,
-        mode,
-    });
-
-    if is_tty {
-        eprint!("\r\x1b[K");
-    }
-
-    let page = page?;
-
-    if let Some(ref result) = page.js_result {
-        command::JsEval { result }.execute()?;
-        return Ok(());
-    }
-
-    if let Some(ref path) = args.screenshot {
-        return command::Screenshot { page: &page, path }.execute();
-    }
-
-    if let Some(ref mode) = args.raw {
-        return command::Raw { page: &page, mode }.execute();
-    }
-
-    if args.json {
-        return command::Json {
-            page: &page,
-            url: url.as_str(),
-            selector: args.selector.as_deref(),
-        }
-        .execute();
-    }
-
-    command::Markdown {
-        page: &page,
-        url: url.as_str(),
-        selector: args.selector.as_deref(),
-    }
-    .execute()
+        .expect("failed to install rustls crypto provider");
 }

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,4 +1,4 @@
-//! Command dispatch — each output mode is a struct with its own `execute`.
+//! Output formatters for stdout (Markdown, JSON, screenshot, raw).
 
 use std::io::Write;
 
@@ -6,7 +6,6 @@ use anyhow::{Context as _, Result, bail};
 
 use crate::bridge::ServoPage;
 
-/// Output an extracted article as Markdown to stdout.
 pub(crate) struct Markdown<'a> {
     pub page: &'a ServoPage,
     pub url: &'a str,
@@ -25,7 +24,6 @@ impl Markdown<'_> {
     }
 }
 
-/// Output an extracted article as JSON to stdout.
 pub(crate) struct Json<'a> {
     pub page: &'a ServoPage,
     pub url: &'a str,
@@ -34,17 +32,31 @@ pub(crate) struct Json<'a> {
 
 impl Json<'_> {
     pub(crate) fn execute(&self) -> Result<()> {
+        let json = self.render()?;
+        writeln!(std::io::stdout(), "{}", servo_fetch::sanitize::sanitize(&json))?;
+        Ok(())
+    }
+
+    /// Emit a single-line NDJSON record for batch output.
+    pub(crate) fn execute_compact(&self) -> Result<()> {
+        let pretty = self.render()?;
+        let line = serde_json::from_str::<serde_json::Value>(&pretty)
+            .ok()
+            .and_then(|v| serde_json::to_string(&v).ok())
+            .unwrap_or(pretty);
+        writeln!(std::io::stdout(), "{}", servo_fetch::sanitize::sanitize(&line))?;
+        Ok(())
+    }
+
+    fn render(&self) -> Result<String> {
         let input = servo_fetch::extract::ExtractInput::new(&self.page.html, self.url)
             .with_layout_json(self.page.layout_json.as_deref())
             .with_inner_text(self.page.inner_text.as_deref())
             .with_selector(self.selector);
-        let json = servo_fetch::extract::extract_json(&input)?;
-        writeln!(std::io::stdout(), "{}", servo_fetch::sanitize::sanitize(&json))?;
-        Ok(())
+        Ok(servo_fetch::extract::extract_json(&input)?)
     }
 }
 
-/// Save the rendered screenshot to a PNG file.
 pub(crate) struct Screenshot<'a> {
     pub page: &'a ServoPage,
     pub path: &'a str,
@@ -64,12 +76,17 @@ impl Screenshot<'_> {
     }
 }
 
-/// Print the result of an evaluated JavaScript expression to stdout.
 pub(crate) struct JsEval<'a> {
     pub result: &'a str,
 }
 
-/// Print raw HTML or inner text to stdout.
+impl JsEval<'_> {
+    pub(crate) fn execute(&self) -> Result<()> {
+        writeln!(std::io::stdout(), "{}", servo_fetch::sanitize::sanitize(self.result))?;
+        Ok(())
+    }
+}
+
 pub(crate) struct Raw<'a> {
     pub page: &'a ServoPage,
     pub mode: &'a crate::cli::RawMode,
@@ -82,13 +99,6 @@ impl Raw<'_> {
             crate::cli::RawMode::Text => self.page.inner_text.as_deref().unwrap_or(""),
         };
         write!(std::io::stdout(), "{}", servo_fetch::sanitize::sanitize(content))?;
-        Ok(())
-    }
-}
-
-impl JsEval<'_> {
-    pub(crate) fn execute(&self) -> Result<()> {
-        writeln!(std::io::stdout(), "{}", servo_fetch::sanitize::sanitize(self.result))?;
         Ok(())
     }
 }

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -1,0 +1,47 @@
+//! Terminal progress UI written directly to stderr.
+
+use std::io::{IsTerminal as _, Write as _};
+
+/// TTY-aware reporter for long-running commands.
+pub(crate) struct Progress {
+    is_tty: bool,
+}
+
+impl Progress {
+    pub(crate) fn new() -> Self {
+        Self {
+            is_tty: std::io::stderr().is_terminal(),
+        }
+    }
+
+    pub(crate) fn header(&self, msg: &str) {
+        if self.is_tty {
+            let _ = writeln!(std::io::stderr(), "{msg}");
+        }
+    }
+
+    pub(crate) fn ticker(&self, msg: &str) {
+        if self.is_tty {
+            let mut out = std::io::stderr();
+            let _ = write!(out, "{msg}");
+            let _ = out.flush();
+        }
+    }
+
+    pub(crate) fn clear(&self) {
+        if self.is_tty {
+            let _ = write!(std::io::stderr(), "\r\x1b[K");
+        }
+    }
+
+    pub(crate) fn item_done(&self, index: usize, total: Option<usize>, url: &str, ok: bool) {
+        if !self.is_tty {
+            return;
+        }
+        let mark = if ok { "✓" } else { "✗" };
+        let _ = match total {
+            Some(total) => writeln!(std::io::stderr(), "[{index}/{total}] {url} {mark}"),
+            None => writeln!(std::io::stderr(), "[{index}] {url} {mark}"),
+        };
+    }
+}

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,0 +1,11 @@
+//! Shared tokio runtime construction.
+
+use std::future::Future;
+
+use anyhow::{Context as _, Result};
+
+/// Run `future` on a new multi-thread tokio runtime.
+pub(crate) fn block_on<F: Future>(future: F) -> Result<F::Output> {
+    let rt = tokio::runtime::Runtime::new().context("failed to create tokio runtime")?;
+    Ok(rt.block_on(future))
+}


### PR DESCRIPTION
## Summary

Slim `main.rs` from 280 lines to 50 by extracting logic into dedicated modules, matching the thin-dispatch pattern.

**New modules:**

| Module | Lines | Responsibility |
|--------|-------|----------------|
| `commands/fetch.rs` | 157 | Single URL, batch fetch, PDF probe |
| `commands/crawl.rs` | 42 | Crawl subcommand dispatch |
| `commands/mcp.rs` | 9 | MCP server dispatch |
| `exit.rs` | 70 | `exit_code`, `is_broken_pipe`, `flush_and_exit` + 5 unit tests |
| `runtime.rs` | 11 | Shared `block_on` — eliminates 3× duplicated `Runtime::new()` |
| `progress.rs` | 47 | TTY-aware progress UI (`header`, `ticker`, `clear`, `item_done`) |
| `output.rs` | 190 | Renamed from `command.rs` to avoid confusion with `commands/` (fd/bat convention) |

## Test Plan

- Manual checks: `--help`, single URL, batch (2 URLs), `crawl --help`, `mcp --help`, `-v`, `-q`, no-args error, `--screenshot` + batch conflict error

## Checklist

- [x] `cargo clippy` passes with zero warnings
- [x] `cargo test` passes
- [x] `cargo fmt --check` passes
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it