### PR TITLE
refactor(engine)!: remove unused CrawlStatus from public API

### DIFF
--- a/crates/servo-fetch/src/engine.rs
+++ b/crates/servo-fetch/src/engine.rs
@@ -447,17 +447,6 @@ impl CrawlResult {
     }
 }
 
-/// Status of a crawled page.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
-#[serde(rename_all = "lowercase")]
-#[non_exhaustive]
-pub enum CrawlStatus {
-    /// Page fetched and extracted successfully.
-    Ok,
-    /// Page failed to load or extract.
-    Error,
-}
-
 /// Crawl a site, invoking `on_page` for each result as it arrives.
 #[allow(clippy::needless_pass_by_value)]
 pub fn crawl_each(opts: CrawlOptions, mut on_page: impl FnMut(&CrawlResult)) -> crate::error::Result<()> {

--- a/crates/servo-fetch/src/lib.rs
+++ b/crates/servo-fetch/src/lib.rs
@@ -23,7 +23,7 @@ pub(crate) mod screenshot;
 pub(crate) mod sys;
 
 pub use engine::{
-    ConsoleLevel, ConsoleMessage, CrawlError, CrawlOptions, CrawlPage, CrawlResult, CrawlStatus, FetchOptions, Page,
-    crawl, crawl_each, extract_json, fetch, markdown, text, validate_url,
+    ConsoleLevel, ConsoleMessage, CrawlError, CrawlOptions, CrawlPage, CrawlResult, FetchOptions, Page, crawl,
+    crawl_each, extract_json, fetch, markdown, text, validate_url,
 };
 pub use error::{Error, Result};


### PR DESCRIPTION
## Summary

**Breaking change.** Removes `servo_fetch::CrawlStatus`, a public enum that has been dead since #93 consolidated `CrawlResult` onto `outcome: Result<CrawlPage, CrawlError>`.

### Why it is dead

```rust
pub enum CrawlStatus { Ok, Error }
```

A full-repo grep confirms:

- The public `engine::CrawlStatus` is **never** referenced from `CrawlResult`, `CrawlPage`, `CrawlError`, or any other public item.
- `CrawlResult`'s JSON serialization writes the `"status"` field as hardcoded `"ok"` / `"error"` string literals, not through this enum.
- The only matches on `CrawlStatus` point to an internal `crate::crawl::CrawlStatus` (`pub(crate)`) used as a private intermediate between `crawl::run` and `engine::CrawlResult::from_internal`. That internal enum remains untouched.

## Test Plan

- `cargo test -p servo-fetch --locked --lib` — 143 tests pass
- `cargo test -p servo-fetch --locked --doc`
- `cargo test -p servo-fetch --locked --test extract`
- `cargo test -p servo-fetch-cli --locked`

## Checklist

- [x] Breaking change, flagged with `!` in the commit subject per Conventional Commits
- [x] No downstream code references the removed symbol (verified via full-repo grep)
- [x] Internal `pub(crate)` `CrawlStatus` and the `from_internal` conversion remain intact
- [x] Bundles naturally with #112 into the 0.8.0 minor bump