### PR TITLE
fix: initialize CryptoProvider in crawl_each

### DIFF
--- a/crates/servo-fetch/src/engine.rs
+++ b/crates/servo-fetch/src/engine.rs
@@ -401,6 +401,7 @@ pub enum CrawlStatus {
 /// Crawl a site, invoking `on_page` for each result as it arrives.
 #[allow(clippy::needless_pass_by_value)]
 pub fn crawl_each(opts: CrawlOptions, mut on_page: impl FnMut(&CrawlResult)) -> crate::error::Result<()> {
+    ensure_crypto_provider();
     let internal_opts = build_crawl_options(&opts)?;
     crate::runtime::block_on(crate::crawl::run(internal_opts, |r| {
         on_page(&CrawlResult::from_internal(r));


### PR DESCRIPTION
## Summary

`crawl_each()` panics when called without a prior `fetch()` call because `ensure_crypto_provider()` was missing. The rustls CryptoProvider is process-global and was only initialized in `fetch()`, not in `crawl_each()`.

## Test Plan

Reproduced the panic before the fix:
```rust
// panics at rustls::crypto::mod.rs:249 without this fix
crawl_each(CrawlOptions::new("https://example.com").limit(1), |r| println!("{}", r.url))?;
```

## Checklist

- [x] `cargo clippy` passes with zero warnings
- [x] `cargo test` passes
- [x] `cargo fmt --check` passes
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it