### PR TITLE
docs: add map command to README and CLI reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ let md = servo_fetch::markdown("https://example.com")?;  // Library: one-liner
 - **Layout-aware extraction** — strips navbars, sidebars, footers by actual rendered position
 - **Parallel batch fetch** — multiple URLs fetched concurrently
 - **Site crawling** — BFS link traversal with robots.txt, same-site scope, and rate limiting
+- **URL discovery** — sitemap-based URL mapping without rendering (fast, lightweight)
 - **Screenshots without GPU** — software renderer captures PNG/full-page screenshots anywhere
 - **Accessibility tree** — AccessKit integration with roles, names, and bounding boxes
 
@@ -92,6 +93,7 @@ servo-fetch "https://example.com" --screenshot page.png  # PNG screenshot
 servo-fetch "https://example.com" --js "document.title"  # Run JavaScript
 servo-fetch URL1 URL2 URL3                               # Parallel batch
 servo-fetch crawl "https://docs.example.com" --limit 20  # Crawl a site
+servo-fetch map "https://example.com"                    # Discover URLs via sitemap
 servo-fetch mcp                                          # MCP server (stdio)
 ```
 
@@ -125,14 +127,22 @@ servo_fetch::crawl_each(
         Err(e) => eprintln!("{}: {e}", result.url),
     },
 )?;
+
+// Discover URLs via sitemap (no rendering)
+let urls = servo_fetch::map(
+    servo_fetch::MapOptions::new("https://example.com").limit(1000),
+)?;
+for u in &urls {
+    println!("{}", u.url);
+}
 ```
 
 Full API reference → [`servo-fetch`](crates/servo-fetch/README.md)
 
 ## MCP Server
 
-Built-in [Model Context Protocol](https://modelcontextprotocol.io/) server with five tools: `fetch`,
-`batch_fetch`, `crawl`, `screenshot`, and `execute_js`.
+Built-in [Model Context Protocol](https://modelcontextprotocol.io/) server with six tools: `fetch`,
+`batch_fetch`, `crawl`, `map`, `screenshot`, and `execute_js`.
 
 ```json
 {

--- a/crates/servo-fetch-cli/README.md
+++ b/crates/servo-fetch-cli/README.md
@@ -68,6 +68,13 @@ servo-fetch crawl "https://docs.example.com" --include "/docs/**" --exclude "/do
 servo-fetch crawl "https://docs.example.com" --json --max-depth 5
 ```
 
+### Discover URLs (sitemap)
+
+```bash
+servo-fetch map "https://example.com"
+servo-fetch map "https://example.com" --limit 100 --include "/blog/**"
+```
+
 ### SPA / dynamic content
 
 ```bash
@@ -127,6 +134,20 @@ servo-fetch mcp --port 8080    # Streamable HTTP transport
 | `--user-agent <UA>` | Override the User-Agent string |
 | `-t, --timeout <SECS>` | Page load timeout in seconds per page (default: 30) |
 | `--settle <MS>` | Extra wait after load event in ms per page (default: 0, max: 10000) |
+
+### Map subcommand
+
+`servo-fetch map <URL>` discovers all URLs on a site via sitemaps without rendering. Falls back to HTML link extraction if no sitemap exists.
+
+| Flag | Description |
+| ---- | ----------- |
+| `--limit <N>` | Maximum URLs to return (default: 5000) |
+| `--include <GLOB>` | URL path patterns to include |
+| `--exclude <GLOB>` | URL path patterns to exclude |
+| `--json` | Output as JSON array with lastmod metadata |
+| `--user-agent <UA>` | Override the User-Agent string |
+| `-t, --timeout <SECS>` | HTTP request timeout in seconds (default: 30) |
+| `--no-fallback` | Skip HTML link extraction fallback |
 
 ## Logging
 
@@ -212,6 +233,18 @@ Streamable HTTP: `servo-fetch mcp --port 8080`
 | `timeout` | number? | Page load timeout in seconds per page (default 30) |
 | `settle_ms` | number? | Extra wait in ms after load event (default 0, max 10000) |
 | `selector` | string? | CSS selector to extract a specific section per page |
+
+</details>
+
+<details>
+<summary><b>map</b> — discover URLs via sitemaps without rendering</summary>
+
+| Parameter | Type | Description |
+| --------- | ---- | ----------- |
+| `url` | string | Site URL to discover pages for (http/https only) |
+| `limit` | number? | Maximum URLs to return (default 5000) |
+| `include_glob` | string[]? | URL path patterns to include |
+| `exclude_glob` | string[]? | URL path patterns to exclude |
 
 </details>
 

--- a/crates/servo-fetch/README.md
+++ b/crates/servo-fetch/README.md
@@ -112,6 +112,7 @@ let page = tokio::task::spawn_blocking(|| {
 | `fetch(opts)` | Fetch with full options → `Page` |
 | `crawl(opts)` | Crawl site → `Vec<CrawlResult>` |
 | `crawl_each(opts, cb)` | Crawl site, streaming results |
+| `map(opts)` | Discover URLs via sitemaps → `Vec<MappedUrl>` |
 
 See [docs.rs](https://docs.rs/servo-fetch) for the full API reference and [`examples/`](examples/) for complete runnable programs.
 


### PR DESCRIPTION
## Summary

Documents the `map` command added in #125. 
All flags and parameters verified against actual implementation (`MapArgs`, `MapOptions`, `MapParams`).

## Test Plan

N/A

## Checklist

- [x] `cargo clippy` passes with zero warnings
- [x] `cargo test` passes
- [x] `cargo fmt --check` passes
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it