### PR TITLE
fix: warn when --selector matches no elements

### DIFF
--- a/crates/servo-fetch-cli/src/output.rs
+++ b/crates/servo-fetch-cli/src/output.rs
@@ -19,7 +19,11 @@ impl Markdown<'_> {
                 .with_layout_json(self.page.layout_json.as_deref())
                 .with_inner_text(Some(&self.page.inner_text))
                 .with_selector(Some(selector));
-            servo_fetch::extract::extract_text(&input)?
+            let text = servo_fetch::extract::extract_text(&input)?;
+            if text.is_empty() {
+                tracing::warn!(selector, "no elements matched the selector");
+            }
+            text
         } else {
             self.page.markdown_with_url(self.url)?
         };


### PR DESCRIPTION
## Summary

Emit a `WARN` to stderr when `--selector` matches no elements. Follows the jq/pup convention: stdout stays empty, exit 0, but the user gets diagnostic feedback via tracing.

## Test Plan

- `cargo test --workspace`: 185 passed

## Checklist

- [x] `cargo clippy` passes with zero warnings
- [x] `cargo test` passes
- [x] `cargo fmt --check` passes
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it
