### PR TITLE
test: add HTML extraction edge cases

### DIFF
--- a/crates/servo-fetch/tests/extract.rs
+++ b/crates/servo-fetch/tests/extract.rs
@@ -80,6 +80,28 @@ fn empty_body_without_inner_text_returns_empty() {
 }
 
 #[test]
+fn empty_title_keeps_body_content() {
+    let html = fixture("empty_title.html");
+    let text = extract::extract_text(&input(&html)).unwrap();
+    assert!(text.contains("Readable content remains available"));
+}
+
+#[test]
+fn missing_body_does_not_fail() {
+    let html = fixture("missing_body.html");
+    let text = extract::extract_text(&input(&html)).unwrap();
+    assert!(text.contains("Loose text outside a body element"));
+}
+
+#[test]
+fn script_only_page_returns_no_script_text() {
+    let html = fixture("script_only.html");
+    let text = extract::extract_text(&input(&html)).unwrap();
+    assert!(!text.contains("hidden script content"));
+    assert!(!text.contains("window.__DATA__"));
+}
+
+#[test]
 fn byline_and_excerpt_rendered_in_markdown() {
     let html = fixture("article_with_meta.html");
     let text = extract::extract_text(&input(&html)).unwrap();

--- a/crates/servo-fetch/tests/fixtures/empty_title.html
+++ b/crates/servo-fetch/tests/fixtures/empty_title.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html>
+<head>
+  <title></title>
+</head>
+<body>
+  <main>
+    <h1>Visible heading</h1>
+    <p>Readable content remains available when the title tag is empty.</p>
+  </main>
+</body>
+</html>

--- a/crates/servo-fetch/tests/fixtures/missing_body.html
+++ b/crates/servo-fetch/tests/fixtures/missing_body.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<html>
+<head>
+  <title>Missing Body</title>
+</head>
+<p>Loose text outside a body element should not make extraction fail.</p>
+</html>

--- a/crates/servo-fetch/tests/fixtures/script_only.html
+++ b/crates/servo-fetch/tests/fixtures/script_only.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+<head>
+  <title>Script Only</title>
+</head>
+<body>
+  <script>
+    window.__DATA__ = { message: "hidden script content" };
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Closes #80.

Adds fixture-backed extraction coverage for edge-case HTML pages with:
- an empty `<title>`
- no explicit `<body>` element
- only script content in the body

## Test Plan

- `cargo fmt --check`
- `git diff --check`

Attempted `cargo test -p servo-fetch --test extract`, but this local environment is missing `cc1plus`, so Servo's `glslopt` dependency fails during C++ compilation before the Rust tests run.

## Checklist

- [ ] `cargo clippy` passes with zero warnings
- [ ] `cargo test` passes
- [x] `cargo fmt --check` passes
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it