### PR TITLE
fix: use _exit on all platforms to avoid SpiderMonkey destructor race

### DIFF
--- a/crates/servo-fetch-cli/src/exit.rs
+++ b/crates/servo-fetch-cli/src/exit.rs
@@ -21,18 +21,15 @@ fn is_broken_pipe(err: &anyhow::Error) -> bool {
     })
 }
 
-/// Flush stdio and terminate. On Linux, uses `libc::_exit` to skip
-/// SpiderMonkey's static destructors that race on `pthread_mutex_destroy`.
+/// Flush stdio and terminate via `libc::_exit`, skipping SpiderMonkey's
+/// static destructors that race on `pthread_mutex_destroy`.
 pub(crate) fn flush_and_exit(code: i32) -> ! {
     let _ = std::io::stdout().flush();
     let _ = std::io::stderr().flush();
-    #[cfg(target_os = "linux")]
     #[allow(unsafe_code)]
     unsafe {
         libc::_exit(code);
     }
-    #[cfg(not(target_os = "linux"))]
-    std::process::exit(code);
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Use `_exit` on all platforms to avoid SpiderMonkey destructor race.

## Test Plan

Verified on macOS (arm64) that exit codes and stdio flushing work correctly with `_exit`:
- `servo-fetch "https://example.com"` → stdout output, exit 0
- `servo-fetch "not-a-url"` → stderr error, exit 1
- `servo-fetch` (no args) → stderr error, exit 1
- `servo-fetch --version` → stdout `servo-fetch 0.6.1`, exit 0
- `servo-fetch "https://example.com" | head -1` → broken pipe, exit 0

## Checklist

- [x] `cargo clippy` passes with zero warnings
- [x] `cargo test` passes
- [x] `cargo fmt --check` passes
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it
