### PR TITLE
fix(extract): return error on invalid CSS selector instead of crashing

### DIFF
--- a/crates/servo-fetch/src/engine.rs
+++ b/crates/servo-fetch/src/engine.rs
@@ -713,6 +713,16 @@ mod tests {
     }
 
     #[test]
+    fn page_markdown_with_invalid_selector_returns_error() {
+        let page = Page {
+            html: "<html><body><p>x</p></body></html>".into(),
+            ..Page::default()
+        };
+        let err = page.markdown_with_selector("", "###invalid[[[").unwrap_err();
+        assert!(err.to_string().contains("invalid CSS selector"));
+    }
+
+    #[test]
     fn fetch_rejects_invalid_url() {
         let result = fetch(FetchOptions::new("not a url"));
         assert!(result.is_err());

--- a/crates/servo-fetch/src/extract.rs
+++ b/crates/servo-fetch/src/extract.rs
@@ -20,6 +20,9 @@ pub enum ExtractError {
     /// Failed to serialize JSON output.
     #[error("JSON serialization failed")]
     Json(#[from] serde_json::Error),
+    /// The provided CSS selector is invalid.
+    #[error("invalid CSS selector")]
+    InvalidSelector,
 }
 
 /// Structured article data for JSON output.
@@ -114,7 +117,7 @@ impl<'a> ExtractInput<'a> {
 /// Returns [`ExtractError::Fmt`] if Markdown assembly fails.
 pub fn extract_text(input: &ExtractInput<'_>) -> Result<String, ExtractError> {
     if let Some(selector) = input.selector {
-        return Ok(extract_by_selector(input.html, input.layout_json, selector));
+        return extract_by_selector(input.html, input.layout_json, selector);
     }
     let article = parse_article(input.html, input.url, input.layout_json, input.inner_text);
 
@@ -138,7 +141,7 @@ pub fn extract_text(input: &ExtractInput<'_>) -> Result<String, ExtractError> {
 /// Returns [`ExtractError::Json`] if JSON serialization fails.
 pub fn extract_json(input: &ExtractInput<'_>) -> Result<String, ExtractError> {
     if let Some(selector) = input.selector {
-        let text = extract_by_selector(input.html, input.layout_json, selector);
+        let text = extract_by_selector(input.html, input.layout_json, selector)?;
         let data = ArticleData {
             title: String::new(),
             content: String::new(),
@@ -220,19 +223,20 @@ fn parse_article(html: &str, url: &str, layout_json: Option<&str>, inner_text: O
     }
 }
 
-fn extract_by_selector(html: &str, layout_json: Option<&str>, selector: &str) -> String {
+fn extract_by_selector(html: &str, layout_json: Option<&str>, selector: &str) -> Result<String, ExtractError> {
+    let matcher = dom_query::Matcher::new(selector).map_err(|_| ExtractError::InvalidSelector)?;
     let filtered = filter(html, layout_json);
     let doc = Document::from(filtered.as_ref());
-    let selected = doc.select(selector);
+    let selected = doc.select_matcher(&matcher);
     let fragment = selected.html();
     if fragment.is_empty() {
-        return String::new();
+        return Ok(String::new());
     }
     let converter = HtmlToMarkdown::builder().skip_tags(vec!["script", "style"]).build();
     let markdown = converter
         .convert(&fragment)
         .unwrap_or_else(|_| selected.text().to_string());
-    clean_markdown(&markdown)
+    Ok(clean_markdown(&markdown))
 }
 
 fn filter<'a>(html: &'a str, layout_json: Option<&str>) -> Cow<'a, str> {

--- a/crates/servo-fetch/tests/extract.rs
+++ b/crates/servo-fetch/tests/extract.rs
@@ -107,6 +107,15 @@ fn selector_no_match_returns_empty() {
 }
 
 #[test]
+fn invalid_selector_returns_error() {
+    let html = fixture("simple.html");
+    let mut input = input(&html);
+    input.selector = Some("###invalid[[[");
+    let err = extract::extract_text(&input).unwrap_err();
+    assert!(err.to_string().contains("invalid CSS selector"));
+}
+
+#[test]
 fn extract_json_selector_includes_url() {
     let html = fixture("article.html");
     let input = ExtractInput::new(&html, "https://example.com/page").with_selector(Some("article"));


### PR DESCRIPTION
## Summary

Fixes a SEGFAULT (exit 139) when an invalid CSS selector is passed via `--selector`. Before this fix, `servo-fetch https://example.com --selector "###invalid[[["` crashed the process.

### Root cause

`extract_by_selector` called `dom_query::Document::select(selector)` which panics on parse failure (documented behavior). In the Servo runtime, panics trigger `mozalloc_abort` → SIGSEGV.

## Test Plan

- `cargo test -p servo-fetch --locked --lib` — 147 tests (was 146, +1)
- `cargo test -p servo-fetch --locked --test extract` — 15 tests (was 14, +1)
- `cargo test -p servo-fetch --locked --doc`
- `cargo test -p servo-fetch-cli --locked`
- Manual: `servo-fetch https://example.com --selector "###invalid[[["` → `ERROR invalid CSS selector` (exit 1, no crash)

## Checklist

- [x] `cargo clippy` passes with zero warnings
- [x] `cargo test` passes
- [x] `cargo fmt --check` passes
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it