### PR TITLE
feat(ci): publish signed multi-arch Docker image on release

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+*
+!Dockerfile
+!dist/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -178,6 +178,15 @@ jobs:
             gh release upload "$TAG" "$ARCHIVE.tar.gz" "$ARCHIVE.tar.gz.sha256"
           fi
 
+      - name: Upload Linux binary for docker job
+        if: runner.os == 'Linux'
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        with:
+          name: binary-${{ matrix.target }}
+          path: target/${{ matrix.target }}/release/servo-fetch
+          if-no-files-found: error
+          retention-days: 1
+
   publish-crate:
     name: Publish to crates.io
     needs: [create-release, build-release]
@@ -203,9 +212,79 @@ jobs:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
         run: cargo publish --workspace --locked --no-verify
 
+  publish-docker:
+    name: Publish Docker image
+    needs: [create-release, build-release]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    env:
+      VERSION: ${{ needs.create-release.outputs.version }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Download Linux binaries
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        with:
+          pattern: binary-*-linux-gnu
+          path: artifacts
+
+      - name: Stage binaries for docker buildx
+        run: |
+          set -euo pipefail
+          mkdir -p dist/amd64 dist/arm64
+          cp artifacts/binary-x86_64-unknown-linux-gnu/servo-fetch dist/amd64/servo-fetch
+          cp artifacts/binary-aarch64-unknown-linux-gnu/servo-fetch dist/arm64/servo-fetch
+          chmod +x dist/amd64/servo-fetch dist/arm64/servo-fetch
+
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
+        id: meta
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
+
+      - uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        id: build
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ env.VERSION }}
+            REVISION=${{ github.sha }}
+          provenance: mode=max
+          sbom: true
+
+      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Sign image with cosign (keyless)
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          cosign sign --yes --recursive "ghcr.io/${{ github.repository }}@${DIGEST}"
+
   publish-release:
     name: Publish Release
-    needs: [create-release, build-release, publish-crate]
+    needs: [create-release, build-release, publish-crate, publish-docker]
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     permissions:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,48 @@
+# syntax=docker/dockerfile:1.7
+
+ARG DEBIAN_IMAGE=debian:trixie-slim@sha256:109e2c65005bf160609e4ba6acf7783752f8502ad218e298253428690b9eaa4b
+
+FROM ${DEBIAN_IMAGE}
+
+ARG TARGETARCH
+ARG VERSION=dev
+ARG REVISION=unknown
+
+LABEL org.opencontainers.image.title="servo-fetch" \
+      org.opencontainers.image.description="Fetch, render, and extract web content via the Servo engine" \
+      org.opencontainers.image.source="https://github.com/konippi/servo-fetch" \
+      org.opencontainers.image.url="https://github.com/konippi/servo-fetch" \
+      org.opencontainers.image.documentation="https://github.com/konippi/servo-fetch#readme" \
+      org.opencontainers.image.authors="konippi" \
+      org.opencontainers.image.version="${VERSION}" \
+      org.opencontainers.image.revision="${REVISION}" \
+      org.opencontainers.image.licenses="MIT OR Apache-2.0" \
+      org.opencontainers.image.base.name="debian:trixie-slim" \
+      org.opencontainers.image.base.digest="sha256:109e2c65005bf160609e4ba6acf7783752f8502ad218e298253428690b9eaa4b"
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      curl ca-certificates \
+      libegl1 libegl-mesa0 libfontconfig1 libfreetype6 libharfbuzz0b \
+      libglib2.0-0t64 libssl3t64 \
+      fonts-dejavu-core fonts-noto-core fonts-liberation2 \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN groupadd --gid 1001 servo \
+    && useradd --uid 1001 --gid servo \
+       --shell /usr/sbin/nologin --home-dir /home/servo --create-home servo
+
+COPY --chown=servo:servo --chmod=0755 \
+     dist/${TARGETARCH}/servo-fetch /usr/local/bin/servo-fetch
+
+USER servo
+WORKDIR /home/servo
+
+EXPOSE 3000
+# fontconfig cache on /tmp for --read-only compatibility
+ENV XDG_CACHE_HOME=/tmp
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
+    CMD curl -fsS --max-time 2 http://127.0.0.1:3000/health || exit 1
+
+ENTRYPOINT ["servo-fetch"]
+CMD ["serve", "--host", "0.0.0.0", "--port", "3000"]

--- a/README.md
+++ b/README.md
@@ -177,6 +177,19 @@ Endpoints: `GET /health`, `GET /version`, `POST /v1/fetch`, `POST /v1/batch_fetc
 
 Full HTTP API reference → [`servo-fetch-cli` README](crates/servo-fetch-cli/README.md#http-api-server)
 
+## Docker
+
+Multi-arch image on GitHub Container Registry (`linux/amd64`, `linux/arm64`):
+
+```bash
+docker run --rm -p 3000:3000 ghcr.io/konippi/servo-fetch:latest
+curl -X POST http://127.0.0.1:3000/v1/fetch \
+  -H 'content-type: application/json' \
+  -d '{"url":"https://example.com"}'
+```
+
+Runs as non-root (UID 1001). Images are signed with [cosign](https://github.com/sigstore/cosign) (keyless) and published with SLSA provenance and SBOM attestations.
+
 ## Agent Skills
 
 servo-fetch ships with an [Agent Skills](https://agentskills.io/) package for AI coding agents:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -27,6 +27,7 @@ servo-fetch processes untrusted web content. The following areas are in scope:
 - `--js` output is sanitized before printing to the terminal
 - MCP `execute_js` rejects scripts longer than 10,000 characters; MCP `fetch` output is bounded by `max_length` / `start_index` to limit response size
 - HTTP API (`serve` subcommand) enforces the same SSRF protection, URL scheme whitelist, and sanitization as the CLI/MCP paths; additionally caps request bodies at 1 MiB, clamps `execute_js` expressions at 10,000 characters, and defaults to binding on `127.0.0.1` (explicit `--host` required to expose). Rate limiting, authentication, and TLS must be provided by a reverse proxy or ingress.
+- The published Docker image (`ghcr.io/konippi/servo-fetch`) runs as a non-root user (UID 1001), ships with a `HEALTHCHECK`, and is signed with [cosign](https://github.com/sigstore/cosign) keyless. Release builds attach [SLSA build provenance](https://slsa.dev/) and an [SPDX SBOM](https://spdx.dev/) as OCI attestations. Recommended deployment flags: `--read-only --tmpfs /tmp --cap-drop=ALL --security-opt=no-new-privileges`.
 - Crawl validates every discovered link against RFC 6890 before following it, enforces same-site (eTLD+1) scope by default, applies `robots.txt` per RFC 9309 (4xx → allow, 5xx/network → disallow, redirects disabled to avoid cross-authority SSRF), and rate-limits requests to a minimum 500ms interval
 
 ## Known limitations

--- a/crates/servo-fetch-cli/README.md
+++ b/crates/servo-fetch-cli/README.md
@@ -321,3 +321,40 @@ curl -X POST http://127.0.0.1:3000/v1/screenshot \
   -d '{"url":"https://example.com","full_page":true}' \
   -o page.png
 ```
+
+## Docker
+
+Multi-arch image (`linux/amd64`, `linux/arm64`) on GitHub Container Registry:
+
+```bash
+docker run --rm -p 3000:3000 ghcr.io/konippi/servo-fetch:latest
+```
+
+Override the default `serve` with any `servo-fetch` subcommand:
+
+```bash
+docker run --rm ghcr.io/konippi/servo-fetch:latest https://example.com
+docker run --rm ghcr.io/konippi/servo-fetch:latest --version
+```
+
+Minimum-privilege deployment:
+
+```bash
+docker run --rm -p 3000:3000 \
+  --read-only --tmpfs /tmp \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  ghcr.io/konippi/servo-fetch:latest
+```
+
+The image runs as UID 1001 and includes a `HEALTHCHECK` against `/health`.
+
+### Image signing
+
+Images are signed with [cosign](https://github.com/sigstore/cosign) keyless via GitHub OIDC and ship with [SLSA build provenance](https://slsa.dev/) and an [SPDX SBOM](https://spdx.dev/) as OCI attestations.
+
+```bash
+cosign verify ghcr.io/konippi/servo-fetch:latest \
+  --certificate-identity-regexp '^https://github.com/konippi/servo-fetch/' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+```

--- a/skills/servo-fetch/references/guide.md
+++ b/skills/servo-fetch/references/guide.md
@@ -117,3 +117,13 @@ servo-fetch serve --port 3000
 ```
 
 `POST /v1/fetch`, `/v1/batch_fetch`, `/v1/screenshot`, `/v1/execute_js`, `/v1/crawl`, `/v1/map` accept the same parameters as the MCP tools as JSON bodies. `GET /health` and `/version` are also exposed.
+
+### Docker
+
+Prebuilt multi-arch image published on every release:
+
+```bash
+docker run --rm -p 3000:3000 ghcr.io/konippi/servo-fetch:latest
+```
+
+The container runs the HTTP API on port 3000 as non-root (UID 1001) and exposes the same endpoints as above.


### PR DESCRIPTION
## Summary

Adds the Docker image half of #123. On every release tag push, `release.yml` now downloads the freshly-built Linux x86_64 / aarch64 binaries from the existing build matrix and publishes a multi-arch image to `ghcr.io/konippi/servo-fetch` with cosign keyless signatures plus SLSA provenance and SPDX SBOM attestations.

## Related issues

Part of #123

## Test Plan

- Local image smoke (14 checks) — cross-compiled a 75-line Rust stub for `aarch64-linux-gnu` that mirrors the servo-fetch CLI surface (`--version`, URL fetch, `serve`) and staged it as `dist/arm64/servo-fetch`, then `docker buildx build --platform linux/arm64 --load -t servo-fetch:qa .`. Verified OCI labels (11 fields including `base.name`/`base.digest`), `USER = servo / uid=1001`, default `CMD` starts the HTTP server, `/health` + `/version` respond, `XDG_CACHE_HOME=/tmp` works, `/tmp` is writable (stub wrote a test file), `ENTRYPOINT` override paths (`--version`, URL) work, `HEALTHCHECK` reaches `healthy` within start-period, full hardening flags (`--read-only --tmpfs /tmp --cap-drop=ALL --security-opt=no-new-privileges`) keep the container running and serving, final image 131 MB.
- Workflow static checks — `actionlint .github/workflows/release.yml` clean, `docker buildx build --check` clean on both `linux/amd64` and `linux/arm64`.

## Checklist

- [x] Ran `cargo fmt`, `cargo clippy`, and `cargo test` locally (no Rust changes in this PR, but last main run was clean)
- [x] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed
- [x] Tests added or updated, or explained why not in the Test Plan (no Rust changes; infra validated with actionlint + local image QA)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it