### PR TITLE
fix(runtime): memoize tokio runtime and fail-fast on async callers

### DIFF
--- a/crates/servo-fetch/src/runtime.rs
+++ b/crates/servo-fetch/src/runtime.rs
@@ -1,11 +1,51 @@
-//! Shared tokio runtime construction.
+//! Shared tokio runtime for bridging servo-fetch's sync API to the async crawl
+//! implementation.
 
 use std::future::Future;
+use std::sync::LazyLock;
 
-use anyhow::{Context as _, Result};
+use anyhow::{Result, bail};
+use tokio::runtime::{Builder, Handle, Runtime};
 
-/// Run `future` on a new multi-thread tokio runtime.
+/// Process-wide tokio runtime dedicated to servo-fetch's sync↔async bridge.
+static RUNTIME: LazyLock<Runtime> = LazyLock::new(|| {
+    Builder::new_current_thread()
+        .enable_all()
+        .thread_name("servo-fetch-runtime")
+        .build()
+        .expect("failed to build servo-fetch tokio runtime")
+});
+
+/// Run `future` on the shared tokio runtime, blocking the calling thread.
 pub(crate) fn block_on<F: Future>(future: F) -> Result<F::Output> {
-    let rt = tokio::runtime::Runtime::new().context("failed to create tokio runtime")?;
-    Ok(rt.block_on(future))
+    if Handle::try_current().is_ok() {
+        bail!(
+            "servo-fetch sync API cannot be called from within a Tokio runtime; \
+             wrap the call in `tokio::task::spawn_blocking`"
+        );
+    }
+    Ok(RUNTIME.block_on(future))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn runs_future_in_sync_context() {
+        let n = block_on(async { 42 }).unwrap();
+        assert_eq!(n, 42);
+    }
+
+    #[test]
+    fn rejects_call_from_async_context() {
+        // Spin up a minimal runtime just to simulate an async caller.
+        let outer = Builder::new_current_thread().enable_all().build().unwrap();
+        let result = outer.block_on(async { block_on(async { 1 }) });
+        assert!(result.is_err(), "should refuse to run inside a tokio runtime");
+        assert!(
+            result.unwrap_err().to_string().contains("Tokio runtime"),
+            "error message should mention Tokio runtime"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Creating a fresh `tokio::runtime::Runtime` per `block_on` call was wasteful, and panicked with `"Cannot start a runtime from within a runtime"` when the caller was already inside another Tokio runtime — notably the MCP `crawl` tool handler which awaits `servo_fetch::crawl_each`.

## Test Plan

- `cargo test -p servo-fetch --locked --lib` — 127 passed (2 new: `runtime::tests::{runs_future_in_sync_context, rejects_call_from_async_context}`)

## Checklist

- [x] `cargo clippy` passes with zero warnings
- [x] `cargo test` passes
- [x] `cargo fmt --check` passes
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it