### PR TITLE
feat(map): add URL discovery via sitemaps without rendering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5218,6 +5218,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
+name = "quick-xml"
+version = "0.39.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "721da970c312655cde9b4ffe0547f20a8494866a4af5ff51f18b7c633d0c870b"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "quick_cache"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6479,6 +6488,7 @@ dependencies = [
  "dom_smoothie",
  "dpi",
  "euclid 0.22.14",
+ "flate2",
  "globset",
  "htmd",
  "image",
@@ -6486,6 +6496,7 @@ dependencies = [
  "os_pipe",
  "pdf-extract",
  "psl",
+ "quick-xml",
  "rustls",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,8 @@ tokio = { version = "1", features = ["rt-multi-thread"] }
 tracing = "0.1"
 url = "2"
 ureq = "3"
+quick-xml = "0.39"
+flate2 = "1"
 
 [workspace.lints.rust]
 missing_docs = "warn"

--- a/crates/servo-fetch-cli/src/cli.rs
+++ b/crates/servo-fetch-cli/src/cli.rs
@@ -83,6 +83,8 @@ pub(crate) enum Command {
     Mcp(McpArgs),
     /// Crawl a website by following links (BFS). Respects robots.txt.
     Crawl(CrawlArgs),
+    /// Discover URLs on a site via sitemaps (no rendering).
+    Map(MapArgs),
 }
 
 #[derive(clap::Args, Debug)]
@@ -132,6 +134,40 @@ pub(crate) struct CrawlArgs {
     /// Override the User-Agent string
     #[arg(long, value_name = "UA")]
     pub user_agent: Option<String>,
+}
+
+#[derive(clap::Args, Debug)]
+pub(crate) struct MapArgs {
+    /// Starting URL to discover links from
+    pub url: String,
+
+    /// Maximum number of URLs to discover
+    #[arg(long, default_value_t = 5000, value_name = "N")]
+    pub limit: usize,
+
+    /// URL path glob patterns to include (e.g. "/docs/**")
+    #[arg(long, value_name = "GLOB")]
+    pub include: Vec<String>,
+
+    /// URL path glob patterns to exclude (e.g. "/docs/archive/**")
+    #[arg(long, value_name = "GLOB")]
+    pub exclude: Vec<String>,
+
+    /// Output as JSON array with metadata
+    #[arg(long)]
+    pub json: bool,
+
+    /// Skip HTML link fallback if no sitemap is found
+    #[arg(long)]
+    pub no_fallback: bool,
+
+    /// Override the User-Agent string
+    #[arg(long, value_name = "UA")]
+    pub user_agent: Option<String>,
+
+    /// Timeout in seconds per HTTP request
+    #[arg(short = 't', long, default_value_t = 30, value_parser = clap::value_parser!(u64).range(1..), value_name = "SECS")]
+    pub timeout: u64,
 }
 
 #[cfg(test)]

--- a/crates/servo-fetch-cli/src/commands.rs
+++ b/crates/servo-fetch-cli/src/commands.rs
@@ -1,3 +1,4 @@
 pub(crate) mod crawl;
 pub(crate) mod fetch;
+pub(crate) mod map;
 pub(crate) mod mcp;

--- a/crates/servo-fetch-cli/src/commands/map.rs
+++ b/crates/servo-fetch-cli/src/commands/map.rs
@@ -1,0 +1,35 @@
+//! Map subcommand — URL discovery via sitemaps.
+
+use std::io::{self, Write as _};
+
+use crate::cli::MapArgs;
+
+/// Discover URLs on a site and stream them to stdout.
+pub(crate) fn run(args: &MapArgs) -> anyhow::Result<()> {
+    let mut opts = servo_fetch::MapOptions::new(&args.url)
+        .limit(args.limit)
+        .timeout(args.timeout)
+        .no_fallback(args.no_fallback);
+    if !args.include.is_empty() {
+        opts = opts.include(&args.include.iter().map(String::as_str).collect::<Vec<_>>());
+    }
+    if !args.exclude.is_empty() {
+        opts = opts.exclude(&args.exclude.iter().map(String::as_str).collect::<Vec<_>>());
+    }
+    if let Some(ref ua) = args.user_agent {
+        opts = opts.user_agent(ua);
+    }
+
+    let results = servo_fetch::map(opts)?;
+
+    let mut out = io::stdout().lock();
+    if args.json {
+        let json = serde_json::to_string_pretty(&results)?;
+        writeln!(out, "{json}")?;
+    } else {
+        for entry in &results {
+            writeln!(out, "{}", entry.url)?;
+        }
+    }
+    Ok(())
+}

--- a/crates/servo-fetch-cli/src/main.rs
+++ b/crates/servo-fetch-cli/src/main.rs
@@ -28,6 +28,7 @@ fn dispatch(args: &Cli) -> anyhow::Result<()> {
     match &args.command {
         Some(Command::Mcp(mcp)) => commands::mcp::run(mcp),
         Some(Command::Crawl(crawl)) => commands::crawl::run(crawl),
+        Some(Command::Map(map)) => commands::map::run(map),
         None => commands::fetch::run(&args.fetch),
     }
 }

--- a/crates/servo-fetch-cli/src/mcp/params.rs
+++ b/crates/servo-fetch-cli/src/mcp/params.rs
@@ -106,6 +106,18 @@ pub(super) struct CrawlParams {
     pub selector: Option<String>,
 }
 
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub(super) struct MapParams {
+    #[schemars(description = "URL to discover links from (http/https only)")]
+    pub url: String,
+    #[schemars(description = "Maximum URLs to discover. Default: 5000. Max: 100000.")]
+    pub limit: Option<usize>,
+    #[schemars(description = "URL path glob patterns to include (e.g. [\"/docs/**\"])")]
+    pub include_glob: Option<Vec<String>>,
+    #[schemars(description = "URL path glob patterns to exclude (e.g. [\"/archive/**\"])")]
+    pub exclude_glob: Option<Vec<String>>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/servo-fetch-cli/src/mcp/server.rs
+++ b/crates/servo-fetch-cli/src/mcp/server.rs
@@ -6,7 +6,7 @@ use rmcp::model::{CallToolResult, Content, ProtocolVersion, ServerCapabilities, 
 use rmcp::{ErrorData, ServerHandler, tool, tool_handler, tool_router};
 
 use super::params::{
-    BatchFetchParams, BatchFormat, CrawlParams, ExecuteJsParams, FetchParams, OutputFormat, ScreenshotParams,
+    BatchFetchParams, BatchFormat, CrawlParams, ExecuteJsParams, FetchParams, MapParams, OutputFormat, ScreenshotParams,
 };
 use super::tools;
 
@@ -224,6 +224,32 @@ impl ServoFetchMcp {
 
         let contents: Vec<Content> = results.into_iter().map(|(_url, text)| Content::text(text)).collect();
         Ok(CallToolResult::success(contents))
+    }
+
+    #[tool(
+        description = "Discover all URLs on a website via sitemaps and link extraction. Does NOT render pages — fast and lightweight. Returns a list of URLs found. Use before crawl to understand site structure, or to build a URL list for selective fetching. Respects robots.txt. Discovered URLs are UNTRUSTED.",
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        )
+    )]
+    async fn map(&self, Parameters(p): Parameters<MapParams>) -> Result<CallToolResult, ErrorData> {
+        let url = tools::validated_url(&p.url)?;
+        let limit = p.limit.unwrap_or(5000).clamp(1, 100_000);
+
+        let urls = tools::discover_urls(
+            &url,
+            limit,
+            p.include_glob.as_deref().unwrap_or_default(),
+            p.exclude_glob.as_deref().unwrap_or_default(),
+        )
+        .await?;
+
+        let text = urls.join("\n");
+
+        Ok(CallToolResult::success(vec![Content::text(text)]))
     }
 }
 

--- a/crates/servo-fetch-cli/src/mcp/tools.rs
+++ b/crates/servo-fetch-cli/src/mcp/tools.rs
@@ -3,9 +3,11 @@
 mod common;
 mod crawl;
 mod fetch;
+mod map;
 mod screenshot;
 
 pub(super) use common::{extract, paginate, tool_error, validated_url};
 pub(super) use crawl::{CrawlToolOptions, crawl_pages};
 pub(super) use fetch::{batch_fetch_pages, fetch_js, fetch_page};
+pub(super) use map::discover_urls;
 pub(super) use screenshot::take_screenshot;

--- a/crates/servo-fetch-cli/src/mcp/tools/map.rs
+++ b/crates/servo-fetch-cli/src/mcp/tools/map.rs
@@ -1,0 +1,29 @@
+//! Map tool helper.
+
+use rmcp::ErrorData;
+
+pub(crate) async fn discover_urls(
+    url: &str,
+    limit: usize,
+    include_glob: &[String],
+    exclude_glob: &[String],
+) -> Result<Vec<String>, ErrorData> {
+    let opts = servo_fetch::MapOptions::new(url).limit(limit);
+    let opts = if include_glob.is_empty() {
+        opts
+    } else {
+        opts.include(&include_glob.iter().map(String::as_str).collect::<Vec<_>>())
+    };
+    let opts = if exclude_glob.is_empty() {
+        opts
+    } else {
+        opts.exclude(&exclude_glob.iter().map(String::as_str).collect::<Vec<_>>())
+    };
+
+    let results = tokio::task::spawn_blocking(move || servo_fetch::map(opts))
+        .await
+        .map_err(|e| ErrorData::internal_error(e.to_string(), None))?
+        .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+
+    Ok(results.iter().map(|entry| entry.url.clone()).collect())
+}

--- a/crates/servo-fetch-cli/tests/mcp.rs
+++ b/crates/servo-fetch-cli/tests/mcp.rs
@@ -31,13 +31,14 @@ async fn list_tools_returns_expected_tools() {
     let client = connect().await;
     let tools = client.list_tools(None).await.unwrap();
 
-    assert_eq!(tools.tools.len(), 5);
+    assert_eq!(tools.tools.len(), 6);
     let names: Vec<&str> = tools.tools.iter().map(|t| t.name.as_ref()).collect();
     assert!(names.contains(&"fetch"));
     assert!(names.contains(&"batch_fetch"));
     assert!(names.contains(&"screenshot"));
     assert!(names.contains(&"execute_js"));
     assert!(names.contains(&"crawl"));
+    assert!(names.contains(&"map"));
 }
 
 #[tokio::test]

--- a/crates/servo-fetch/Cargo.toml
+++ b/crates/servo-fetch/Cargo.toml
@@ -32,6 +32,8 @@ tokio = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }
 ureq = { workspace = true }
+quick-xml = { workspace = true }
+flate2 = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/crates/servo-fetch/src/crawl.rs
+++ b/crates/servo-fetch/src/crawl.rs
@@ -91,13 +91,13 @@ impl Frontier {
     }
 }
 
-fn normalize_url(url: &Url) -> String {
+pub(crate) fn normalize_url(url: &Url) -> String {
     let mut u = url.clone();
     u.set_fragment(None);
     u.to_string()
 }
 
-fn is_same_site(seed: &Url, candidate: &Url) -> bool {
+pub(crate) fn is_same_site(seed: &Url, candidate: &Url) -> bool {
     match (registrable_domain(seed), registrable_domain(candidate)) {
         (Some(a), Some(b)) => a == b,
         _ => seed.host_str() == candidate.host_str(),
@@ -110,7 +110,7 @@ fn registrable_domain(url: &Url) -> Option<String> {
     Some(std::str::from_utf8(domain.as_bytes()).ok()?.to_string())
 }
 
-fn matches_scope(url: &Url, include: Option<&GlobSet>, exclude: Option<&GlobSet>) -> bool {
+pub(crate) fn matches_scope(url: &Url, include: Option<&GlobSet>, exclude: Option<&GlobSet>) -> bool {
     let path = url.path();
     if let Some(exc) = exclude {
         if exc.is_match(path) {
@@ -124,12 +124,12 @@ fn matches_scope(url: &Url, include: Option<&GlobSet>, exclude: Option<&GlobSet>
 }
 
 /// Build a `GlobSet` from user-provided patterns.
-pub(crate) fn build_globset(patterns: &[String]) -> anyhow::Result<GlobSet> {
+pub(crate) fn build_globset(patterns: &[String]) -> Result<GlobSet, globset::Error> {
     let mut builder = GlobSetBuilder::new();
     for p in patterns {
         builder.add(Glob::new(p)?);
     }
-    Ok(builder.build()?)
+    builder.build()
 }
 
 fn strip_directive<'a>(line: &'a str, directive: &str) -> Option<&'a str> {
@@ -157,7 +157,7 @@ fn product_token(user_agent: &str) -> &str {
 }
 
 /// Outcome of `RobotsRules::fetch`.
-enum RobotsPolicy {
+pub(crate) enum RobotsPolicy {
     Rules(RobotsRules),
     /// 4xx other than 401/403 — treat as no restrictions.
     Unavailable,
@@ -166,7 +166,7 @@ enum RobotsPolicy {
 }
 
 impl RobotsPolicy {
-    fn is_allowed(&self, url: &Url) -> bool {
+    pub(crate) fn is_allowed(&self, url: &Url) -> bool {
         match self {
             Self::Rules(r) => r.is_allowed(url),
             Self::Unavailable => true,
@@ -175,12 +175,13 @@ impl RobotsPolicy {
     }
 }
 
-struct RobotsRules {
-    rules: Vec<(bool, String)>,
+pub(crate) struct RobotsRules {
+    pub(crate) rules: Vec<(bool, String)>,
+    pub(crate) sitemaps: Vec<Url>,
 }
 
 impl RobotsRules {
-    fn fetch(seed: &Url, user_agent: Option<&str>) -> RobotsPolicy {
+    pub(crate) fn fetch(seed: &Url, user_agent: Option<&str>) -> RobotsPolicy {
         let Some(url) = robots_url(seed) else {
             return RobotsPolicy::Unreachable;
         };
@@ -209,10 +210,17 @@ impl RobotsRules {
 
     fn parse(body: &str, product_token: &str) -> Self {
         let mut rules = Vec::new();
+        let mut sitemaps = Vec::new();
         let mut in_matching_agent = false;
         for line in body.lines() {
             let line = line.split('#').next().unwrap_or("").trim();
             if line.is_empty() {
+                continue;
+            }
+            if let Some(val) = strip_directive(line, "sitemap") {
+                if let Ok(url) = Url::parse(val.trim()) {
+                    sitemaps.push(url);
+                }
                 continue;
             }
             if let Some(agent) = strip_directive(line, "user-agent") {
@@ -228,7 +236,7 @@ impl RobotsRules {
                 }
             }
         }
-        Self { rules }
+        Self { rules, sitemaps }
     }
 
     fn is_allowed(&self, url: &Url) -> bool {

--- a/crates/servo-fetch/src/engine.rs
+++ b/crates/servo-fetch/src/engine.rs
@@ -485,6 +485,122 @@ pub fn crawl(opts: CrawlOptions) -> crate::error::Result<Vec<CrawlResult>> {
     Ok(results)
 }
 
+/// Options for URL discovery (sitemap + link extraction, no rendering).
+#[must_use = "options do nothing until passed to map()"]
+#[derive(Debug, Clone)]
+pub struct MapOptions {
+    url: String,
+    limit: usize,
+    include: Vec<String>,
+    exclude: Vec<String>,
+    user_agent: Option<String>,
+    timeout: u64,
+    no_fallback: bool,
+}
+
+impl MapOptions {
+    /// Create map options for the given URL.
+    pub fn new(url: impl Into<String>) -> Self {
+        Self {
+            url: url.into(),
+            limit: 5000,
+            include: Vec::new(),
+            exclude: Vec::new(),
+            user_agent: None,
+            timeout: 30,
+            no_fallback: false,
+        }
+    }
+
+    /// Maximum number of URLs to discover.
+    pub fn limit(mut self, n: usize) -> Self {
+        self.limit = n;
+        self
+    }
+
+    /// URL path glob patterns to include.
+    pub fn include(mut self, patterns: &[&str]) -> Self {
+        self.include = patterns.iter().map(|s| (*s).to_string()).collect();
+        self
+    }
+
+    /// URL path glob patterns to exclude.
+    pub fn exclude(mut self, patterns: &[&str]) -> Self {
+        self.exclude = patterns.iter().map(|s| (*s).to_string()).collect();
+        self
+    }
+
+    /// Override the User-Agent string.
+    pub fn user_agent(mut self, ua: impl Into<String>) -> Self {
+        self.user_agent = Some(ua.into());
+        self
+    }
+
+    /// Timeout in seconds per HTTP request.
+    pub fn timeout(mut self, secs: u64) -> Self {
+        self.timeout = secs;
+        self
+    }
+
+    /// Skip HTML link fallback if no sitemap is found.
+    pub fn no_fallback(mut self, yes: bool) -> Self {
+        self.no_fallback = yes;
+        self
+    }
+}
+
+/// A discovered URL from sitemap or link extraction.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct MappedUrl {
+    /// The discovered URL.
+    pub url: String,
+    /// Last modification date from sitemap, if available.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lastmod: Option<String>,
+}
+
+/// Discover URLs on a site via sitemaps and link extraction (no rendering).
+#[allow(clippy::needless_pass_by_value)]
+pub fn map(opts: MapOptions) -> crate::error::Result<Vec<MappedUrl>> {
+    ensure_crypto_provider();
+    let seed = url::Url::parse(&opts.url).map_err(|e| Error::InvalidUrl {
+        url: opts.url.clone(),
+        reason: e.to_string(),
+    })?;
+    crate::net::validate_url(seed.as_str()).map_err(|e| map_url_error(&opts.url, e))?;
+
+    let include = if opts.include.is_empty() {
+        None
+    } else {
+        Some(crate::crawl::build_globset(&opts.include)?)
+    };
+    let exclude = if opts.exclude.is_empty() {
+        None
+    } else {
+        Some(crate::crawl::build_globset(&opts.exclude)?)
+    };
+
+    let internal = crate::map::MapConfig {
+        seed,
+        limit: opts.limit,
+        include,
+        exclude,
+        user_agent: opts.user_agent,
+        timeout: Duration::from_secs(opts.timeout),
+        no_fallback: opts.no_fallback,
+    };
+
+    let mut results = Vec::new();
+    crate::runtime::block_on(crate::map::run(&internal, |entry| {
+        results.push(MappedUrl {
+            url: entry.url.clone(),
+            lastmod: entry.lastmod.clone(),
+        });
+    }))
+    .map_err(|e| Error::Engine(e.to_string()))?;
+    Ok(results)
+}
+
 /// Fetch a URL and return readable Markdown.
 pub fn markdown(url: &str) -> crate::error::Result<String> {
     fetch(FetchOptions::new(url))?.markdown_with_url(url)
@@ -533,12 +649,12 @@ fn build_crawl_options(opts: &CrawlOptions) -> crate::error::Result<crate::crawl
     let include = if opts.include.is_empty() {
         None
     } else {
-        Some(crate::crawl::build_globset(&opts.include).map_err(|e| Error::Engine(e.to_string()))?)
+        Some(crate::crawl::build_globset(&opts.include)?)
     };
     let exclude = if opts.exclude.is_empty() {
         None
     } else {
-        Some(crate::crawl::build_globset(&opts.exclude).map_err(|e| Error::Engine(e.to_string()))?)
+        Some(crate::crawl::build_globset(&opts.exclude)?)
     };
     Ok(crate::crawl::CrawlOptions {
         seed,

--- a/crates/servo-fetch/src/lib.rs
+++ b/crates/servo-fetch/src/lib.rs
@@ -16,6 +16,7 @@ pub(crate) mod crawl;
 pub(crate) mod engine;
 pub(crate) mod error;
 pub(crate) mod layout;
+pub(crate) mod map;
 pub(crate) mod net;
 pub(crate) mod pdf;
 pub(crate) mod runtime;
@@ -23,7 +24,7 @@ pub(crate) mod screenshot;
 pub(crate) mod sys;
 
 pub use engine::{
-    ConsoleLevel, ConsoleMessage, CrawlError, CrawlOptions, CrawlPage, CrawlResult, FetchOptions, Page, crawl,
-    crawl_each, extract_json, fetch, markdown, text, validate_url,
+    ConsoleLevel, ConsoleMessage, CrawlError, CrawlOptions, CrawlPage, CrawlResult, FetchOptions, MapOptions,
+    MappedUrl, Page, crawl, crawl_each, extract_json, fetch, map, markdown, text, validate_url,
 };
 pub use error::{Error, Result};

--- a/crates/servo-fetch/src/map.rs
+++ b/crates/servo-fetch/src/map.rs
@@ -1,0 +1,768 @@
+//! URL discovery via sitemap parsing — no rendering required.
+
+use std::collections::{HashSet, VecDeque};
+use std::io::Read as _;
+use std::time::{Duration, Instant};
+
+use url::Url;
+
+use crate::bridge;
+use crate::crawl::{RobotsPolicy, RobotsRules};
+use crate::crawl::{is_same_site, matches_scope, normalize_url};
+use crate::net;
+
+const MAP_SITEMAP_MAX_BYTES: u64 = 50 * 1024 * 1024;
+const MAP_SITEMAP_MAX_DECOMPRESSED: u64 = 10 * 1024 * 1024;
+const MAP_GZIP_MAX_RATIO: u64 = 100;
+const MAP_HTML_MAX_BYTES: u64 = 2 * 1024 * 1024;
+const MAP_MAX_REDIRECTS: u8 = 5;
+const MAP_MAX_SITEMAPS: usize = 200;
+const MAP_MAX_INDEX_DEPTH: u8 = 5;
+const MAP_MIN_FETCH_INTERVAL: Duration = Duration::from_millis(500);
+const MAP_URL_MAX_LEN: usize = 2048;
+const HTML_SNIFF_LEN: usize = 100;
+
+/// Options for URL discovery.
+pub(crate) struct MapConfig {
+    pub seed: Url,
+    pub limit: usize,
+    pub include: Option<globset::GlobSet>,
+    pub exclude: Option<globset::GlobSet>,
+    pub user_agent: Option<String>,
+    pub timeout: Duration,
+    pub no_fallback: bool,
+}
+
+/// A discovered URL with optional metadata.
+#[derive(serde::Serialize)]
+pub(crate) struct MapEntry {
+    pub url: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lastmod: Option<String>,
+}
+
+/// Run URL discovery for a site.
+pub(crate) async fn run(opts: &MapConfig, mut on_url: impl FnMut(&MapEntry)) {
+    let ua = opts
+        .user_agent
+        .as_deref()
+        .unwrap_or_else(|| bridge::default_user_agent());
+    let agent = build_agent(ua, opts.timeout);
+
+    let robots = {
+        let seed = opts.seed.clone();
+        let user_agent = opts.user_agent.clone();
+        tokio::task::spawn_blocking(move || RobotsRules::fetch(&seed, user_agent.as_deref()))
+            .await
+            .unwrap_or(RobotsPolicy::Unreachable)
+    };
+
+    let mut visited = HashSet::new();
+    let mut count = 0;
+    let mut last_fetch = Instant::now()
+        .checked_sub(MAP_MIN_FETCH_INTERVAL)
+        .unwrap_or_else(Instant::now);
+    let mut sitemap_queue: VecDeque<(Url, u8)> = discover_sitemaps(&robots, &opts.seed)
+        .into_iter()
+        .map(|u| (u, 0))
+        .collect();
+    let mut sitemaps_fetched = 0;
+
+    while let Some((sitemap_url, depth)) = sitemap_queue.pop_front() {
+        if sitemaps_fetched >= MAP_MAX_SITEMAPS || count >= opts.limit {
+            break;
+        }
+        if depth > MAP_MAX_INDEX_DEPTH
+            || !is_same_site(&opts.seed, &sitemap_url)
+            || net::validate_url(sitemap_url.as_str()).is_err()
+        {
+            continue;
+        }
+
+        throttle(&mut last_fetch).await;
+        sitemaps_fetched += 1;
+
+        let body = {
+            let agent = agent.clone();
+            tokio::task::spawn_blocking({
+                let seed = opts.seed.clone();
+                move || fetch_sitemap(&agent, &sitemap_url, &seed)
+            })
+            .await
+            .ok()
+            .flatten()
+        };
+        let Some(body) = body else { continue };
+
+        for entry in parse_sitemap(&body) {
+            match entry {
+                SitemapEntry::Url { loc, lastmod } => {
+                    if count >= opts.limit {
+                        break;
+                    }
+                    if let Some(e) = validate_entry(&loc, lastmod, &opts.seed, &robots, opts, &mut visited) {
+                        on_url(&e);
+                        count += 1;
+                    }
+                }
+                SitemapEntry::Sitemap { loc } => {
+                    if let Ok(url) = Url::parse(&loc) {
+                        sitemap_queue.push_back((url, depth + 1));
+                    }
+                }
+            }
+        }
+    }
+
+    if count == 0 && !opts.no_fallback {
+        throttle(&mut last_fetch).await;
+        let html = {
+            let agent = agent.clone();
+            let seed = opts.seed.clone();
+            tokio::task::spawn_blocking(move || fetch_html(&agent, &seed))
+                .await
+                .ok()
+                .flatten()
+        };
+        if let Some(html) = html {
+            for link in extract_links(&html, &opts.seed) {
+                if count >= opts.limit {
+                    break;
+                }
+                if let Some(e) = validate_entry(link.as_str(), None, &opts.seed, &robots, opts, &mut visited) {
+                    on_url(&e);
+                    count += 1;
+                }
+            }
+        }
+    }
+}
+
+fn discover_sitemaps(robots: &RobotsPolicy, seed: &Url) -> Vec<Url> {
+    let mut urls = Vec::new();
+    if let RobotsPolicy::Rules(rules) = robots {
+        urls.extend(rules.sitemaps.iter().cloned());
+    }
+    if let Ok(default) = seed.join("/sitemap.xml") {
+        if !urls.contains(&default) {
+            urls.push(default);
+        }
+    }
+    urls
+}
+
+fn build_agent(ua: &str, timeout: Duration) -> ureq::Agent {
+    ureq::Agent::new_with_config(
+        ureq::config::Config::builder()
+            .max_redirects(0)
+            .http_status_as_error(false)
+            .timeout_global(Some(timeout))
+            .user_agent(ua)
+            .build(),
+    )
+}
+
+fn fetch_following_redirects(agent: &ureq::Agent, url: &Url, seed: &Url) -> Option<ureq::http::Response<ureq::Body>> {
+    let mut current = url.clone();
+    for _ in 0..MAP_MAX_REDIRECTS {
+        let resp = agent.get(current.as_str()).call().ok()?;
+        let status = resp.status().as_u16();
+        if matches!(status, 301 | 302 | 303 | 307 | 308) {
+            let location = resp.headers().get("location")?.to_str().ok()?;
+            let next = current.join(location).ok()?;
+            if net::validate_url(next.as_str()).is_err() || !is_same_site(seed, &next) {
+                return None;
+            }
+            current = next;
+            continue;
+        }
+        if status >= 400 {
+            return None;
+        }
+        return Some(resp);
+    }
+    None
+}
+
+fn fetch_sitemap(agent: &ureq::Agent, url: &Url, seed: &Url) -> Option<String> {
+    let resp = fetch_following_redirects(agent, url, seed)?;
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+
+    let is_gzip = url
+        .path()
+        .rsplit('/')
+        .next()
+        .and_then(|seg| std::path::Path::new(seg).extension())
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("gz"))
+        || content_type.contains("gzip")
+        || resp
+            .headers()
+            .get("content-encoding")
+            .and_then(|v| v.to_str().ok())
+            .is_some_and(|v| v.contains("gzip"));
+
+    if is_gzip {
+        let bytes = resp
+            .into_body()
+            .with_config()
+            .limit(MAP_SITEMAP_MAX_BYTES)
+            .read_to_vec()
+            .ok()?;
+        let mut decoded = Vec::new();
+        flate2::read::GzDecoder::new(bytes.as_slice())
+            .take(MAP_SITEMAP_MAX_DECOMPRESSED)
+            .read_to_end(&mut decoded)
+            .ok()?;
+        if decoded.len() as u64 > bytes.len() as u64 * MAP_GZIP_MAX_RATIO {
+            return None;
+        }
+        if looks_like_html(&decoded) {
+            return None;
+        }
+        String::from_utf8(decoded).ok()
+    } else {
+        let body = resp
+            .into_body()
+            .with_config()
+            .limit(MAP_SITEMAP_MAX_BYTES)
+            .read_to_string()
+            .ok()?;
+        if looks_like_html(body.as_bytes()) {
+            return None;
+        }
+        Some(body)
+    }
+}
+
+fn looks_like_html(bytes: &[u8]) -> bool {
+    const DOCTYPE: &[u8] = b"<!doctype";
+    const HTML: &[u8] = b"<html";
+    const BOM: &[u8] = b"\xef\xbb\xbf";
+    let mut prefix = bytes.get(..HTML_SNIFF_LEN).unwrap_or(bytes);
+    if prefix.starts_with(BOM) {
+        prefix = &prefix[BOM.len()..];
+    }
+    let prefix = prefix
+        .iter()
+        .position(|b| !b.is_ascii_whitespace())
+        .map_or(&[][..], |i| &prefix[i..]);
+    prefix
+        .get(..DOCTYPE.len())
+        .is_some_and(|p| p.eq_ignore_ascii_case(DOCTYPE))
+        || prefix.get(..HTML.len()).is_some_and(|p| p.eq_ignore_ascii_case(HTML))
+}
+
+fn fetch_html(agent: &ureq::Agent, url: &Url) -> Option<String> {
+    let resp = fetch_following_redirects(agent, url, url)?;
+    resp.into_body()
+        .with_config()
+        .limit(MAP_HTML_MAX_BYTES)
+        .read_to_string()
+        .ok()
+}
+
+fn extract_links(html: &str, base: &Url) -> Vec<Url> {
+    dom_query::Document::from(html)
+        .select("a[href]")
+        .iter()
+        .filter_map(|el| {
+            let href = el.attr("href")?;
+            let href = href.trim();
+            if href.is_empty() {
+                return None;
+            }
+            let resolved = base.join(href).ok()?;
+            matches!(resolved.scheme(), "http" | "https").then_some(resolved)
+        })
+        .collect()
+}
+
+enum SitemapEntry {
+    Url { loc: String, lastmod: Option<String> },
+    Sitemap { loc: String },
+}
+
+fn parse_sitemap(body: &str) -> Vec<SitemapEntry> {
+    use quick_xml::events::Event;
+    use quick_xml::reader::Reader;
+
+    let mut reader = Reader::from_str(body);
+    let mut entries = Vec::new();
+    let mut buf = Vec::new();
+    let mut capture = Capture::Idle;
+    let mut loc = String::new();
+    let mut lastmod = String::new();
+    let mut in_url = false;
+    let mut in_sitemap = false;
+    let mut depth: u32 = 0;
+
+    loop {
+        match reader.read_event_into(&mut buf) {
+            Ok(Event::Start(e)) => {
+                let name = e.local_name();
+                match name.as_ref() {
+                    b"url" => {
+                        in_url = true;
+                        depth = 0;
+                    }
+                    b"sitemap" => {
+                        in_sitemap = true;
+                        depth = 0;
+                    }
+                    b"loc" if (in_url || in_sitemap) && depth == 0 => capture = Capture::Loc,
+                    b"lastmod" if in_url && depth == 0 => capture = Capture::Lastmod,
+                    _ if in_url || in_sitemap => depth += 1,
+                    _ => {}
+                }
+            }
+            Ok(Event::Text(e)) => {
+                if let Ok(text) = e.xml10_content() {
+                    match capture {
+                        Capture::Loc => loc.push_str(text.trim()),
+                        Capture::Lastmod => lastmod.push_str(text.trim()),
+                        Capture::Idle => {}
+                    }
+                } else {
+                    loc.clear();
+                    lastmod.clear();
+                    capture = Capture::Idle;
+                }
+            }
+            Ok(Event::GeneralRef(e)) => {
+                let resolved = match &*e {
+                    b"amp" => "&",
+                    b"lt" => "<",
+                    b"gt" => ">",
+                    b"quot" => "\"",
+                    b"apos" => "'",
+                    _ => "",
+                };
+                match capture {
+                    Capture::Loc => loc.push_str(resolved),
+                    Capture::Lastmod => lastmod.push_str(resolved),
+                    Capture::Idle => {}
+                }
+            }
+            Ok(Event::End(e)) => {
+                let name = e.local_name();
+                match name.as_ref() {
+                    b"url" if in_url => {
+                        if !loc.is_empty() {
+                            let lm = if lastmod.is_empty() {
+                                None
+                            } else {
+                                Some(std::mem::take(&mut lastmod))
+                            };
+                            entries.push(SitemapEntry::Url {
+                                loc: std::mem::take(&mut loc),
+                                lastmod: lm,
+                            });
+                        }
+                        loc.clear();
+                        lastmod.clear();
+                        in_url = false;
+                    }
+                    b"sitemap" if in_sitemap => {
+                        if !loc.is_empty() {
+                            entries.push(SitemapEntry::Sitemap {
+                                loc: std::mem::take(&mut loc),
+                            });
+                        }
+                        loc.clear();
+                        lastmod.clear();
+                        in_sitemap = false;
+                    }
+                    b"loc" | b"lastmod" if capture != Capture::Idle => capture = Capture::Idle,
+                    _ if depth > 0 => depth -= 1,
+                    _ => {}
+                }
+            }
+            Ok(Event::Eof) | Err(_) => break,
+            _ => {}
+        }
+        buf.clear();
+    }
+
+    entries
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Capture {
+    Idle,
+    Loc,
+    Lastmod,
+}
+
+fn validate_entry(
+    loc: &str,
+    lastmod: Option<String>,
+    seed: &Url,
+    robots: &RobotsPolicy,
+    opts: &MapConfig,
+    visited: &mut HashSet<String>,
+) -> Option<MapEntry> {
+    if loc.len() > MAP_URL_MAX_LEN {
+        return None;
+    }
+    let url = net::validate_url(loc).ok()?;
+    if !is_same_site(seed, &url) {
+        return None;
+    }
+    if !robots.is_allowed(&url) {
+        return None;
+    }
+    if !matches_scope(&url, opts.include.as_ref(), opts.exclude.as_ref()) {
+        return None;
+    }
+    let normalized = normalize_url(&url);
+    if !visited.insert(normalized.clone()) {
+        return None;
+    }
+    Some(MapEntry {
+        url: normalized,
+        lastmod,
+    })
+}
+
+async fn throttle(last_fetch: &mut Instant) {
+    let elapsed = last_fetch.elapsed();
+    if elapsed < MAP_MIN_FETCH_INTERVAL {
+        tokio::time::sleep(MAP_MIN_FETCH_INTERVAL.saturating_sub(elapsed)).await;
+    }
+    *last_fetch = Instant::now();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_config(seed: &str) -> MapConfig {
+        MapConfig {
+            seed: Url::parse(seed).unwrap(),
+            limit: 100,
+            include: None,
+            exclude: None,
+            user_agent: None,
+            timeout: Duration::from_secs(30),
+            no_fallback: false,
+        }
+    }
+
+    #[test]
+    fn parse_urlset() {
+        let xml = r#"<?xml version="1.0"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://example.com/a</loc><lastmod>2026-01-01</lastmod></url>
+  <url><loc>https://example.com/b</loc></url>
+</urlset>"#;
+        let entries = parse_sitemap(xml);
+        assert_eq!(entries.len(), 2);
+        match &entries[0] {
+            SitemapEntry::Url { loc, lastmod } => {
+                assert_eq!(loc, "https://example.com/a");
+                assert_eq!(lastmod.as_deref(), Some("2026-01-01"));
+            }
+            SitemapEntry::Sitemap { .. } => panic!("expected Url"),
+        }
+        match &entries[1] {
+            SitemapEntry::Url { loc, lastmod } => {
+                assert_eq!(loc, "https://example.com/b");
+                assert!(lastmod.is_none());
+            }
+            SitemapEntry::Sitemap { .. } => panic!("expected Url"),
+        }
+    }
+
+    #[test]
+    fn parse_sitemapindex() {
+        let xml = r#"<?xml version="1.0"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap><loc>https://example.com/sitemap1.xml</loc></sitemap>
+  <sitemap><loc>https://example.com/sitemap2.xml</loc></sitemap>
+</sitemapindex>"#;
+        let entries = parse_sitemap(xml);
+        assert_eq!(entries.len(), 2);
+        match &entries[0] {
+            SitemapEntry::Sitemap { loc } => assert_eq!(loc, "https://example.com/sitemap1.xml"),
+            SitemapEntry::Url { .. } => panic!("expected Sitemap"),
+        }
+    }
+
+    #[test]
+    fn parse_handles_xml_entities() {
+        let xml = r"<urlset><url><loc>https://example.com/a?b=1&amp;c=2</loc></url></urlset>";
+        let entries = parse_sitemap(xml);
+        assert_eq!(entries.len(), 1);
+        match &entries[0] {
+            SitemapEntry::Url { loc, .. } => assert_eq!(loc, "https://example.com/a?b=1&c=2"),
+            SitemapEntry::Sitemap { .. } => panic!("expected Url"),
+        }
+    }
+
+    #[test]
+    fn parse_handles_namespaced_tags() {
+        let xml = r#"<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+                xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
+  <url>
+    <loc>https://example.com/page</loc>
+    <image:image><image:loc>https://example.com/img.png</image:loc></image:image>
+  </url>
+</urlset>"#;
+        let entries = parse_sitemap(xml);
+        assert_eq!(entries.len(), 1);
+        match &entries[0] {
+            SitemapEntry::Url { loc, .. } => assert_eq!(loc, "https://example.com/page"),
+            SitemapEntry::Sitemap { .. } => panic!("expected Url"),
+        }
+    }
+
+    #[test]
+    fn parse_loc_after_nested_extension() {
+        let xml = r#"<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+                xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
+  <url>
+    <image:image><image:loc>https://example.com/img.png</image:loc></image:image>
+    <loc>https://example.com/page</loc>
+    <lastmod>2026-01-01</lastmod>
+  </url>
+</urlset>"#;
+        let entries = parse_sitemap(xml);
+        assert_eq!(entries.len(), 1);
+        match &entries[0] {
+            SitemapEntry::Url { loc, lastmod } => {
+                assert_eq!(loc, "https://example.com/page");
+                assert_eq!(lastmod.as_deref(), Some("2026-01-01"));
+            }
+            SitemapEntry::Sitemap { .. } => panic!("expected Url"),
+        }
+    }
+
+    #[test]
+    fn parse_empty_body_returns_empty() {
+        assert!(parse_sitemap("").is_empty());
+        assert!(parse_sitemap("<html><body>Not Found</body></html>").is_empty());
+    }
+
+    #[test]
+    fn looks_like_html_detects_variants() {
+        assert!(looks_like_html(b"<!DOCTYPE html>"));
+        assert!(looks_like_html(b"<!doctype html>"));
+        assert!(looks_like_html(b"<html lang=\"en\">"));
+        assert!(looks_like_html(b"<HTML>"));
+        assert!(looks_like_html(b"\xef\xbb\xbf<!DOCTYPE html>"));
+        assert!(looks_like_html(b"  \n<!doctype html>"));
+        assert!(looks_like_html(b"\xef\xbb\xbf  <html>"));
+        assert!(!looks_like_html(b"<?xml version=\"1.0\"?>"));
+        assert!(!looks_like_html(b"<urlset>"));
+        assert!(!looks_like_html(b""));
+    }
+
+    #[test]
+    fn validate_entry_rejects_private_ip() {
+        let opts = test_config("https://example.com");
+
+        let mut visited = HashSet::new();
+        let result = validate_entry(
+            "http://127.0.0.1/secret",
+            None,
+            &opts.seed,
+            &RobotsPolicy::Unavailable,
+            &opts,
+            &mut visited,
+        );
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn validate_entry_rejects_cross_site() {
+        let opts = test_config("https://example.com");
+        let robots = RobotsPolicy::Unavailable;
+        let mut visited = HashSet::new();
+        let result = validate_entry("https://evil.com/page", None, &opts.seed, &robots, &opts, &mut visited);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn validate_entry_deduplicates() {
+        let opts = test_config("https://example.com");
+        let robots = RobotsPolicy::Unavailable;
+        let mut visited = HashSet::new();
+        let first = validate_entry(
+            "https://example.com/page",
+            None,
+            &opts.seed,
+            &robots,
+            &opts,
+            &mut visited,
+        );
+        assert!(first.is_some());
+        let second = validate_entry(
+            "https://example.com/page",
+            None,
+            &opts.seed,
+            &robots,
+            &opts,
+            &mut visited,
+        );
+        assert!(second.is_none());
+    }
+
+    #[test]
+    fn validate_entry_rejects_long_url() {
+        let opts = test_config("https://example.com");
+        let robots = RobotsPolicy::Unavailable;
+        let mut visited = HashSet::new();
+        let long_url = format!("https://example.com/{}", "a".repeat(MAP_URL_MAX_LEN));
+        let result = validate_entry(&long_url, None, &opts.seed, &robots, &opts, &mut visited);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn discover_sitemaps_includes_robots_and_default() {
+        let seed = Url::parse("https://example.com").unwrap();
+        let robots = RobotsPolicy::Rules(RobotsRules {
+            rules: Vec::new(),
+            sitemaps: vec![Url::parse("https://example.com/custom-sitemap.xml").unwrap()],
+        });
+        let sitemaps = discover_sitemaps(&robots, &seed);
+        assert_eq!(sitemaps.len(), 2);
+        assert_eq!(sitemaps[0].as_str(), "https://example.com/custom-sitemap.xml");
+        assert_eq!(sitemaps[1].as_str(), "https://example.com/sitemap.xml");
+    }
+
+    #[test]
+    fn discover_sitemaps_deduplicates_default() {
+        let seed = Url::parse("https://example.com").unwrap();
+        let robots = RobotsPolicy::Rules(RobotsRules {
+            rules: Vec::new(),
+            sitemaps: vec![Url::parse("https://example.com/sitemap.xml").unwrap()],
+        });
+        let sitemaps = discover_sitemaps(&robots, &seed);
+        assert_eq!(sitemaps.len(), 1);
+    }
+
+    mod integration {
+        use super::super::*;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        #[tokio::test]
+        async fn fetch_sitemap_parses_urlset() {
+            let server = MockServer::start().await;
+            let xml = r#"<?xml version="1.0"?><urlset><url><loc>https://example.com/a</loc></url></urlset>"#;
+            Mock::given(method("GET"))
+                .and(path("/sitemap.xml"))
+                .respond_with(ResponseTemplate::new(200).set_body_string(xml))
+                .mount(&server)
+                .await;
+
+            let agent = build_agent("test/1.0", Duration::from_secs(5));
+            let url = Url::parse(&format!("{}/sitemap.xml", server.uri())).unwrap();
+            let body = tokio::task::spawn_blocking(move || fetch_sitemap(&agent, &url, &url))
+                .await
+                .unwrap();
+
+            let entries = parse_sitemap(&body.unwrap());
+            assert_eq!(entries.len(), 1);
+        }
+
+        #[tokio::test]
+        async fn fetch_sitemap_rejects_html_error_page() {
+            let server = MockServer::start().await;
+            Mock::given(method("GET"))
+                .and(path("/sitemap.xml"))
+                .respond_with(
+                    ResponseTemplate::new(200).set_body_string("<!DOCTYPE html><html><body>Not Found</body></html>"),
+                )
+                .mount(&server)
+                .await;
+
+            let agent = build_agent("test/1.0", Duration::from_secs(5));
+            let url = Url::parse(&format!("{}/sitemap.xml", server.uri())).unwrap();
+            let body = tokio::task::spawn_blocking(move || fetch_sitemap(&agent, &url, &url))
+                .await
+                .unwrap();
+
+            assert!(body.is_none());
+        }
+
+        #[tokio::test]
+        async fn fetch_sitemap_returns_none_on_404() {
+            let server = MockServer::start().await;
+            Mock::given(method("GET"))
+                .and(path("/sitemap.xml"))
+                .respond_with(ResponseTemplate::new(404))
+                .mount(&server)
+                .await;
+
+            let agent = build_agent("test/1.0", Duration::from_secs(5));
+            let url = Url::parse(&format!("{}/sitemap.xml", server.uri())).unwrap();
+            let body = tokio::task::spawn_blocking(move || fetch_sitemap(&agent, &url, &url))
+                .await
+                .unwrap();
+
+            assert!(body.is_none());
+        }
+
+        #[tokio::test]
+        async fn fetch_sitemap_handles_gzip() {
+            use flate2::Compression;
+            use flate2::write::GzEncoder;
+            use std::io::Write;
+
+            let server = MockServer::start().await;
+            let xml = r#"<?xml version="1.0"?><urlset><url><loc>https://example.com/gz</loc></url></urlset>"#;
+            let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+            encoder.write_all(xml.as_bytes()).unwrap();
+            let compressed = encoder.finish().unwrap();
+
+            Mock::given(method("GET"))
+                .and(path("/sitemap.xml.gz"))
+                .respond_with(
+                    ResponseTemplate::new(200)
+                        .set_body_bytes(compressed)
+                        .insert_header("content-type", "application/gzip"),
+                )
+                .mount(&server)
+                .await;
+
+            let agent = build_agent("test/1.0", Duration::from_secs(5));
+            let url = Url::parse(&format!("{}/sitemap.xml.gz", server.uri())).unwrap();
+            let body = tokio::task::spawn_blocking(move || fetch_sitemap(&agent, &url, &url))
+                .await
+                .unwrap();
+
+            let entries = parse_sitemap(&body.unwrap());
+            assert_eq!(entries.len(), 1);
+        }
+
+        #[tokio::test]
+        async fn fetch_html_extracts_links() {
+            let server = MockServer::start().await;
+            Mock::given(method("GET"))
+                .and(path("/"))
+                .respond_with(
+                    ResponseTemplate::new(200).set_body_string(r#"<html><body><a href="/link">x</a></body></html>"#),
+                )
+                .mount(&server)
+                .await;
+
+            let agent = build_agent("test/1.0", Duration::from_secs(5));
+            let seed = Url::parse(&server.uri()).unwrap();
+            let html = tokio::task::spawn_blocking({
+                let seed = seed.clone();
+                move || fetch_html(&agent, &seed)
+            })
+            .await
+            .unwrap()
+            .unwrap();
+
+            let links = extract_links(&html, &seed);
+            assert_eq!(links.len(), 1);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds `servo-fetch map <URL>` — discovers all URLs on a site via sitemaps without rendering pages. Fast and lightweight (no Servo engine needed).

How it works:
1. Fetches `robots.txt` for `Sitemap:` directives
2. Fetches and parses sitemap XML (including sitemap index recursion and gzip)
3. Falls back to HTML link extraction from the seed page if no sitemap exists
4. Applies same-site filter, robots.txt `Disallow`, glob include/exclude, and deduplication

## Test Plan

- `cargo test -p servo-fetch --locked --lib` — 166 tests (148 existing + 18 new map tests)
- `cargo test -p servo-fetch --locked --test extract` — 15 tests
- `cargo test -p servo-fetch-cli --locked --test mcp` — 12 tests
- Manual: `./target/debug/servo-fetch map https://servo.org --limit 10`
- Manual: `./target/debug/servo-fetch map http://servo.org --limit 3` (redirect follow)
- Manual: `./target/debug/servo-fetch map https://127.0.0.1/` → "address not allowed"

## Checklist

- [x] `cargo clippy` passes with zero warnings
- [x] `cargo test` passes
- [x] `cargo fmt --check` passes
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it