### PR TITLE
fix: move libc dependency to all platforms for _exit

### DIFF
--- a/crates/servo-fetch-cli/Cargo.toml
+++ b/crates/servo-fetch-cli/Cargo.toml
@@ -22,6 +22,7 @@ anyhow = { workspace = true }
 axum = "0.8"
 base64 = { workspace = true }
 clap = { version = "4", features = ["derive"] }
+libc = "0.2"
 rmcp = { version = "1", features = ["server", "transport-io", "transport-streamable-http-server", "macros"] }
 rustls = { workspace = true }
 schemars = "1"
@@ -30,9 +31,6 @@ serde_json = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "signal"] }
 tracing = { workspace = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter", "tracing-log"] }
-
-[target.'cfg(unix)'.dependencies]
-libc = "0.2"
 
 [dev-dependencies]
 assert_cmd = "2"


### PR DESCRIPTION
## Summary

Move `libc` from `[target.'cfg(unix)'.dependencies]` to `[dependencies]` so it is available on Windows.

PR #89 changed `flush_and_exit` to use `libc::_exit` on all platforms, but `libc` was still gated behind `cfg(unix)`, causing `error[E0433]: cannot find module or crate 'libc'` on Windows CI.

## Test Plan

- Release workflow Windows build failure: https://github.com/konippi/servo-fetch/actions/runs/25296134070/job/74155201230

## Checklist

- [x] `cargo clippy` passes with zero warnings
- [x] `cargo test` passes
- [x] `cargo fmt --check` passes
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it