### PR TITLE
feat: derive PartialEq and Eq for ConsoleMessage

### DIFF
--- a/crates/servo-fetch/src/engine.rs
+++ b/crates/servo-fetch/src/engine.rs
@@ -101,7 +101,7 @@ impl Page {
 }
 
 /// Browser console message captured during page load.
-#[derive(Debug, Clone, serde::Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
 #[non_exhaustive]
 pub struct ConsoleMessage {
     /// Severity level.


### PR DESCRIPTION
## Summary

Derive `PartialEq` and `Eq` for `ConsoleMessage`, enabling `assert_eq!` in tests.

## Test Plan

- `cargo test --workspace`: 185 passed

## Checklist

- [x] `cargo clippy` passes with zero warnings
- [x] `cargo test` passes
- [x] `cargo fmt --check` passes
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it