### PR TITLE
fix(robots): pass caller timeout to robots.txt fetch

### DIFF
--- a/crates/servo-fetch/src/crawl.rs
+++ b/crates/servo-fetch/src/crawl.rs
@@ -111,7 +111,8 @@ pub(crate) async fn run(opts: CrawlOptions, mut on_page: impl FnMut(&CrawlPageRe
     let robots = tokio::task::spawn_blocking({
         let seed = opts.seed.clone();
         let user_agent = opts.user_agent.clone();
-        move || RobotsRules::fetch(&seed, user_agent.as_deref())
+        let timeout = Duration::from_secs(opts.timeout_secs);
+        move || RobotsRules::fetch(&seed, user_agent.as_deref(), timeout)
     })
     .await
     .unwrap_or(RobotsPolicy::Unreachable);

--- a/crates/servo-fetch/src/map.rs
+++ b/crates/servo-fetch/src/map.rs
@@ -52,7 +52,8 @@ pub(crate) async fn run(opts: &MapConfig, mut on_url: impl FnMut(&MapEntry)) {
     let robots = {
         let seed = opts.seed.clone();
         let user_agent = opts.user_agent.clone();
-        tokio::task::spawn_blocking(move || RobotsRules::fetch(&seed, user_agent.as_deref()))
+        let timeout = opts.timeout;
+        tokio::task::spawn_blocking(move || RobotsRules::fetch(&seed, user_agent.as_deref(), timeout))
             .await
             .unwrap_or(RobotsPolicy::Unreachable)
     };

--- a/crates/servo-fetch/src/robots.rs
+++ b/crates/servo-fetch/src/robots.rs
@@ -7,7 +7,6 @@ use url::Url;
 use crate::bridge;
 
 const ROBOTS_MAX_BYTES: u64 = 512 * 1024;
-const ROBOTS_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Outcome of `RobotsRules::fetch`.
 pub(crate) enum RobotsPolicy {
@@ -34,7 +33,7 @@ pub(crate) struct RobotsRules {
 }
 
 impl RobotsRules {
-    pub(crate) fn fetch(seed: &Url, user_agent: Option<&str>) -> RobotsPolicy {
+    pub(crate) fn fetch(seed: &Url, user_agent: Option<&str>, timeout: Duration) -> RobotsPolicy {
         let Some(url) = robots_url(seed) else {
             return RobotsPolicy::Unreachable;
         };
@@ -42,7 +41,7 @@ impl RobotsRules {
         let agent = ureq::Agent::new_with_config(
             ureq::config::Config::builder()
                 .max_redirects(0)
-                .timeout_global(Some(ROBOTS_TIMEOUT))
+                .timeout_global(Some(timeout))
                 .user_agent(ua)
                 .build(),
         );
@@ -309,7 +308,7 @@ mod tests {
         }
 
         async fn call(seed: Url, user_agent: Option<&'static str>) -> RobotsPolicy {
-            tokio::task::spawn_blocking(move || RobotsRules::fetch(&seed, user_agent))
+            tokio::task::spawn_blocking(move || RobotsRules::fetch(&seed, user_agent, Duration::from_secs(5)))
                 .await
                 .unwrap()
         }


### PR DESCRIPTION
## Summary

Add `timeout: Duration` parameter to `RobotsRules::fetch`. Callers (crawl, map) pass their user-configured timeout directly. No robots-specific cap.

## Test Plan

- `cargo test -p servo-fetch --locked --lib` — 166 tests pass
- `cargo test -p servo-fetch-cli --locked --test mcp` — 12 tests pass

## Checklist

- [x] `cargo clippy` passes with zero warnings
- [x] `cargo test` passes
- [x] `cargo fmt --check` passes
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it