### PR TITLE
fix: recover page content on load timeout instead of returning empty

### DIFF
--- a/crates/servo-fetch/src/bridge.rs
+++ b/crates/servo-fetch/src/bridge.rs
@@ -487,20 +487,30 @@ fn start_fetch(
 }
 
 fn finish_fetch(servo: &servo::Servo, p: &PendingFetch) -> Result<ServoPage> {
-    if p.state.loaded_at.get().is_none() && Instant::now() > p.deadline {
-        return Err(anyhow!(
-            "page load timed out after {timeout}s (try increasing --timeout)",
-            timeout = p.request.timeout_secs,
-        ));
-    }
+    let timed_out = p.state.loaded_at.get().is_none() && Instant::now() > p.deadline;
 
     if let Some(ref ctx) = p.dedicated_ctx {
         let _ = ctx.make_current();
     }
 
-    wait_for_ready_state(servo, &p.webview, p.deadline);
+    if !timed_out {
+        wait_for_ready_state(servo, &p.webview, p.deadline);
+    }
 
-    let html = eval_js(servo, &p.webview, "document.documentElement.outerHTML")?;
+    let html = match eval_js(servo, &p.webview, "document.documentElement.outerHTML") {
+        Ok(h) if !h.is_empty() => h,
+        _ if timed_out => {
+            return Err(anyhow!(
+                "page load timed out after {timeout}s (try increasing --timeout)",
+                timeout = p.request.timeout_secs,
+            ));
+        }
+        other => other?,
+    };
+
+    if timed_out {
+        tracing::warn!("page load did not complete; returning best-effort content");
+    }
     let inner_text = eval_js(servo, &p.webview, "document.body.innerText").ok();
     let layout_json = eval_js(servo, &p.webview, LAYOUT_JS).ok();
 


### PR DESCRIPTION
## Summary

When `LoadStatus::Complete` never fires (e.g. ad/tracker iframes stalling the load event), attempt to extract HTML from the DOM instead of returning an empty error. On timeout, `eval_js("document.documentElement.outerHTML")` is attempted. If the DOM has content, it is returned as best-effort with a warn log. If the DOM is empty, the original timeout error is preserved.

| Site | Before | After |
|------|--------|-------|
| Qiita | ❌ Empty | ✅ Content extracted |
| BBC News | ❌ Empty | ✅ Content extracted |

## Test Plan

- `cargo test --workspace` — 191 tests pass
- Manual verification: Qiita, BBC News confirmed working
- Regression check: example.com, Wikipedia, react.dev, Next.js docs, GitHub, HN — all unchanged

## Checklist

- [x] `cargo clippy` passes with zero warnings
- [x] `cargo test` passes
- [x] `cargo fmt --check` passes
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it