### PR TITLE
refactor(lib): restrict some modules to crate visibility

### DIFF
--- a/crates/servo-fetch/src/layout.rs
+++ b/crates/servo-fetch/src/layout.rs
@@ -4,9 +4,9 @@
 use serde::Deserialize;
 
 /// Default viewport width used by Servo for rendering.
-pub const VIEWPORT_WIDTH: u32 = 1280;
+pub(crate) const VIEWPORT_WIDTH: u32 = 1280;
 /// Default viewport height used by Servo for rendering.
-pub const VIEWPORT_HEIGHT: u32 = 800;
+pub(crate) const VIEWPORT_HEIGHT: u32 = 800;
 
 /// ARIA roles that influence our layout heuristics.
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
@@ -48,7 +48,7 @@ impl Position {
 
 /// A page element with CSS layout data, deserialized from the injected JS.
 #[derive(Deserialize)]
-pub struct LayoutElement {
+pub(crate) struct LayoutElement {
     tag: String,
     role: Option<Role>,
     w: f64,
@@ -80,7 +80,7 @@ impl LayoutElement {
 
 /// CSS selectors for elements that should be stripped before passing to readability.
 #[must_use]
-pub fn selectors_to_strip(elements: &[LayoutElement]) -> Vec<String> {
+pub(crate) fn selectors_to_strip(elements: &[LayoutElement]) -> Vec<String> {
     let mut sels: Vec<String> = elements
         .iter()
         .filter(|el| el.should_remove())

--- a/crates/servo-fetch/src/lib.rs
+++ b/crates/servo-fetch/src/lib.rs
@@ -8,14 +8,14 @@
 
 #![deny(unsafe_code)]
 
-pub mod engine;
-pub mod error;
 pub mod extract;
-pub mod layout;
 pub mod sanitize;
 
 pub(crate) mod bridge;
 pub(crate) mod crawl;
+pub(crate) mod engine;
+pub(crate) mod error;
+pub(crate) mod layout;
 pub(crate) mod net;
 pub(crate) mod pdf;
 pub(crate) mod runtime;


### PR DESCRIPTION
## Summary

Restrict engine/error/layout modules to crate visibility.

## Test Plan

- `cargo test -p servo-fetch --locked --lib` — 125 passed
- `cargo test -p servo-fetch --locked --doc` — 1 passed (the `servo_fetch::markdown` + `servo_fetch::Error` example in `lib.rs` still resolves)
- `cargo test -p servo-fetch --locked --test extract` — 14 passed (`servo_fetch::extract::*` path still works)
- `cargo test -p servo-fetch-cli --locked` — 12 + 17 passed (network-gated tests skipped as usual)

## Checklist

- [x] `cargo clippy` passes with zero warnings
- [x] `cargo test` passes
- [x] `cargo fmt --check` passes
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it

