### PR TITLE
fix(crawl): apply robots.txt per RFC 9309 with per-request UA

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,6 +292,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "assert_cmd"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1390,6 +1400,24 @@ name = "data-url"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
+
+[[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
 name = "der"
@@ -6467,6 +6495,7 @@ dependencies = [
  "tracing",
  "ureq",
  "url",
+ "wiremock",
 ]
 
 [[package]]
@@ -9709,6 +9738,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d129932f4644ac2396cb456385cbf9e63b5b30c6e8dc4820bdca4eb082037a5"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64 0.22.1",
+ "deadpool",
+ "futures",
+ "http 1.4.0",
+ "http-body-util",
+ "hyper 1.9.0",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
 ]
 
 [[package]]

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,7 +26,7 @@ servo-fetch processes untrusted web content. The following areas are in scope:
 - All output is sanitized to remove ANSI escape sequences, control characters, and BiDi override characters ([CVE-2021-42574](https://www.cve.org/CVERecord?id=CVE-2021-42574))
 - `--js` output is sanitized before printing to the terminal
 - MCP `execute_js` rejects scripts longer than 10,000 characters; MCP `fetch` output is bounded by `max_length` / `start_index` to limit response size
-- Crawl validates every discovered link against RFC 6890 before following it, enforces same-site (eTLD+1) scope by default, respects `robots.txt` (fail-closed: if robots.txt cannot be fetched, no links are followed), and rate-limits requests to a minimum 500ms interval
+- Crawl validates every discovered link against RFC 6890 before following it, enforces same-site (eTLD+1) scope by default, applies `robots.txt` per RFC 9309 (4xx → allow, 5xx/network → disallow, redirects disabled to avoid cross-authority SSRF), and rate-limits requests to a minimum 500ms interval
 
 ## Known limitations
 

--- a/crates/servo-fetch/Cargo.toml
+++ b/crates/servo-fetch/Cargo.toml
@@ -42,6 +42,10 @@ os_pipe = "1"
 [target.'cfg(windows)'.dependencies]
 servo = { workspace = true, features = ["no-wgl"] }
 
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros"] }
+wiremock = "0.6"
+
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]
 

--- a/crates/servo-fetch/src/bridge.rs
+++ b/crates/servo-fetch/src/bridge.rs
@@ -18,7 +18,7 @@ use crate::layout;
 
 const JS_EVAL_TIMEOUT: Duration = Duration::from_secs(10);
 
-fn default_user_agent() -> &'static str {
+pub(crate) fn default_user_agent() -> &'static str {
     static UA: OnceLock<String> = OnceLock::new();
     UA.get_or_init(|| {
         let raw = std::env::var("SERVO_FETCH_USER_AGENT")

--- a/crates/servo-fetch/src/crawl.rs
+++ b/crates/servo-fetch/src/crawl.rs
@@ -141,31 +141,73 @@ fn strip_directive<'a>(line: &'a str, directive: &str) -> Option<&'a str> {
     }
 }
 
+fn robots_url(seed: &Url) -> Option<Url> {
+    let mut base = seed.clone();
+    base.set_username("").ok();
+    base.set_password(None).ok();
+    base.join("/robots.txt").ok()
+}
+
+fn product_token(user_agent: &str) -> &str {
+    user_agent
+        .split(|c: char| c == '/' || c.is_whitespace())
+        .next()
+        .filter(|s| !s.is_empty())
+        .unwrap_or("*")
+}
+
+/// Outcome of `RobotsRules::fetch`.
+enum RobotsPolicy {
+    Rules(RobotsRules),
+    /// 4xx other than 401/403 — treat as no restrictions.
+    Unavailable,
+    /// Auth wall, server error, or network failure — fail closed.
+    Unreachable,
+}
+
+impl RobotsPolicy {
+    fn is_allowed(&self, url: &Url) -> bool {
+        match self {
+            Self::Rules(r) => r.is_allowed(url),
+            Self::Unavailable => true,
+            Self::Unreachable => false,
+        }
+    }
+}
+
 struct RobotsRules {
     rules: Vec<(bool, String)>,
 }
 
 impl RobotsRules {
-    fn fetch(seed: &Url) -> Option<Self> {
-        let robots_url = format!("{}://{}/robots.txt", seed.scheme(), seed.host_str()?);
-        let body = ureq::Agent::new_with_config(
+    fn fetch(seed: &Url, user_agent: Option<&str>) -> RobotsPolicy {
+        let Some(url) = robots_url(seed) else {
+            return RobotsPolicy::Unreachable;
+        };
+        let ua = user_agent.unwrap_or_else(|| bridge::default_user_agent());
+        let agent = ureq::Agent::new_with_config(
             ureq::config::Config::builder()
                 .max_redirects(0)
                 .timeout_global(Some(ROBOTS_TIMEOUT))
+                .user_agent(ua)
                 .build(),
-        )
-        .get(&robots_url)
-        .call()
-        .ok()?
-        .into_body()
-        .with_config()
-        .limit(ROBOTS_MAX_BYTES)
-        .read_to_string()
-        .ok()?;
-        Some(Self::parse(&body))
+        );
+        match agent.get(url.as_str()).call() {
+            Ok(resp) => resp
+                .into_body()
+                .with_config()
+                .limit(ROBOTS_MAX_BYTES)
+                .read_to_string()
+                .map_or(RobotsPolicy::Unreachable, |body| {
+                    RobotsPolicy::Rules(Self::parse(&body, product_token(ua)))
+                }),
+            Err(ureq::Error::StatusCode(401 | 403 | 429)) => RobotsPolicy::Unreachable,
+            Err(ureq::Error::StatusCode(code)) if (400..500).contains(&code) => RobotsPolicy::Unavailable,
+            Err(_) => RobotsPolicy::Unreachable,
+        }
     }
 
-    fn parse(body: &str) -> Self {
+    fn parse(body: &str, product_token: &str) -> Self {
         let mut rules = Vec::new();
         let mut in_matching_agent = false;
         for line in body.lines() {
@@ -175,7 +217,7 @@ impl RobotsRules {
             }
             if let Some(agent) = strip_directive(line, "user-agent") {
                 let agent = agent.trim();
-                in_matching_agent = agent == "*" || agent.eq_ignore_ascii_case("servo-fetch");
+                in_matching_agent = agent == "*" || agent.eq_ignore_ascii_case(product_token);
             } else if in_matching_agent {
                 let rule = strip_directive(line, "disallow")
                     .map(|p| (false, p.trim()))
@@ -258,11 +300,11 @@ fn extract_links_from_html(html: &str, base: &Url) -> Vec<Url> {
 pub(crate) async fn run(opts: CrawlOptions, mut on_page: impl FnMut(&CrawlPageResult)) -> Vec<CrawlPageResult> {
     let robots = tokio::task::spawn_blocking({
         let seed = opts.seed.clone();
-        move || RobotsRules::fetch(&seed)
+        let user_agent = opts.user_agent.clone();
+        move || RobotsRules::fetch(&seed, user_agent.as_deref())
     })
     .await
-    .ok()
-    .flatten();
+    .unwrap_or(RobotsPolicy::Unreachable);
 
     let mut frontier = Frontier::new(&opts.seed);
     let mut results = Vec::new();
@@ -342,7 +384,7 @@ pub(crate) async fn run(opts: CrawlOptions, mut on_page: impl FnMut(&CrawlPageRe
                 }
                 if !is_same_site(&opts.seed, link)
                     || net::validate_url(link.as_str()).is_err()
-                    || !robots.as_ref().is_some_and(|r| r.is_allowed(link))
+                    || !robots.is_allowed(link)
                     || !matches_scope(link, opts.include.as_ref(), opts.exclude.as_ref())
                 {
                     continue;
@@ -435,7 +477,7 @@ mod tests {
 
     #[test]
     fn robots_parse_allow_disallow() {
-        let rules = RobotsRules::parse("User-agent: *\nDisallow: /admin\nAllow: /admin/public\n");
+        let rules = RobotsRules::parse("User-agent: *\nDisallow: /admin\nAllow: /admin/public\n", "servo-fetch");
         assert!(!rules.is_allowed(&Url::parse("https://x.com/admin/secret").unwrap()));
         assert!(rules.is_allowed(&Url::parse("https://x.com/admin/public/page").unwrap()));
         assert!(rules.is_allowed(&Url::parse("https://x.com/page").unwrap()));
@@ -443,7 +485,10 @@ mod tests {
 
     #[test]
     fn robots_longest_match_wins() {
-        let rules = RobotsRules::parse("User-agent: *\nAllow: /\nDisallow: /private\nAllow: /private/ok\n");
+        let rules = RobotsRules::parse(
+            "User-agent: *\nAllow: /\nDisallow: /private\nAllow: /private/ok\n",
+            "servo-fetch",
+        );
         assert!(rules.is_allowed(&Url::parse("https://x.com/public").unwrap()));
         assert!(!rules.is_allowed(&Url::parse("https://x.com/private/secret").unwrap()));
         assert!(rules.is_allowed(&Url::parse("https://x.com/private/ok/page").unwrap()));
@@ -451,20 +496,20 @@ mod tests {
 
     #[test]
     fn robots_empty_allows_all() {
-        let rules = RobotsRules::parse("");
+        let rules = RobotsRules::parse("", "servo-fetch");
         assert!(rules.is_allowed(&Url::parse("https://x.com/anything").unwrap()));
     }
 
     #[test]
     fn robots_case_insensitive_directives() {
-        let rules = RobotsRules::parse("USER-AGENT: *\nDISALLOW: /blocked\nALLOW: /blocked/ok\n");
+        let rules = RobotsRules::parse("USER-AGENT: *\nDISALLOW: /blocked\nALLOW: /blocked/ok\n", "servo-fetch");
         assert!(!rules.is_allowed(&Url::parse("https://x.com/blocked/secret").unwrap()));
         assert!(rules.is_allowed(&Url::parse("https://x.com/blocked/ok").unwrap()));
     }
 
     #[test]
     fn robots_wildcard() {
-        let rules = RobotsRules::parse("User-agent: *\nDisallow: /private/*/secret\n");
+        let rules = RobotsRules::parse("User-agent: *\nDisallow: /private/*/secret\n", "servo-fetch");
         assert!(!rules.is_allowed(&Url::parse("https://x.com/private/foo/secret").unwrap()));
         assert!(!rules.is_allowed(&Url::parse("https://x.com/private/bar/baz/secret").unwrap()));
         assert!(rules.is_allowed(&Url::parse("https://x.com/private/foo/public").unwrap()));
@@ -472,7 +517,7 @@ mod tests {
 
     #[test]
     fn robots_dollar_anchor() {
-        let rules = RobotsRules::parse("User-agent: *\nDisallow: /*.pdf$\n");
+        let rules = RobotsRules::parse("User-agent: *\nDisallow: /*.pdf$\n", "servo-fetch");
         assert!(!rules.is_allowed(&Url::parse("https://x.com/doc/report.pdf").unwrap()));
         assert!(rules.is_allowed(&Url::parse("https://x.com/doc/report.pdf/view").unwrap()));
         assert!(rules.is_allowed(&Url::parse("https://x.com/doc/report.html").unwrap()));
@@ -586,5 +631,155 @@ mod tests {
         assert!(!f.is_duplicate_content("unique content"));
         assert!(f.is_duplicate_content("unique content"));
         assert!(!f.is_duplicate_content("different content"));
+    }
+
+    #[test]
+    fn robots_url_preserves_authority_and_drops_userinfo() {
+        let cases = [
+            (
+                "http://u:p@example.com:8080/x?q=1#f",
+                "http://example.com:8080/robots.txt",
+            ),
+            ("http://example.com:80/x", "http://example.com/robots.txt"),
+            ("https://example.com:80/x", "https://example.com:80/robots.txt"),
+            ("https://[2001:db8::1]:8443/", "https://[2001:db8::1]:8443/robots.txt"),
+        ];
+        for (input, expected) in cases {
+            let seed = Url::parse(input).unwrap();
+            assert_eq!(robots_url(&seed).unwrap().as_str(), expected, "input: {input}");
+        }
+    }
+
+    #[test]
+    fn product_token_extracts_leading_identifier() {
+        assert_eq!(product_token("MyBot/1.0"), "MyBot");
+        assert_eq!(product_token("MyBot/1.0 (+https://example.com)"), "MyBot");
+        assert_eq!(product_token("servo-fetch/0.7.1"), "servo-fetch");
+    }
+
+    #[test]
+    fn product_token_falls_back_to_wildcard() {
+        assert_eq!(product_token(""), "*");
+        assert_eq!(product_token("/MyBot"), "*");
+        assert_eq!(product_token("   "), "*");
+    }
+
+    #[test]
+    fn policy_unavailable_allows_all() {
+        assert!(RobotsPolicy::Unavailable.is_allowed(&Url::parse("https://x.com/anything").unwrap()));
+    }
+
+    #[test]
+    fn policy_unreachable_disallows_all() {
+        assert!(!RobotsPolicy::Unreachable.is_allowed(&Url::parse("https://x.com/anything").unwrap()));
+    }
+
+    #[test]
+    fn parse_honors_custom_product_token() {
+        let body = "User-agent: MyBot\nDisallow: /private\nUser-agent: *\nAllow: /\n";
+        let rules = RobotsRules::parse(body, "MyBot");
+        assert!(!rules.is_allowed(&Url::parse("https://x.com/private").unwrap()));
+        assert!(rules.is_allowed(&Url::parse("https://x.com/public").unwrap()));
+    }
+
+    #[test]
+    fn parse_falls_back_to_wildcard_for_unknown_token() {
+        let body = "User-agent: GoogleBot\nDisallow: /google-only\nUser-agent: *\nDisallow: /shared\n";
+        let rules = RobotsRules::parse(body, "MyBot");
+        assert!(rules.is_allowed(&Url::parse("https://x.com/google-only").unwrap()));
+        assert!(!rules.is_allowed(&Url::parse("https://x.com/shared").unwrap()));
+    }
+
+    mod fetch {
+        //! HTTP-level tests for `RobotsRules::fetch`
+        use super::*;
+        use wiremock::matchers::{header, method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        async fn serve(status: u16, body: &str) -> (MockServer, Url) {
+            let server = MockServer::start().await;
+            Mock::given(method("GET"))
+                .and(path("/robots.txt"))
+                .respond_with(ResponseTemplate::new(status).set_body_string(body))
+                .mount(&server)
+                .await;
+            let seed = Url::parse(&server.uri()).unwrap();
+            (server, seed)
+        }
+
+        async fn call(seed: Url, user_agent: Option<&'static str>) -> RobotsPolicy {
+            tokio::task::spawn_blocking(move || RobotsRules::fetch(&seed, user_agent))
+                .await
+                .unwrap()
+        }
+
+        #[tokio::test]
+        async fn ok_parses_rules_for_product_token() {
+            let (_server, seed) = serve(200, "User-agent: MyBot\nDisallow: /private\n").await;
+            let policy = call(seed.clone(), Some("MyBot/1.0")).await;
+            let target = seed.join("/private").unwrap();
+            assert!(!policy.is_allowed(&target));
+            assert!(policy.is_allowed(&seed.join("/public").unwrap()));
+        }
+
+        #[tokio::test]
+        async fn status_404_is_unavailable() {
+            let (_server, seed) = serve(404, "").await;
+            assert!(matches!(call(seed, None).await, RobotsPolicy::Unavailable));
+        }
+
+        #[tokio::test]
+        async fn status_410_is_unavailable() {
+            let (_server, seed) = serve(410, "").await;
+            assert!(matches!(call(seed, None).await, RobotsPolicy::Unavailable));
+        }
+
+        #[tokio::test]
+        async fn status_401_is_unreachable() {
+            let (_server, seed) = serve(401, "").await;
+            assert!(matches!(call(seed, None).await, RobotsPolicy::Unreachable));
+        }
+
+        #[tokio::test]
+        async fn status_403_is_unreachable() {
+            let (_server, seed) = serve(403, "").await;
+            assert!(matches!(call(seed, None).await, RobotsPolicy::Unreachable));
+        }
+
+        #[tokio::test]
+        async fn status_429_is_unreachable() {
+            let (_server, seed) = serve(429, "").await;
+            assert!(matches!(call(seed, None).await, RobotsPolicy::Unreachable));
+        }
+
+        #[tokio::test]
+        async fn status_500_is_unreachable() {
+            let (_server, seed) = serve(500, "").await;
+            assert!(matches!(call(seed, None).await, RobotsPolicy::Unreachable));
+        }
+
+        #[tokio::test]
+        async fn body_exceeding_size_limit_is_unreachable() {
+            // ROBOTS_MAX_BYTES is 512 KiB; send slightly more.
+            let size = usize::try_from(ROBOTS_MAX_BYTES).unwrap() + 1024;
+            let oversized = "a".repeat(size);
+            let (_server, seed) = serve(200, &oversized).await;
+            assert!(matches!(call(seed, None).await, RobotsPolicy::Unreachable));
+        }
+
+        #[tokio::test]
+        async fn sends_caller_provided_user_agent() {
+            let server = MockServer::start().await;
+            Mock::given(method("GET"))
+                .and(path("/robots.txt"))
+                .and(header("user-agent", "CustomBot/9.9"))
+                .respond_with(ResponseTemplate::new(200).set_body_string("User-agent: *\n"))
+                .expect(1)
+                .mount(&server)
+                .await;
+            let seed = Url::parse(&server.uri()).unwrap();
+            let _ = call(seed, Some("CustomBot/9.9")).await;
+            // MockServer verifies `.expect(1)` on drop; a mismatching UA would fail.
+        }
     }
 }


### PR DESCRIPTION
## Summary

The crawl's robots.txt handling had three bugs that hit real sites:

1. **Port was dropped from the robots.txt URL.** `format!("{scheme}://{host}/robots.txt")` ignored the port, so a seed at `https://example.com:8443/` would fetch the wrong authority's robots.txt (or none) and the crawl silently degraded to seed-only.
2. **All non-2xx responses were treated as fail-closed.** A 404 (the common case for sites without a robots.txt) caused every discovered link to be skipped, collapsing crawls to a single page.
3. **The User-Agent used for matching was hardcoded to `servo-fetch`.** Even when the caller set `CrawlOptions::user_agent("MyBot/1.0")`, the `User-agent: MyBot` group in robots.txt was ignored and only `*` applied.

## Test Plan

- `cargo test -p servo-fetch --locked --lib` — 143 passed
- `cargo test -p servo-fetch-cli --locked` — no regressions

## Checklist

- [x] `cargo clippy` passes with zero warnings
- [x] `cargo test` passes
- [x] `cargo fmt --check` passes
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it