### PR TITLE
fix(ci): use !cancelled() instead of always() for gate job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,7 +170,7 @@ jobs:
 
   ci-passed:
     name: CI Passed
-    if: always()
+    if: '!cancelled()'
     needs: [changes, clippy, test, fmt, deny, shear, typos]
     runs-on: ubuntu-24.04
     timeout-minutes: 5


### PR DESCRIPTION
## Summary

Fixes spurious CI failure on cancelled runs caused by `concurrency.cancel-in-progress: true`.

When multiple pushes to `main` happen in quick succession, `cancel-in-progress` cancels the older run. The `ci-passed` gate job used `if: always()`, which runs even when the workflow is cancelled — it then detects `"cancelled"` in `needs` results and reports failure.

## Test Plan

N/A

## Checklist

- [x] `cargo clippy` passes with zero warnings
- [x] `cargo test` passes
- [x] `cargo fmt --check` passes
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it