### PR TITLE
test(e2e): migrate parallel tests to wiremock and share mock helper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,7 +199,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y cmake clang pkg-config libfontconfig-dev libfreetype-dev \
             libssl-dev libglib2.0-dev libegl1-mesa-dev
-      - run: cargo nextest run -p servo-fetch-cli --run-ignored only --locked --cargo-profile ci --no-fail-fast -E 'not test(parallel)'
+      - run: cargo nextest run -p servo-fetch-cli --run-ignored only --locked --cargo-profile ci --no-fail-fast
       - name: sccache stats
         if: always()
         run: sccache --show-stats

--- a/crates/servo-fetch-cli/Cargo.toml
+++ b/crates/servo-fetch-cli/Cargo.toml
@@ -11,10 +11,23 @@ readme = "README.md"
 keywords = ["servo", "headless-browser", "fetch", "mcp", "cli"]
 categories = ["command-line-utilities", "web-programming"]
 include = ["src/**/*", "Cargo.toml", "LICENSE-MIT", "LICENSE-APACHE", "README.md"]
+autotests = false
 
 [[bin]]
 name = "servo-fetch"
 path = "src/main.rs"
+
+[[test]]
+name = "cli"
+path = "tests/cli.rs"
+
+[[test]]
+name = "mcp"
+path = "tests/mcp.rs"
+
+[[test]]
+name = "parallel"
+path = "tests/parallel.rs"
 
 [dependencies]
 servo-fetch = { workspace = true }

--- a/crates/servo-fetch-cli/tests/cli.rs
+++ b/crates/servo-fetch-cli/tests/cli.rs
@@ -7,6 +7,9 @@ use predicates::prelude::*;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
+mod common;
+use common::mock_page;
+
 fn servo_fetch() -> Command {
     Command::cargo_bin("servo-fetch").expect("binary exists")
 }
@@ -73,12 +76,6 @@ fn help_flag() {
 }
 
 const TIMEOUT: &str = "--timeout=30";
-
-fn mock_page(html: &str) -> ResponseTemplate {
-    ResponseTemplate::new(200)
-        .insert_header("content-type", "text/html")
-        .set_body_string(html.to_string())
-}
 
 #[test]
 #[ignore = "e2e: requires Servo engine"]

--- a/crates/servo-fetch-cli/tests/common.rs
+++ b/crates/servo-fetch-cli/tests/common.rs
@@ -1,0 +1,11 @@
+//! Shared helpers for integration tests.
+
+#![allow(dead_code, unreachable_pub)]
+
+use wiremock::ResponseTemplate;
+
+pub fn mock_page(html: impl Into<String>) -> ResponseTemplate {
+    ResponseTemplate::new(200)
+        .insert_header("content-type", "text/html")
+        .set_body_string(html.into())
+}

--- a/crates/servo-fetch-cli/tests/mcp.rs
+++ b/crates/servo-fetch-cli/tests/mcp.rs
@@ -5,6 +5,9 @@ use rmcp::transport::TokioChildProcess;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
+mod common;
+use common::mock_page;
+
 async fn connect() -> rmcp::service::RunningService<rmcp::RoleClient, impl rmcp::service::Service<rmcp::RoleClient>> {
     let mut cmd = tokio::process::Command::new(env!("CARGO_BIN_EXE_servo-fetch"));
     cmd.arg("mcp");
@@ -97,13 +100,9 @@ async fn fetch_returns_content() {
     let server = MockServer::start().await;
     Mock::given(method("GET"))
         .and(path("/"))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .insert_header("content-type", "text/html")
-                .set_body_string(
-                    "<html><head><title>Test Page</title></head><body><p>Hello from Servo</p></body></html>",
-                ),
-        )
+        .respond_with(mock_page(
+            "<html><head><title>Test Page</title></head><body><p>Hello from Servo</p></body></html>",
+        ))
         .mount(&server)
         .await;
 
@@ -126,11 +125,9 @@ async fn execute_js_returns_title() {
     let server = MockServer::start().await;
     Mock::given(method("GET"))
         .and(path("/"))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .insert_header("content-type", "text/html")
-                .set_body_string("<html><head><title>JS Title</title></head><body></body></html>"),
-        )
+        .respond_with(mock_page(
+            "<html><head><title>JS Title</title></head><body></body></html>",
+        ))
         .mount(&server)
         .await;
 
@@ -210,22 +207,16 @@ async fn crawl_returns_multiple_pages() {
     let link = format!(r#"<a href="{}/page2">next</a>"#, server.uri());
     Mock::given(method("GET"))
         .and(path("/"))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .insert_header("content-type", "text/html")
-                .set_body_string(format!(
-                    "<html><head><title>Root</title></head><body>{link}</body></html>"
-                )),
-        )
+        .respond_with(mock_page(format!(
+            "<html><head><title>Root</title></head><body>{link}</body></html>"
+        )))
         .mount(&server)
         .await;
     Mock::given(method("GET"))
         .and(path("/page2"))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .insert_header("content-type", "text/html")
-                .set_body_string("<html><head><title>Page 2</title></head><body><p>Second page</p></body></html>"),
-        )
+        .respond_with(mock_page(
+            "<html><head><title>Page 2</title></head><body><p>Second page</p></body></html>",
+        ))
         .mount(&server)
         .await;
     Mock::given(method("GET"))
@@ -256,20 +247,16 @@ async fn batch_fetch_returns_multiple_results() {
     let server = MockServer::start().await;
     Mock::given(method("GET"))
         .and(path("/a"))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .insert_header("content-type", "text/html")
-                .set_body_string("<html><head><title>A</title></head><body>Page A</body></html>"),
-        )
+        .respond_with(mock_page(
+            "<html><head><title>A</title></head><body>Page A</body></html>",
+        ))
         .mount(&server)
         .await;
     Mock::given(method("GET"))
         .and(path("/b"))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .insert_header("content-type", "text/html")
-                .set_body_string("<html><head><title>B</title></head><body>Page B</body></html>"),
-        )
+        .respond_with(mock_page(
+            "<html><head><title>B</title></head><body>Page B</body></html>",
+        ))
         .mount(&server)
         .await;
 

--- a/crates/servo-fetch-cli/tests/parallel.rs
+++ b/crates/servo-fetch-cli/tests/parallel.rs
@@ -2,10 +2,15 @@
 
 use rmcp::ServiceExt;
 use rmcp::transport::TokioChildProcess;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer};
+
+mod common;
+use common::mock_page;
 
 async fn connect() -> rmcp::service::RunningService<rmcp::RoleClient, impl rmcp::service::Service<rmcp::RoleClient>> {
     let mut cmd = tokio::process::Command::new(env!("CARGO_BIN_EXE_servo-fetch"));
-    cmd.arg("mcp");
+    cmd.args(["mcp", "--allow-private-addresses"]);
     let transport = TokioChildProcess::new(cmd).unwrap();
     ().serve(transport).await.expect("MCP handshake failed")
 }
@@ -18,24 +23,39 @@ fn call_params(name: &str, args: &serde_json::Value) -> rmcp::model::CallToolReq
 }
 
 #[tokio::test]
-#[ignore = "requires Servo + network"]
+#[ignore = "e2e: requires Servo engine"]
 async fn parallel_fetches_do_not_cross_contaminate() {
-    // Two public test URLs with distinct, stable content markers.
-    const URLS: &[(&str, &str)] = &[
-        ("https://example.com", "Example Domain"),
-        ("https://example.org", "Example Domain"),
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/alpha"))
+        .respond_with(mock_page(
+            "<html><head><title>Alpha</title></head><body><h1>Alpha Marker</h1></body></html>",
+        ))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/beta"))
+        .respond_with(mock_page(
+            "<html><head><title>Beta</title></head><body><h1>Beta Marker</h1></body></html>",
+        ))
+        .mount(&server)
+        .await;
+
+    let cases = [
+        (format!("{}/alpha", server.uri()), "Alpha Marker", "Beta Marker"),
+        (format!("{}/beta", server.uri()), "Beta Marker", "Alpha Marker"),
     ];
 
     let client = connect().await;
-    let calls = URLS.iter().map(|(url, _)| {
+    let calls = cases.iter().map(|(url, _, _)| {
         client.call_tool(call_params(
             "fetch",
-            &serde_json::json!({ "url": url, "max_length": 2000, "timeout": 60 }),
+            &serde_json::json!({ "url": url, "max_length": 2000, "timeout": 30 }),
         ))
     });
     let results = futures_util::future::join_all(calls).await;
 
-    for ((url, marker), result) in URLS.iter().zip(results) {
+    for ((url, expected, forbidden), result) in cases.iter().zip(results) {
         let r = result.unwrap_or_else(|e| panic!("fetch {url} failed: {e}"));
         let text = r
             .content
@@ -44,34 +64,55 @@ async fn parallel_fetches_do_not_cross_contaminate() {
             .map(|t| t.text.as_str())
             .collect::<String>();
         assert!(
-            text.contains(marker),
-            "response for {url} missing marker {marker:?}; got: {text}"
+            text.contains(expected),
+            "response for {url} missing {expected:?}; got: {text}"
+        );
+        assert!(
+            !text.contains(forbidden),
+            "response for {url} leaked {forbidden:?} from a sibling request"
         );
     }
 }
 
 #[tokio::test]
-#[ignore = "requires Servo + network"]
+#[ignore = "e2e: requires Servo engine"]
 async fn concurrent_full_page_screenshots_are_distinct() {
-    // Stress the dedicated `SoftwareRenderingContext`: each PNG must be unique.
-    // All URLs must render visually distinct pages.
-    const URLS: &[&str] = &[
-        "https://example.com",
-        "https://www.iana.org/help/example-domains",
-        "https://httpbin.org/html",
+    let server = MockServer::start().await;
+    let pages = [
+        (
+            "/red",
+            "<html><body style=\"background:#ff0000;height:800px\"><h1>RED</h1></body></html>",
+        ),
+        (
+            "/green",
+            "<html><body style=\"background:#00ff00;height:800px\"><h1>GREEN</h1></body></html>",
+        ),
+        (
+            "/blue",
+            "<html><body style=\"background:#0000ff;height:800px\"><h1>BLUE</h1></body></html>",
+        ),
     ];
+    for (p, html) in &pages {
+        Mock::given(method("GET"))
+            .and(path(*p))
+            .respond_with(mock_page(*html))
+            .mount(&server)
+            .await;
+    }
+
+    let urls: Vec<String> = pages.iter().map(|(p, _)| format!("{}{p}", server.uri())).collect();
 
     let client = connect().await;
-    let calls = URLS.iter().map(|url| {
+    let calls = urls.iter().map(|url| {
         client.call_tool(call_params(
             "screenshot",
-            &serde_json::json!({ "url": url, "full_page": true, "timeout": 60 }),
+            &serde_json::json!({ "url": url, "full_page": true, "timeout": 30 }),
         ))
     });
     let results = futures_util::future::join_all(calls).await;
 
     let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
-    for (url, result) in URLS.iter().zip(results) {
+    for (url, result) in urls.iter().zip(results) {
         let r = result.unwrap_or_else(|e| panic!("screenshot {url} failed: {e}"));
         let png_b64 = r
             .content


### PR DESCRIPTION
## Summary

Migrate `tests/parallel.rs` from external dependencies (`example.com`, `example.org`, `httpbin.org`) to local `wiremock` servers, and extract the shared `mock_page` helper into `tests/common.rs` to eliminate duplication across test binaries.

Why:
- External hosts are out of our control: flaky latency, rate limits, schema changes, and occasional outages were the reason these tests were excluded from CI via `-E 'not test(parallel)'`. With wiremock the tests now run hermetically.
- Enables the CI `e2e` job to exercise cross-contamination and concurrent rendering coverage alongside the other E2E tests.
- The `mock_page` boilerplate was duplicated across `cli.rs`, `mcp.rs` (inline), and `parallel.rs`. A single shared helper keeps mock construction consistent.

## Test Plan

- `cargo test --workspace --locked`
- `cargo nextest run -p servo-fetch-cli --run-ignored only --locked`

Verified on macOS 14 (arm64).

## Checklist

- [x] `cargo clippy` passes with zero warnings
- [x] `cargo test` passes
- [x] `cargo fmt --check` passes
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it