### PR TITLE
fix: enable servo experimental preferences for SPA compatibility

### DIFF
--- a/crates/servo-fetch/src/bridge.rs
+++ b/crates/servo-fetch/src/bridge.rs
@@ -555,6 +555,9 @@ fn build_servo(waker: FlagWaker) -> Result<(Rc<SoftwareRenderingContext>, servo:
         dom_webxr_enabled: false,
         dom_serviceworker_enabled: false,
         dom_bluetooth_enabled: false,
+        dom_intersection_observer_enabled: true,
+        dom_indexeddb_enabled: true,
+        layout_grid_enabled: true,
         user_agent: default_user_agent().to_owned(),
         ..Preferences::default()
     };


### PR DESCRIPTION
## Summary

Enable three Servo experimental preferences for modern SPA compatibility:

- `dom_intersection_observer_enabled` — lazy loading, infinite scroll, virtual lists
- `layout_grid_enabled` — CSS Grid layouts used by most modern sites
- `dom_indexeddb_enabled` — SPA state management and caching

| Site | Before | After |
|------|--------|-------|
| react.dev | ❌ "client-side exception" | ✅ |
| nextjs.org/docs | ❌ "couldn't load" | ✅ |
| crates.io | ⚠️ Empty content | ✅ |

## Test Plan

- `cargo test --workspace` — 191 tests pass, no regressions
- Manual verification: react.dev, nextjs.org/docs, crates.io confirmed working

## Checklist

- [x] `cargo clippy` passes with zero warnings
- [x] `cargo test` passes
- [x] `cargo fmt --check` passes
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it
