### PR TITLE
fix: correct URL validation error routing and trailing-dot bypass

### DIFF
--- a/crates/servo-fetch/src/engine.rs
+++ b/crates/servo-fetch/src/engine.rs
@@ -223,10 +223,7 @@ impl FetchOptions {
 pub fn fetch(opts: FetchOptions) -> crate::error::Result<Page> {
     ensure_crypto_provider();
 
-    crate::net::validate_url(&opts.url).map_err(|e| Error::InvalidUrl {
-        url: opts.url.clone(),
-        reason: e.to_string(),
-    })?;
+    crate::net::validate_url(&opts.url).map_err(|e| map_url_error(&opts.url, e))?;
 
     if matches!(opts.mode, FetchMode::Content)
         && let Some(bytes) = crate::pdf::probe(&opts.url, opts.timeout.as_secs().max(1))
@@ -434,21 +431,25 @@ pub fn text(url: &str) -> crate::error::Result<String> {
 
 /// Validate a URL for fetching. Rejects disallowed schemes and private addresses.
 pub fn validate_url(url: &str) -> crate::error::Result<url::Url> {
-    crate::net::validate_url(url).map_err(|e| Error::InvalidUrl {
-        url: url.into(),
-        reason: e.to_string(),
-    })
+    crate::net::validate_url(url).map_err(|e| map_url_error(url, e))
 }
 
 fn ensure_crypto_provider() {
     let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
 }
 
+fn map_url_error(url: &str, e: crate::net::UrlError) -> Error {
+    match e {
+        crate::net::UrlError::PrivateAddress(host) => Error::AddressNotAllowed(host),
+        crate::net::UrlError::Invalid(reason) => Error::InvalidUrl {
+            url: url.into(),
+            reason,
+        },
+    }
+}
+
 fn build_crawl_options(opts: &CrawlOptions) -> crate::error::Result<crate::crawl::CrawlOptions> {
-    let seed = crate::net::validate_url(&opts.url).map_err(|e| Error::InvalidUrl {
-        url: opts.url.clone(),
-        reason: e.to_string(),
-    })?;
+    let seed = crate::net::validate_url(&opts.url).map_err(|e| map_url_error(&opts.url, e))?;
     let include = if opts.include.is_empty() {
         None
     } else {

--- a/crates/servo-fetch/src/net.rs
+++ b/crates/servo-fetch/src/net.rs
@@ -2,7 +2,6 @@
 
 /// Returns `true` if the host resolves to a private or reserved address.
 pub(crate) fn is_private_host(host: &str) -> bool {
-    // Fast path for common blocked hosts; comprehensive check follows via IP parsing.
     const BLOCKED_HOSTS: &[&str] = &[
         "localhost",
         "127.0.0.1",
@@ -11,6 +10,7 @@ pub(crate) fn is_private_host(host: &str) -> bool {
         "169.254.169.254",
         "metadata.google.internal",
     ];
+    let host = host.strip_suffix('.').unwrap_or(host);
     if BLOCKED_HOSTS.iter().any(|&b| host.eq_ignore_ascii_case(b)) {
         return true;
     }
@@ -70,18 +70,37 @@ fn is_private_ipv6(ip: &std::net::Ipv6Addr) -> bool {
         || s0 & 0xff00 == 0xff00 // ff00::/8  multicast
 }
 
-/// Validate and sanitize a URL for fetching.
-///
-/// Only `http`/`https` schemes are accepted, embedded credentials are stripped,
-/// and hosts that resolve to private or reserved addresses are rejected. DNS is
-/// not resolved, so DNS rebinding attacks remain possible downstream.
-pub(crate) fn validate_url(input: &str) -> anyhow::Result<url::Url> {
-    use anyhow::{Context as _, bail};
+/// Why a URL was rejected by [`validate_url`].
+#[derive(Debug)]
+pub(crate) enum UrlError {
+    /// Malformed URL or disallowed scheme.
+    Invalid(String),
+    /// Host resolves to a private or reserved address.
+    PrivateAddress(String),
+}
 
-    let mut parsed = url::Url::parse(input).with_context(|| format!("invalid URL: {input}"))?;
+impl std::fmt::Display for UrlError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Invalid(reason) => f.write_str(reason),
+            Self::PrivateAddress(host) => {
+                write!(f, "access to private/local addresses is not allowed: {host}")
+            }
+        }
+    }
+}
+
+/// Only `http`/`https` schemes are accepted, embedded credentials are stripped,
+/// and hosts that resolve to private or reserved addresses are rejected.
+pub(crate) fn validate_url(input: &str) -> Result<url::Url, UrlError> {
+    let mut parsed = url::Url::parse(input).map_err(|e| UrlError::Invalid(format!("invalid URL: {input}: {e}")))?;
     match parsed.scheme() {
         "http" | "https" => {}
-        s => bail!("scheme '{s}' not allowed; only http:// and https:// are supported"),
+        s => {
+            return Err(UrlError::Invalid(format!(
+                "scheme '{s}' not allowed; only http:// and https:// are supported"
+            )));
+        }
     }
     if !parsed.username().is_empty() || parsed.password().is_some() {
         tracing::warn!("credentials stripped from URL");
@@ -90,7 +109,7 @@ pub(crate) fn validate_url(input: &str) -> anyhow::Result<url::Url> {
     }
     if let Some(host) = parsed.host_str() {
         if is_private_host(host) {
-            bail!("access to private/local addresses is not allowed: {host}");
+            return Err(UrlError::PrivateAddress(host.to_string()));
         }
     }
     Ok(parsed)
@@ -192,5 +211,11 @@ mod tests {
     #[test]
     fn validate_url_empty_string() {
         assert!(validate_url("").is_err());
+    }
+
+    #[test]
+    fn blocks_trailing_dot() {
+        assert!(is_private_host("localhost."));
+        assert!(is_private_host("metadata.google.internal."));
     }
 }


### PR DESCRIPTION
## Summary

Two URL validation fixes:

1. **Error routing**: `Error::AddressNotAllowed` was unreachable — all validation errors were mapped to `Error::InvalidUrl`. Introduced `pub(crate) enum UrlError` in `net.rs` to type-safely distinguish parse failures from private address rejections, and route them to the correct public `Error` variant via `map_url_error` helper.

2. **Trailing-dot SSRF bypass**: `http://localhost./` bypassed `is_private_host` because `host_str()` preserves the trailing dot per WHATWG URL Standard. Now stripped before comparison.

## Test Plan

```
cargo clippy --workspace --all-targets -- -D warnings  # pass
cargo test --workspace                                  # 185 passed
cargo fmt --all --check                                 # pass
```

## Checklist

- [x] `cargo clippy` passes with zero warnings
- [x] `cargo test` passes
- [x] `cargo fmt --check` passes
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it