### PR TITLE
docs: add crawl options example

### DIFF
--- a/crates/servo-fetch/examples/crawl_with_filter.rs
+++ b/crates/servo-fetch/examples/crawl_with_filter.rs
@@ -1,0 +1,29 @@
+//! Crawl a site with filters and extraction options.
+
+use std::time::Duration;
+
+use servo_fetch::{CrawlOptions, crawl_each};
+
+fn main() -> Result<(), servo_fetch::Error> {
+    let opts = CrawlOptions::new("https://example.com")
+        .limit(20)
+        .max_depth(2)
+        .timeout(Duration::from_secs(45))
+        .settle(Duration::from_secs(1))
+        .include(&["/docs/**", "/blog/**"])
+        .exclude(&["/docs/archive/**", "/blog/tags/**"])
+        .selector("main")
+        .json(false)
+        .user_agent("servo-fetch crawl_with_filter example");
+
+    crawl_each(opts, |result| match &result.outcome {
+        Ok(page) => {
+            println!("✓ {} (depth={}, title={:?})", result.url, result.depth, page.title);
+        }
+        Err(e) => {
+            println!("✗ {} — {e}", result.url);
+        }
+    })?;
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add `crawl_with_filter.rs` showing the full `CrawlOptions` builder
- demonstrate include/exclude globs, selector extraction, timeout/settle, JSON mode, and user agent setup

Closes #82

## Tests
- `cargo fmt --check`
- `cargo check -p servo-fetch --example crawl_with_filter` could not complete locally because Servo's `glslopt` dependency needs `cc1plus`, and this environment does not have the C++ compiler component installed.