### PR TITLE
chore(build): tune cargo profiles and linker config

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,14 @@
+[target.'cfg(all())']
+rustflags = [
+  "-C", "symbol-mangling-version=v0",
+]
+
+[target.'cfg(all(target_env = "msvc", target_os = "windows"))']
+linker = "rust-lld"
+rustflags = [
+  "-C", "target-feature=+crt-static",
+  "-C", "link-arg=/Brepro",
+]
+
+[env]
+MACOSX_DEPLOYMENT_TARGET = "13.0"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,10 @@ cargo deny check                                            # License & advisory
 typos                                                       # Spell check
 ```
 
+### Profiling
+
+`cargo build --profile profiling` produces a release-optimized binary with debug symbols and thin LTO for use with `cargo flamegraph` or `perf record`.
+
 ### Coverage
 
 ```sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,3 +71,13 @@ inherits = "test"
 debug = 0
 strip = "debuginfo"
 incremental = false
+
+[profile.profiling]
+inherits = "release"
+debug = true
+strip = "none"
+lto = "thin"
+codegen-units = 1
+
+[profile.dev.package."*"]
+opt-level = 1


### PR DESCRIPTION
## Summary

Tune cargo build configuration so `cargo run` / `cargo test` stay usable despite Servo's heavy render pipeline, and add a dedicated profile for profiling work.

## Test Plan

Measured cold build + runtime + binary size locally on M3 Pro (Rust 1.95.0, macOS) with and without these changes:

| Metric | Before | After | Delta |
|---|---|---|---|
| `cargo build -p servo-fetch-cli` | ~2–8 min (partial cache) | 13m 27s | +5–8 min cold |
| `servo-fetch fetch https://example.com` (dev binary) | 6.74 s | **4.35 s** | **−35 %** |
| `target/debug/servo-fetch` size | 370 MB | **215 MB** | **−42 %** |

## Checklist

- [x] Ran `cargo fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
- [x] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed
- [x] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it