### PR TITLE
ci: add cargo shear

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,23 @@ jobs:
           persist-credentials: false
       - uses: EmbarkStudios/cargo-deny-action@91bf2b620e09e18d6eb78b92e7861937469acedb # v2.0.17
 
+  shear:
+    name: Unused Dependencies
+    needs: [changes]
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: taiki-e/install-action@481c34c1cf3a84c68b5e46f4eccfc82af798415a # v2.75.23
+        with:
+          tool: cargo-shear
+      - run: cargo shear
+
   typos:
     name: Spell Check
     runs-on: ubuntu-24.04
@@ -154,7 +171,7 @@ jobs:
   ci-passed:
     name: CI Passed
     if: always()
-    needs: [changes, clippy, test, fmt, deny, typos]
+    needs: [changes, clippy, test, fmt, deny, shear, typos]
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:

--- a/crates/servo-fetch/Cargo.toml
+++ b/crates/servo-fetch/Cargo.toml
@@ -42,6 +42,9 @@ servo = { workspace = true, features = ["no-wgl"] }
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]
 
+[package.metadata.cargo-shear]
+ignored = ["rustls"]
+
 [package.metadata.cargo-machete]
 ignored = ["rustls"]
 


### PR DESCRIPTION
## Summary

Add [cargo-shear](https://github.com/Boshen/cargo-shear) to CI for detecting unused dependencies, misplaced deps, and unlinked source files.

## Test Plan

```bash
cargo shear
```

## Checklist

- [x] `cargo clippy` passes with zero warnings
- [x] `cargo test` passes
- [x] `cargo fmt --check` passes
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it
