### PR TITLE
ci(nextest): add repository config and wire profiles into CI

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,26 @@
+[profile.default]
+slow-timeout = { period = "5s", terminate-after = 4 }
+final-status-level = "slow"
+
+[[profile.default.overrides]]
+filter = 'package(=servo-fetch-cli) & test(=concurrent_full_page_screenshots_are_distinct)'
+threads-required = "num-test-threads"
+slow-timeout = { period = "120s", terminate-after = 3 }
+
+[[profile.default.overrides]]
+filter = 'package(=servo-fetch-cli) & kind(=test)'
+threads-required = 2
+slow-timeout = { period = "60s", terminate-after = 4 }
+
+[profile.ci]
+fail-fast = false
+failure-output = "immediate-final"
+
+[profile.ci.junit]
+path = "junit.xml"
+store-failure-output = true
+store-success-output = false
+
+[profile.ci-e2e]
+inherits = "ci"
+retries = { backoff = "fixed", count = 2, delay = "2s" }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
               - 'clippy.toml'
               - '.rustfmt.toml'
               - 'rust-toolchain.toml'
+              - '.config/nextest.toml'
               - '.github/workflows/ci.yml'
 
   clippy:
@@ -99,8 +100,16 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y cmake clang pkg-config libfontconfig-dev libfreetype-dev \
             libssl-dev libglib2.0-dev libegl1-mesa-dev
-      - run: cargo nextest run --workspace --locked --cargo-profile ci --no-fail-fast
+      - run: cargo nextest run --workspace --locked --cargo-profile ci --profile ci
       - run: cargo test --workspace --locked --profile ci --doc
+      - name: Upload JUnit report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: nextest-junit-ci
+          path: target/nextest/ci/junit.xml
+          if-no-files-found: ignore
+          retention-days: 14
       - name: sccache stats
         if: always()
         run: sccache --show-stats
@@ -182,7 +191,6 @@ jobs:
       RUSTC_WRAPPER: sccache
       CCACHE: sccache
       RUST_BACKTRACE: 1
-      NEXTEST_RETRIES: 2
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -199,7 +207,15 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y cmake clang pkg-config libfontconfig-dev libfreetype-dev \
             libssl-dev libglib2.0-dev libegl1-mesa-dev
-      - run: cargo nextest run -p servo-fetch-cli --run-ignored only --locked --cargo-profile ci --no-fail-fast
+      - run: cargo nextest run -p servo-fetch-cli --run-ignored only --locked --cargo-profile ci --profile ci-e2e
+      - name: Upload JUnit report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: nextest-junit-e2e
+          path: target/nextest/ci-e2e/junit.xml
+          if-no-files-found: ignore
+          retention-days: 14
       - name: sccache stats
         if: always()
         run: sccache --show-stats


### PR DESCRIPTION
## Summary

Introduce `.config/nextest.toml` with three profiles and wire the CI workflow to use them. Centralizes settings that were previously scattered between `--no-fail-fast` CLI flags and a `NEXTEST_RETRIES=2` env var, and surfaces slow-test / subprocess-leak diagnostics that the default profile would miss.

## Related issues

N/A

## Test Plan

Validated locally with `cargo-nextest 0.9.133` on macOS (aarch64-apple-darwin):

- `cargo nextest show-config test-groups --profile {default,ci,ci-e2e}` — all three profiles load
- End-to-end run: `cargo nextest run --profile ci -p servo-fetch --test extract` → 15/15 passed
- JUnit output at `target/nextest/ci/junit.xml` has valid `<testsuites>` / `<testcase>` structure

## Checklist

- [x] Ran `cargo fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
- [x] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed
- [x] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it