### PR TITLE
fix: respect --json flag in crawl output

### DIFF
--- a/crates/servo-fetch-cli/src/commands/crawl.rs
+++ b/crates/servo-fetch-cli/src/commands/crawl.rs
@@ -1,11 +1,11 @@
 //! Crawl subcommand — BFS website crawler.
 
-use std::io::Write as _;
+use std::io::{self, Write as _};
 
 use crate::cli::CrawlArgs;
 use crate::progress::Progress;
 
-/// Crawl a site starting from `args.url` and stream NDJSON results to stdout.
+/// Crawl a site starting from `args.url` and stream results to stdout.
 pub(crate) fn run(args: &CrawlArgs) -> anyhow::Result<()> {
     let opts = servo_fetch::CrawlOptions::new(&args.url)
         .limit(args.limit)
@@ -25,14 +25,41 @@ pub(crate) fn run(args: &CrawlArgs) -> anyhow::Result<()> {
 
     let progress = Progress::new();
     let mut completed = 0usize;
+    let json = args.json;
+    let mut write_err: Option<io::Error> = None;
 
     servo_fetch::crawl_each(opts, |result| {
         completed += 1;
-        let line = serde_json::to_string(result).expect("CrawlResult is always serializable");
-        let _ = writeln!(std::io::stdout(), "{}", servo_fetch::sanitize::sanitize(&line));
+        if write_err.is_some() {
+            return;
+        }
+        let res = if json { emit_json(result) } else { emit_markdown(result) };
+        if let Err(e) = res {
+            write_err = Some(e);
+            return;
+        }
         let ok = result.status == servo_fetch::CrawlStatus::Ok;
         progress.item_done(completed, None, &result.url, ok);
     })?;
 
+    if let Some(e) = write_err {
+        return Err(e.into());
+    }
     Ok(())
+}
+
+fn emit_json(result: &servo_fetch::CrawlResult) -> io::Result<()> {
+    let line = serde_json::to_string(result).expect("CrawlResult is always serializable");
+    writeln!(io::stdout(), "{}", servo_fetch::sanitize::sanitize(&line))
+}
+
+fn emit_markdown(result: &servo_fetch::CrawlResult) -> io::Result<()> {
+    let mut out = io::stdout();
+    writeln!(out, "--- {} ---", result.url)?;
+    if let Some(content) = &result.content {
+        writeln!(out, "{}", servo_fetch::sanitize::sanitize(content))?;
+    } else if let Some(err) = &result.error {
+        tracing::warn!(url = %result.url, "{err}");
+    }
+    writeln!(out)
 }


### PR DESCRIPTION
## Summary

`crawl` subcommand always emitted NDJSON regardless of `--json` flag. Now:

- Default: Markdown with `--- URL ---` headers (consistent with `fetch` batch output)
- `--json`: NDJSON (existing behavior)

Also propagates write errors out of the callback instead of silently ignoring them, and logs crawl failures to stderr via `tracing::warn`.

## Test Plan

```
cargo clippy --workspace --all-targets -- -D warnings  # pass
cargo test --workspace                                 # 185 passed
cargo fmt --all --check                                # pass
```

## Checklist

- [x] `cargo clippy` passes with zero warnings
- [x] `cargo test` passes
- [x] `cargo fmt --check` passes
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it