### PR TITLE
fix: remove duplicate URL validation in PDF probe

### DIFF
--- a/crates/servo-fetch/src/pdf.rs
+++ b/crates/servo-fetch/src/pdf.rs
@@ -10,7 +10,6 @@ const HEAD_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Return PDF bytes when the resource is a PDF, `None` otherwise.
 pub(crate) fn probe(url: &str, timeout_secs: u64) -> Option<Vec<u8>> {
-    crate::net::validate_url(url).ok()?;
     if !looks_like_pdf_url(url) {
         return None;
     }
@@ -87,10 +86,5 @@ mod tests {
     fn probe_returns_none_for_unresolvable_host() {
         // Suffix matches, HEAD fails quickly.
         assert!(probe("http://invalid.invalid/foo.pdf", 1).is_none());
-    }
-
-    #[test]
-    fn probe_rejects_private_ip_pdf() {
-        assert!(probe("http://127.0.0.1/report.pdf", 1).is_none());
     }
 }


### PR DESCRIPTION
## Summary

`pdf::probe()` called `validate_url()` redundantly — `engine::fetch()` already validates the URL before calling `probe()`. This caused the "credentials stripped from URL" warning to appear twice.

## Test Plan

```
cargo clippy --workspace --all-targets -- -D warnings  # pass
cargo test --workspace                                 # 184 passed
cargo fmt --all --check                                # pass
```

## Checklist

- [x] `cargo clippy` passes with zero warnings
- [x] `cargo test` passes
- [x] `cargo fmt --check` passes
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it