### PR TITLE
feat: support custom User-Agent via CLI flag and library API

### DIFF
--- a/crates/servo-fetch-cli/README.md
+++ b/crates/servo-fetch-cli/README.md
@@ -94,6 +94,7 @@ servo-fetch mcp --port 8080    # Streamable HTTP transport
 | `--raw html\|text` | Raw HTML or plain text output |
 | `-t, --timeout <SECS>` | Page load timeout in seconds (default: 30) |
 | `--settle <MS>` | Extra wait after load event in ms (default: 0, max: 10000) |
+| `--user-agent <UA>` | Override the User-Agent string |
 | `-v, --verbose` | Increase log verbosity (`-v` info, `-vv` debug, `-vvv` trace) |
 | `-q, --quiet` | Suppress all logs except errors |
 
@@ -123,6 +124,7 @@ servo-fetch mcp --port 8080    # Streamable HTTP transport
 | `--exclude <GLOB>` | URL path patterns to exclude |
 | `--json` | Output content as JSON per page |
 | `--selector <CSS>` | Extract specific section per page |
+| `--user-agent <UA>` | Override the User-Agent string |
 
 ## Logging
 
@@ -138,6 +140,13 @@ RUST_LOG="servo_fetch=trace,servo=debug" servo-fetch "..." # include Servo inter
 ```
 
 `RUST_LOG` uses [`tracing-subscriber`'s directive syntax](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html) and always wins over CLI flags.
+
+## Environment Variables
+
+| Variable | Description |
+| -------- | ----------- |
+| `SERVO_FETCH_USER_AGENT` | Default User-Agent string (overridden by `--user-agent`) |
+| `RUST_LOG` | Fine-grained log filter (overrides `-v`/`-q`) |
 
 ## MCP Server
 

--- a/crates/servo-fetch-cli/src/cli.rs
+++ b/crates/servo-fetch-cli/src/cli.rs
@@ -61,6 +61,10 @@ pub(crate) struct FetchArgs {
     /// Output raw HTML or plain text instead of Readability extraction
     #[arg(long, value_name = "MODE", value_enum, conflicts_with_all = ["json", "screenshot", "js", "selector"])]
     pub raw: Option<RawMode>,
+
+    /// Override the User-Agent string
+    #[arg(long, value_name = "UA")]
+    pub user_agent: Option<String>,
 }
 
 /// Raw output mode.
@@ -124,6 +128,10 @@ pub(crate) struct CrawlArgs {
     /// Extra wait in ms after load event per page
     #[arg(long, default_value_t = 0, value_parser = clap::value_parser!(u64).range(0..=10_000), value_name = "MS")]
     pub settle: u64,
+
+    /// Override the User-Agent string
+    #[arg(long, value_name = "UA")]
+    pub user_agent: Option<String>,
 }
 
 #[cfg(test)]

--- a/crates/servo-fetch-cli/src/commands/crawl.rs
+++ b/crates/servo-fetch-cli/src/commands/crawl.rs
@@ -22,6 +22,10 @@ pub(crate) fn run(args: &CrawlArgs) -> anyhow::Result<()> {
     } else {
         opts.exclude(&args.exclude.iter().map(String::as_str).collect::<Vec<_>>())
     };
+    let opts = match args.user_agent {
+        Some(ref ua) => opts.user_agent(ua),
+        None => opts,
+    };
 
     let progress = Progress::new();
     let mut completed = 0usize;

--- a/crates/servo-fetch-cli/src/commands/fetch.rs
+++ b/crates/servo-fetch-cli/src/commands/fetch.rs
@@ -51,12 +51,16 @@ async fn run_batch(args: &FetchArgs, urls: &[String]) -> Result<()> {
         let url_str = url.clone();
         let timeout = args.timeout;
         let settle = args.settle;
+        let user_agent = args.user_agent.clone();
         tokio::task::spawn_blocking(move || {
-            let result = servo_fetch::fetch(
-                FetchOptions::new(&url_str)
-                    .timeout(Duration::from_secs(timeout))
-                    .settle(Duration::from_millis(settle)),
-            );
+            let opts = FetchOptions::new(&url_str)
+                .timeout(Duration::from_secs(timeout))
+                .settle(Duration::from_millis(settle));
+            let opts = match user_agent {
+                Some(ua) => opts.user_agent(ua),
+                None => opts,
+            };
+            let result = servo_fetch::fetch(opts);
             let _ = tx.blocking_send((url_str, result));
             drop(permit);
         });
@@ -132,6 +136,11 @@ fn build_fetch_options(args: &FetchArgs, url: &str) -> FetchOptions {
     } else {
         FetchOptions::new(url)
     };
-    base.timeout(Duration::from_secs(args.timeout))
-        .settle(Duration::from_millis(args.settle))
+    let opts = base
+        .timeout(Duration::from_secs(args.timeout))
+        .settle(Duration::from_millis(args.settle));
+    match args.user_agent {
+        Some(ref ua) => opts.user_agent(ua),
+        None => opts,
+    }
 }

--- a/crates/servo-fetch/README.md
+++ b/crates/servo-fetch/README.md
@@ -34,7 +34,8 @@ use std::time::Duration;
 let page = fetch(
     FetchOptions::new("https://spa-site.com")
         .timeout(Duration::from_secs(60))
-        .settle(Duration::from_millis(3000)),
+        .settle(Duration::from_millis(3000))
+        .user_agent("MyBot/1.0"),
 )?;
 println!("{}", page.html);
 let md = page.markdown()?;

--- a/crates/servo-fetch/src/bridge.rs
+++ b/crates/servo-fetch/src/bridge.rs
@@ -3,7 +3,7 @@
 use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
 use std::rc::Rc;
-use std::sync::{Arc, Condvar, Mutex, mpsc};
+use std::sync::{Arc, Condvar, Mutex, OnceLock, mpsc};
 use std::time::{Duration, Instant};
 
 use anyhow::{Result, anyhow};
@@ -17,6 +17,17 @@ use servo::{
 use crate::layout;
 
 const JS_EVAL_TIMEOUT: Duration = Duration::from_secs(10);
+
+fn default_user_agent() -> &'static str {
+    static UA: OnceLock<String> = OnceLock::new();
+    UA.get_or_init(|| {
+        let raw = std::env::var("SERVO_FETCH_USER_AGENT")
+            .ok()
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| format!("servo-fetch/{}", env!("CARGO_PKG_VERSION")));
+        crate::engine::sanitize_user_agent(raw)
+    })
+}
 /// Max wait before we re-check time-based conditions.
 pub(crate) const FALLBACK_WAIT: Duration = Duration::from_millis(5);
 const LAYOUT_JS: &str = include_str!("js/layout.js");
@@ -242,6 +253,7 @@ pub(crate) struct FetchOptions<'a> {
     /// Extra wait after Servo fires `LoadStatus::Complete`.
     pub settle_ms: u64,
     pub mode: FetchMode,
+    pub user_agent: Option<&'a str>,
 }
 
 /// What to do once the page has loaded. Variants are mutually exclusive.
@@ -256,6 +268,7 @@ struct FetchRequest {
     timeout_secs: u64,
     settle_ms: u64,
     mode: FetchMode,
+    user_agent: Option<String>,
     reply: mpsc::Sender<Result<ServoPage>>,
 }
 
@@ -273,7 +286,7 @@ struct Engine {
 }
 
 /// Servo engine — lives for the process lifetime. Shutdown is via process exit.
-static ENGINE: std::sync::OnceLock<Engine> = std::sync::OnceLock::new();
+static ENGINE: OnceLock<Engine> = OnceLock::new();
 
 /// Fetch a page via Servo. First call spawns a persistent Servo thread.
 pub(crate) fn fetch_page(opts: FetchOptions<'_>) -> Result<ServoPage> {
@@ -301,6 +314,7 @@ pub(crate) fn fetch_page(opts: FetchOptions<'_>) -> Result<ServoPage> {
             timeout_secs: opts.timeout_secs,
             settle_ms: opts.settle_ms,
             mode: opts.mode,
+            user_agent: opts.user_agent.map(String::from),
             reply: reply_tx,
         })
         .map_err(|_| anyhow!("Servo engine is not running (it may have crashed on a previous request)"))?;
@@ -427,6 +441,9 @@ fn start_fetch(
         Err(e) => return Err((req, anyhow!("bad url: {e}"))),
     };
 
+    let ua = req.user_agent.as_deref().unwrap_or(default_user_agent());
+    servo.set_preference("user_agent", servo::PrefValue::Str(ua.to_owned()));
+
     let dedicated_ctx = if matches!(req.mode, FetchMode::Screenshot { .. }) {
         let size = PhysicalSize::new(layout::VIEWPORT_WIDTH, layout::VIEWPORT_HEIGHT);
         match SoftwareRenderingContext::new(size) {
@@ -538,10 +555,7 @@ fn build_servo(waker: FlagWaker) -> Result<(Rc<SoftwareRenderingContext>, servo:
         dom_webxr_enabled: false,
         dom_serviceworker_enabled: false,
         dom_bluetooth_enabled: false,
-        user_agent: std::env::var("SERVO_FETCH_USER_AGENT")
-            .ok()
-            .filter(|s| !s.is_empty())
-            .unwrap_or_else(|| format!("Mozilla/5.0 (compatible; servo-fetch/{})", env!("CARGO_PKG_VERSION"))),
+        user_agent: default_user_agent().to_owned(),
         ..Preferences::default()
     };
 

--- a/crates/servo-fetch/src/crawl.rs
+++ b/crates/servo-fetch/src/crawl.rs
@@ -26,6 +26,7 @@ pub(crate) struct CrawlOptions {
     pub exclude: Option<GlobSet>,
     pub selector: Option<String>,
     pub json: bool,
+    pub user_agent: Option<String>,
 }
 
 /// Result for a single crawled page.
@@ -283,6 +284,7 @@ pub(crate) async fn run(opts: CrawlOptions, mut on_page: impl FnMut(&CrawlPageRe
         let url_str = url.to_string();
         let timeout = opts.timeout_secs;
         let settle = opts.settle_ms;
+        let user_agent = opts.user_agent.clone();
 
         let page = match tokio::task::spawn_blocking(move || {
             bridge::fetch_page(bridge::FetchOptions {
@@ -290,6 +292,7 @@ pub(crate) async fn run(opts: CrawlOptions, mut on_page: impl FnMut(&CrawlPageRe
                 timeout_secs: timeout,
                 settle_ms: settle,
                 mode: bridge::FetchMode::Content { include_a11y: false },
+                user_agent: user_agent.as_deref(),
             })
         })
         .await

--- a/crates/servo-fetch/src/engine.rs
+++ b/crates/servo-fetch/src/engine.rs
@@ -173,6 +173,7 @@ pub struct FetchOptions {
     pub(crate) timeout: Duration,
     pub(crate) settle: Duration,
     pub(crate) mode: FetchMode,
+    pub(crate) user_agent: Option<String>,
 }
 
 impl FetchOptions {
@@ -183,6 +184,7 @@ impl FetchOptions {
             timeout: Duration::from_secs(30),
             settle: Duration::ZERO,
             mode: FetchMode::Content,
+            user_agent: None,
         }
     }
 
@@ -213,6 +215,12 @@ impl FetchOptions {
         self.settle = settle;
         self
     }
+
+    /// Override the User-Agent string for this request.
+    pub fn user_agent(mut self, ua: impl Into<String>) -> Self {
+        self.user_agent = Some(sanitize_user_agent(ua.into()));
+        self
+    }
 }
 
 /// Fetch a single page via the embedded Servo engine.
@@ -240,6 +248,7 @@ pub fn fetch(opts: FetchOptions) -> crate::error::Result<Page> {
         url: &opts.url,
         timeout_secs: opts.timeout.as_secs().max(1),
         settle_ms: u64::try_from(opts.settle.as_millis()).unwrap_or(u64::MAX),
+        user_agent: opts.user_agent.as_deref(),
         mode: match opts.mode {
             FetchMode::Content => crate::bridge::FetchMode::Content { include_a11y: false },
             FetchMode::Screenshot { full_page } => crate::bridge::FetchMode::Screenshot { full_page },
@@ -277,6 +286,7 @@ pub struct CrawlOptions {
     pub(crate) exclude: Vec<String>,
     pub(crate) selector: Option<String>,
     pub(crate) json: bool,
+    pub(crate) user_agent: Option<String>,
 }
 
 impl CrawlOptions {
@@ -292,6 +302,7 @@ impl CrawlOptions {
             exclude: Vec::new(),
             selector: None,
             json: false,
+            user_agent: None,
         }
     }
 
@@ -340,6 +351,12 @@ impl CrawlOptions {
     /// CSS selector to extract a specific section per page.
     pub fn selector(mut self, selector: impl Into<String>) -> Self {
         self.selector = Some(selector.into());
+        self
+    }
+
+    /// Override the User-Agent string for all pages in this crawl.
+    pub fn user_agent(mut self, ua: impl Into<String>) -> Self {
+        self.user_agent = Some(sanitize_user_agent(ua.into()));
         self
     }
 }
@@ -485,6 +502,15 @@ fn ensure_crypto_provider() {
     let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
 }
 
+/// Replace CR, LF, and NUL with SP per RFC 9110.
+pub(crate) fn sanitize_user_agent(ua: String) -> String {
+    if ua.bytes().any(|b| b == b'\r' || b == b'\n' || b == 0) {
+        ua.replace(['\r', '\n', '\0'], " ")
+    } else {
+        ua
+    }
+}
+
 fn map_url_error(url: &str, e: crate::net::UrlError) -> Error {
     match e {
         crate::net::UrlError::PrivateAddress(host) => Error::AddressNotAllowed(host),
@@ -517,6 +543,7 @@ fn build_crawl_options(opts: &CrawlOptions) -> crate::error::Result<crate::crawl
         exclude,
         selector: opts.selector.clone(),
         json: opts.json,
+        user_agent: opts.user_agent.clone(),
     })
 }
 
@@ -577,6 +604,42 @@ mod tests {
         assert_eq!(opts.max_depth, 5);
         assert_eq!(opts.include, vec!["/docs/**"]);
         assert_eq!(opts.exclude, vec!["/docs/archive/**"]);
+    }
+
+    #[test]
+    fn fetch_user_agent_set() {
+        let opts = FetchOptions::new("https://example.com").user_agent("MyBot/1.0");
+        assert_eq!(opts.user_agent.as_deref(), Some("MyBot/1.0"));
+    }
+
+    #[test]
+    fn fetch_user_agent_default_is_none() {
+        let opts = FetchOptions::new("https://example.com");
+        assert!(opts.user_agent.is_none());
+    }
+
+    #[test]
+    fn fetch_user_agent_sanitizes_crlf() {
+        let opts = FetchOptions::new("https://example.com").user_agent("Bot\r\nX-Evil: yes");
+        assert_eq!(opts.user_agent.as_deref(), Some("Bot  X-Evil: yes"));
+    }
+
+    #[test]
+    fn fetch_user_agent_sanitizes_null() {
+        let opts = FetchOptions::new("https://example.com").user_agent("Bot\0/1.0");
+        assert_eq!(opts.user_agent.as_deref(), Some("Bot /1.0"));
+    }
+
+    #[test]
+    fn fetch_user_agent_empty_string() {
+        let opts = FetchOptions::new("https://example.com").user_agent("");
+        assert_eq!(opts.user_agent.as_deref(), Some(""));
+    }
+
+    #[test]
+    fn crawl_user_agent_sanitizes_crlf() {
+        let opts = CrawlOptions::new("https://example.com").user_agent("Crawler\r\n/2.0");
+        assert_eq!(opts.user_agent.as_deref(), Some("Crawler  /2.0"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Add `--user-agent` CLI flag and `FetchOptions::user_agent()` / `CrawlOptions::user_agent()` builder methods to override the User-Agent string per request.

**Precedence:** `--user-agent` / `.user_agent()` > `SERVO_FETCH_USER_AGENT` env var > built-in default

## Test Plan

- `cargo test --workspace` — 191 tests pass (including 6 new UA-specific tests)
- CLI verified with `--js "navigator.userAgent"`:
  - Custom UA: `--user-agent "QATestBot/99.0"` → confirmed in `navigator.userAgent`
  - Default UA: `servo-fetch/0.6.1`
  - Env var: `SERVO_FETCH_USER_AGENT="EnvBot/3.0"` → confirmed
  - Override precedence: `--user-agent` wins over env var → confirmed
  - No cross-request leakage: custom UA → default UA sequential calls → confirmed
  - CRLF injection: `$'Injector\r\nX-Evil: yes'` → stripped to SP → confirmed
  - Batch fetch: `--user-agent` applied to all URLs → confirmed
  - Crawl subcommand: `--user-agent` works → confirmed

## Checklist

- [x] `cargo clippy` passes with zero warnings
- [x] `cargo test` passes
- [x] `cargo fmt --check` passes
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it
