### PR TITLE
fix(cli): flush stderr on progress clear to prevent output interleaving

### DIFF
--- a/crates/servo-fetch-cli/src/progress.rs
+++ b/crates/servo-fetch-cli/src/progress.rs
@@ -30,7 +30,9 @@ impl Progress {
 
     pub(crate) fn clear(&self) {
         if self.is_tty {
-            let _ = write!(std::io::stderr(), "\r\x1b[K");
+            let mut err = std::io::stderr();
+            let _ = write!(err, "\r\x1b[2K");
+            let _ = err.flush();
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes a race condition where the "Fetching …" progress line bleeds into stdout output when piped (e.g. `servo-fetch … --json | jq`).

`progress.clear()` wrote `\r\x1b[K` to stderr without flushing. When stdout output reached the terminal before the stderr escape sequence, the result was garbled:

```
Fetching https://servo.org...{
  "title": "..."
```

Two changes to `Progress::clear()`:

1. `\x1b[K` → `\x1b[2K` — erase the entire line (not just cursor-to-end), more robust when cursor position is uncertain.
2. Added `flush()` — ensures the erase sequence reaches the terminal before any subsequent stdout write.

## Test Plan

- `cargo test -p servo-fetch --locked --lib`
- `cargo test -p servo-fetch-cli --locked`
- Manual: `./target/release/servo-fetch https://servo.org --json | jq '{title, url}'` — no interleaved "Fetching" line visible

## Checklist

- [x] `cargo clippy` passes with zero warnings
- [x] `cargo test` passes
- [x] `cargo fmt --check` passes
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it