### PR TITLE
chore(labels): add type: test label for test-only changes

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -14,6 +14,9 @@
 - name: "type: perf"
   color: d4c5f9
   description: "Performance improvement (perf:)"
+- name: "type: test"
+  color: bfd4f2
+  description: "Test-only change (test:)"
 - name: "type: deps"
   color: 0366d6
   description: "Dependency updates (chore(deps):)"


### PR DESCRIPTION
## Summary

Adds `type: test` label to align our label taxonomy with [Conventional Commits](https://www.conventionalcommits.org/) `test:` scope.

## Context

`.github/labels.yml` currently omits `type: test`, which forced test-only contributions to be mislabeled as `type: docs`:

- Closed #81 (`test: add cli smoke test` — PR #102) was labeled `type: docs`
- Open #80 (`test: add HTML extraction edge cases`) is labeled `type: docs`

## Test Plan

N/A

## Checklist

- [x] `cargo clippy` passes with zero warnings *(Rust workspace untouched)*
- [x] `cargo test` passes *(Rust workspace untouched)*
- [x] `cargo fmt --check` passes *(Rust workspace untouched)*
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it