### PR TITLE
chore: bump version to 0.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6434,7 +6434,7 @@ dependencies = [
 
 [[package]]
 name = "servo-fetch"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "dom_query",
@@ -6460,7 +6460,7 @@ dependencies = [
 
 [[package]]
 name = "servo-fetch-cli"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = ["crates/servo-fetch-cli"]
 resolver = "3"
 
 [workspace.package]
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 rust-version = "1.86.0"
@@ -12,7 +12,7 @@ repository = "https://github.com/konippi/servo-fetch"
 homepage = "https://github.com/konippi/servo-fetch"
 
 [workspace.dependencies]
-servo-fetch = { path = "crates/servo-fetch", version = "0.6.0" }
+servo-fetch = { path = "crates/servo-fetch", version = "0.6.1" }
 servo = { version = "0.1.0", default-features = false, features = ["baked-in-resources", "js_jit"] }
 anyhow = "1"
 base64 = "0.22"


### PR DESCRIPTION
## Summary

Bump version to 0.6.1.

## Checklist

- [x]  `cargo clippy` passes with zero warnings
- [x] `cargo test` passes
- [x] `cargo fmt --check` passes
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it
