### PR TITLE
chore(ci): suppress zizmor cache-poisoning for sccache inline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,6 +84,7 @@ jobs:
           toolchain: "1.95.0"
           targets: ${{ matrix.target }}
 
+      # zizmor: ignore[cache-poisoning] -- maintainer-controlled trigger only (tag push, no PR)
       - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
 
       - name: Install system dependencies (Linux)

--- a/.github/workflows/test-smoke.yml
+++ b/.github/workflows/test-smoke.yml
@@ -51,6 +51,7 @@ jobs:
           toolchain: "1.95.0"
           targets: ${{ matrix.target }}
 
+      # zizmor: ignore[cache-poisoning] -- maintainer-controlled trigger only (tag push, no PR)
       - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
       - name: Configure sccache
         shell: bash


### PR DESCRIPTION
## Summary

Adds inline `# zizmor: ignore[cache-poisoning]` comments to the `mozilla-actions/sccache-action` uses in `release.yml` and `test-smoke.yml`, documenting that both workflows run only on maintainer-controlled triggers (tag push, plus `workflow_dispatch` for smoke) and therefore cannot be reached by unprivileged PR contributors. 

## Related issues

N/A

## Test Plan

N/A

## Checklist

- [x] Ran `cargo fmt`, `cargo clippy`, and `cargo test` locally (no Rust changes; unaffected)
- [x] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed (n/a — CI-only change, no user-visible behavior)
- [x] Tests added or updated, or explained why not in the Test Plan (n/a — comment-only change verified by actionlint)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it