### PR TITLE
test(cli): add mcp help smoke test

### DIFF
--- a/crates/servo-fetch-cli/tests/cli.rs
+++ b/crates/servo-fetch-cli/tests/cli.rs
@@ -161,6 +161,16 @@ fn crawl_help_shows_options() {
 }
 
 #[test]
+fn mcp_help_shows_options() {
+    servo_fetch()
+        .args(["mcp", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("MCP"))
+        .stdout(predicate::str::contains("--port"));
+}
+
+#[test]
 #[ignore = "requires Servo + network"]
 fn crawl_produces_ndjson() {
     let output = servo_fetch()


### PR DESCRIPTION
## Summary
- add a smoke test for `servo-fetch mcp --help`
- assert the MCP help output includes the command heading and `--port`

Fixes #81

## Test Plan
- `cargo fmt --check`
- `git diff --check`
- `cargo test -p servo-fetch-cli --test cli mcp_help_shows_options` could not complete locally because this host is missing `cc1plus`; compilation failed while building `glslopt` before the test binary ran.