### PR TITLE
docs: clarify optional JSON fields as omitted when not detected

### DIFF
--- a/crates/servo-fetch-cli/README.md
+++ b/crates/servo-fetch-cli/README.md
@@ -106,10 +106,10 @@ servo-fetch mcp --port 8080    # Streamable HTTP transport
 | `title` | string | Page title |
 | `content` | string | Raw HTML extracted by Readability |
 | `text_content` | string | Readable text (Markdown) |
-| `byline` | string? | Author or byline |
-| `excerpt` | string? | Short excerpt or description |
-| `lang` | string? | Document language |
-| `url` | string? | Canonical URL |
+| `byline` | string | Author or byline (omitted if not detected) |
+| `excerpt` | string | Short excerpt or description (omitted if not detected) |
+| `lang` | string | Document language (omitted if not detected) |
+| `url` | string | Canonical URL (omitted if not detected) |
 
 ### Crawl subcommand
 


### PR DESCRIPTION
## Summary

Clarify optional JSON fields as omitted when not detected.

## Test Plan

N/A

## Checklist

- [x] `cargo clippy` passes with zero warnings
- [x] `cargo test` passes
- [x] `cargo fmt --check` passes
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it
