### PR TITLE
feat: model CrawlResult outcome as Result<CrawlPage, CrawlError>

### DIFF
--- a/crates/servo-fetch-cli/src/commands/crawl.rs
+++ b/crates/servo-fetch-cli/src/commands/crawl.rs
@@ -38,7 +38,7 @@ pub(crate) fn run(args: &CrawlArgs) -> anyhow::Result<()> {
             write_err = Some(e);
             return;
         }
-        let ok = result.status == servo_fetch::CrawlStatus::Ok;
+        let ok = result.outcome.is_ok();
         progress.item_done(completed, None, &result.url, ok);
     })?;
 
@@ -56,10 +56,13 @@ fn emit_json(result: &servo_fetch::CrawlResult) -> io::Result<()> {
 fn emit_markdown(result: &servo_fetch::CrawlResult) -> io::Result<()> {
     let mut out = io::stdout();
     writeln!(out, "--- {} ---", result.url)?;
-    if let Some(content) = &result.content {
-        writeln!(out, "{}", servo_fetch::sanitize::sanitize(content))?;
-    } else if let Some(err) = &result.error {
-        tracing::warn!(url = %result.url, "{err}");
+    match &result.outcome {
+        Ok(page) => {
+            writeln!(out, "{}", servo_fetch::sanitize::sanitize(&page.content))?;
+        }
+        Err(e) => {
+            tracing::warn!(url = %result.url, "{e}");
+        }
     }
     writeln!(out)
 }

--- a/crates/servo-fetch-cli/src/mcp/tools/crawl.rs
+++ b/crates/servo-fetch-cli/src/mcp/tools/crawl.rs
@@ -45,11 +45,9 @@ pub(crate) async fn crawl_pages(opts: CrawlToolOptions<'_>) -> Result<Vec<(Strin
 
     let mut results = Vec::new();
     servo_fetch::crawl_each(builder, |r| {
-        let text = if r.status == servo_fetch::CrawlStatus::Ok {
-            let content = r.content.as_deref().unwrap_or_default();
-            paginate(&servo_fetch::sanitize::sanitize(content), 0, opts.max_len)
-        } else {
-            format!("[error] {}", r.error.as_deref().unwrap_or_default())
+        let text = match &r.outcome {
+            Ok(page) => paginate(&servo_fetch::sanitize::sanitize(&page.content), 0, opts.max_len),
+            Err(e) => format!("[error] {e}"),
         };
         results.push((r.url.clone(), text));
     })

--- a/crates/servo-fetch/examples/crawl.rs
+++ b/crates/servo-fetch/examples/crawl.rs
@@ -1,16 +1,17 @@
 //! Crawl a site with streaming results.
 
-use servo_fetch::{CrawlOptions, CrawlStatus, crawl_each};
+use servo_fetch::{CrawlOptions, crawl_each};
 
 fn main() -> Result<(), servo_fetch::Error> {
     crawl_each(
         CrawlOptions::new("https://example.com").limit(5).max_depth(1),
-        |result| {
-            let mark = if result.status == CrawlStatus::Ok { "✓" } else { "✗" };
-            println!(
-                "{mark} {} (depth={}, links={})",
-                result.url, result.depth, result.links_found
-            );
+        |result| match &result.outcome {
+            Ok(page) => {
+                println!("✓ {} (depth={}, links={})", result.url, result.depth, page.links_found);
+            }
+            Err(e) => {
+                println!("✗ {} — {e}", result.url);
+            }
         },
     )?;
 

--- a/crates/servo-fetch/src/engine.rs
+++ b/crates/servo-fetch/src/engine.rs
@@ -345,41 +345,87 @@ impl CrawlOptions {
 }
 
 /// Result for a single crawled page.
-#[derive(Debug, Clone, serde::Serialize)]
+#[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct CrawlResult {
     /// URL of the crawled page.
     pub url: String,
     /// Link depth from the seed URL.
     pub depth: usize,
-    /// Whether the page was fetched successfully.
-    pub status: CrawlStatus,
-    /// Page title, if extraction succeeded.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    /// Page content if successful, or error if failed.
+    pub outcome: Result<CrawlPage, CrawlError>,
+}
+
+/// Successfully crawled page.
+#[derive(Debug, Clone)]
+pub struct CrawlPage {
+    /// Page title.
     pub title: Option<String>,
     /// Extracted content (Markdown or JSON depending on options).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub content: Option<String>,
-    /// Error message, if the page failed to load.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub error: Option<String>,
+    pub content: String,
     /// Number of links discovered on this page.
     pub links_found: usize,
 }
 
+/// Error from a failed crawl attempt.
+#[derive(Debug, Clone)]
+pub struct CrawlError {
+    /// Error message.
+    pub message: String,
+}
+
+impl std::fmt::Display for CrawlError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for CrawlError {}
+
+impl serde::Serialize for CrawlResult {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeMap;
+        match &self.outcome {
+            Ok(page) => {
+                let mut map = serializer.serialize_map(None)?;
+                map.serialize_entry("url", &self.url)?;
+                map.serialize_entry("depth", &self.depth)?;
+                map.serialize_entry("status", "ok")?;
+                if let Some(t) = &page.title {
+                    map.serialize_entry("title", t)?;
+                }
+                map.serialize_entry("content", &page.content)?;
+                map.serialize_entry("links_found", &page.links_found)?;
+                map.end()
+            }
+            Err(e) => {
+                let mut map = serializer.serialize_map(None)?;
+                map.serialize_entry("url", &self.url)?;
+                map.serialize_entry("depth", &self.depth)?;
+                map.serialize_entry("status", "error")?;
+                map.serialize_entry("error", &e.message)?;
+                map.end()
+            }
+        }
+    }
+}
+
 impl CrawlResult {
     fn from_internal(r: &crate::crawl::CrawlPageResult) -> Self {
+        let outcome = match r.status {
+            crate::crawl::CrawlStatus::Ok => Ok(CrawlPage {
+                title: r.title.clone(),
+                content: r.content.clone().unwrap_or_default(),
+                links_found: r.links_found,
+            }),
+            crate::crawl::CrawlStatus::Error => Err(CrawlError {
+                message: r.error.clone().unwrap_or_default(),
+            }),
+        };
         Self {
             url: r.url.clone(),
             depth: r.depth,
-            status: match r.status {
-                crate::crawl::CrawlStatus::Ok => CrawlStatus::Ok,
-                crate::crawl::CrawlStatus::Error => CrawlStatus::Error,
-            },
-            title: r.title.clone(),
-            content: r.content.clone(),
-            error: r.error.clone(),
-            links_found: r.links_found,
+            outcome,
         }
     }
 }

--- a/crates/servo-fetch/src/lib.rs
+++ b/crates/servo-fetch/src/lib.rs
@@ -22,7 +22,7 @@ pub(crate) mod runtime;
 pub(crate) mod screenshot;
 
 pub use engine::{
-    ConsoleLevel, ConsoleMessage, CrawlOptions, CrawlResult, CrawlStatus, FetchOptions, Page, crawl, crawl_each,
-    extract_json, fetch, markdown, text, validate_url,
+    ConsoleLevel, ConsoleMessage, CrawlError, CrawlOptions, CrawlPage, CrawlResult, CrawlStatus, FetchOptions, Page,
+    crawl, crawl_each, extract_json, fetch, markdown, text, validate_url,
 };
 pub use error::{Error, Result};


### PR DESCRIPTION
## Summary

Replace `CrawlResult`'s flat `Option` fields (`status`, `content`, `error`, `title`, `links_found`) with `outcome: Result<CrawlPage, CrawlError>`. This makes illegal states unrepresentable — a successful result always has `content: String` (not `Option`), and a failed result always has an error message.

New public types:
- `CrawlPage` — title, content, links_found
- `CrawlError` — message (implements `Display` + `std::error::Error`)

## Test Plan

```text
cargo test --workspace                                 # 184 passed
cargo build -p servo-fetch --examples       # all 7 examples compile
```

CLI crawl verified:
- `servo-fetch crawl URL --limit 1` → markdown output with `--- URL ---` header
- `servo-fetch crawl URL --limit 1 --json` → flat NDJSON with `status`, `url`, `content`, `links_found` keys

## Checklist

- [x] `cargo clippy` passes with zero warnings
- [x] `cargo test` passes
- [x] `cargo fmt --check` passes
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it