### PR TITLE
fix(ci): update smoke test expectations for new AddressNotAllowed message

### DIFF
--- a/.github/workflows/test-smoke.yml
+++ b/.github/workflows/test-smoke.yml
@@ -113,8 +113,8 @@ jobs:
             }
           }
           check 'file:///etc/passwd'                          "scheme 'file' not allowed"
-          check 'http://127.0.0.1'                            'access to private/local addresses is not allowed: 127\.0\.0\.1'
-          check 'http://169.254.169.254/latest/meta-data/'    'access to private/local addresses is not allowed: 169\.254\.169\.254'
+          check 'http://127.0.0.1'                            'address not allowed: 127\.0\.0\.1'
+          check 'http://169.254.169.254/latest/meta-data/'    'address not allowed: 169\.254\.169\.254'
 
       - name: Smoke (L2 — network, in-shell retry)
         shell: bash


### PR DESCRIPTION
## Summary

Updates the `check 'http://127.0.0.1' ...` and `check 'http://169.254.169.254/...'` L1 smoke assertions in `test-smoke.yml` to match the current CLI surface error message `address not allowed: {host}` (from `FetchError::AddressNotAllowed` in `crates/servo-fetch/src/error.rs`).

## Related issues

N/A

## Test Plan

- Confirmed the new message against the source: `crates/servo-fetch/src/error.rs:31` defines `#[error("address not allowed: {0}")] AddressNotAllowed(String)`, which is what the CLI prints on stderr when `validate_url` rejects a private host. Cross-checked against the serve-side test in `crates/servo-fetch-cli/src/serve.rs` which already asserts `body.contains("address not allowed")`.

## Checklist

- [x] Ran `cargo fmt`, `cargo clippy`, and `cargo test` locally (no Rust changes; unaffected)
- [x] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed (n/a — CI-only fix, no user-visible behavior change)
- [x] Tests added or updated, or explained why not in the Test Plan (the smoke test itself is what we're fixing; the regression can be further guarded by exercising smoke on non-tag pushes, tracked separately)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it