### PR TITLE
docs(security): refresh supported versions policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -39,7 +39,4 @@ servo-fetch processes untrusted web content. The following areas are in scope:
 
 ## Supported versions
 
-| Version | Supported   |
-| ------- | ----------- |
-| 0.2.x   | ✅ (0.2.1+) |
-| 0.1.x   | ❌ (yanked) |
+Security fixes are backported only to the latest 0.x minor release line. All earlier releases are considered deprecated; users are encouraged to upgrade to the latest patch version.


### PR DESCRIPTION
## Summary

The "Supported versions" table was stale — it still listed only 0.1.x (yanked) and 0.2.x as the supported line, while the project has shipped through 0.7.x. Instead of updating the row and re-editing it on every minor bump, this replaces the table with a one-line prose policy that stays accurate across future 0.x releases.

## Test Plan

N/A

## Checklist

- [x] `cargo clippy` passes with zero warnings
- [x] `cargo test` passes
- [x] `cargo fmt --check` passes
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it