### PR TITLE
fix(cli): reject empty --selector at argument parsing

### DIFF
--- a/crates/servo-fetch-cli/src/cli.rs
+++ b/crates/servo-fetch-cli/src/cli.rs
@@ -55,7 +55,7 @@ pub(crate) struct FetchArgs {
     pub settle: u64,
 
     /// CSS selector to extract a specific section
-    #[arg(long, value_name = "CSS")]
+    #[arg(long, value_name = "CSS", value_parser = clap::builder::NonEmptyStringValueParser::new())]
     pub selector: Option<String>,
 
     /// Output raw HTML or plain text instead of Readability extraction
@@ -118,7 +118,7 @@ pub(crate) struct CrawlArgs {
     pub json: bool,
 
     /// CSS selector to extract a specific section per page
-    #[arg(long, value_name = "CSS")]
+    #[arg(long, value_name = "CSS", value_parser = clap::builder::NonEmptyStringValueParser::new())]
     pub selector: Option<String>,
 
     /// Timeout in seconds per page

--- a/crates/servo-fetch/src/engine.rs
+++ b/crates/servo-fetch/src/engine.rs
@@ -723,6 +723,15 @@ mod tests {
     }
 
     #[test]
+    fn page_markdown_with_empty_selector_returns_error() {
+        let page = Page {
+            html: "<html><body><p>x</p></body></html>".into(),
+            ..Page::default()
+        };
+        assert!(page.markdown_with_selector("", "").is_err());
+    }
+
+    #[test]
     fn fetch_rejects_invalid_url() {
         let result = fetch(FetchOptions::new("not a url"));
         assert!(result.is_err());


### PR DESCRIPTION
## Summary

Reject empty `--selector` at argument parsing.

## Test Plan

- `cargo test -p servo-fetch --locked --lib` — 148 tests
- `cargo test -p servo-fetch-cli --locked`
- Manual: `servo-fetch https://example.com --selector ""` → clap error (exit 2)

## Checklist

- [x] `cargo clippy` passes with zero warnings
- [x] `cargo test` passes
- [x] `cargo fmt --check` passes
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it