### PR TITLE
feat: implement Display and as_str() for ConsoleLevel

### DIFF
--- a/crates/servo-fetch/src/engine.rs
+++ b/crates/servo-fetch/src/engine.rs
@@ -129,6 +129,27 @@ pub enum ConsoleLevel {
     Trace,
 }
 
+impl ConsoleLevel {
+    /// Returns the string representation of this level.
+    #[must_use]
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Log => "log",
+            Self::Debug => "debug",
+            Self::Info => "info",
+            Self::Warn => "warn",
+            Self::Error => "error",
+            Self::Trace => "trace",
+        }
+    }
+}
+
+impl std::fmt::Display for ConsoleLevel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.pad(self.as_str())
+    }
+}
+
 #[derive(Debug, Clone, Default)]
 pub(crate) enum FetchMode {
     #[default]


### PR DESCRIPTION
## Summary

Add `Display` impl and `as_str()` method to `ConsoleLevel`, following the same pattern used by `log::Level` and `tracing_core::Level`.

## Test Plan

- `cargo test --workspace`: 185 passed

## Checklist

- [x] `cargo clippy` passes with zero warnings
- [x] `cargo test` passes
- [x] `cargo fmt --check` passes
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it
