### PR TITLE
ci(taplo): add TOML formatter config and workflow

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,14 +1,9 @@
 [target.'cfg(all())']
-rustflags = [
-  "-C", "symbol-mangling-version=v0",
-]
+rustflags = ["-C", "symbol-mangling-version=v0"]
 
 [target.'cfg(all(target_env = "msvc", target_os = "windows"))']
 linker = "rust-lld"
-rustflags = [
-  "-C", "target-feature=+crt-static",
-  "-C", "link-arg=/Brepro",
-]
+rustflags = ["-C", "target-feature=+crt-static", "-C", "link-arg=/Brepro"]
 
 [env]
 MACOSX_DEPLOYMENT_TARGET = "13.0"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
               - 'clippy.toml'
               - '.rustfmt.toml'
               - 'rust-toolchain.toml'
+              - 'taplo.toml'
               - '.config/nextest.toml'
               - '.github/workflows/ci.yml'
 
@@ -132,6 +133,23 @@ jobs:
           components: rustfmt
       - run: cargo fmt --all --check
 
+  taplo:
+    name: TOML Lint
+    needs: [changes]
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: taiki-e/install-action@b5fddbb5361bce8a06fb168c9d403a6cc552b084 # v2.75.29
+        with:
+          tool: taplo-cli
+      - run: taplo fmt --check --diff
+
   deny:
     name: Licenses & Advisories
     needs: [changes]
@@ -223,7 +241,7 @@ jobs:
   ci-passed:
     name: CI Passed
     if: '!cancelled()'
-    needs: [changes, clippy, test, e2e, fmt, deny, shear, typos]
+    needs: [changes, clippy, test, e2e, fmt, taplo, deny, shear, typos]
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,7 @@ cargo test -- --ignored                                     # Run Servo+network 
 cargo clippy                                                # Lint (pedantic)
 cargo fmt                                                   # Format
 cargo deny check                                            # License & advisory check
+taplo fmt                                                   # Format TOML files (install: cargo install taplo-cli --locked)
 typos                                                       # Spell check
 ```
 

--- a/deny.toml
+++ b/deny.toml
@@ -2,34 +2,34 @@
 version = 2
 yanked = "deny"
 ignore = [
-    "RUSTSEC-2023-0071", # bincode unmaintained
-    "RUSTSEC-2024-0436", # paste unmaintained
-    "RUSTSEC-2025-0075", # unic-common unmaintained
-    "RUSTSEC-2025-0080", # unic-ucd-version unmaintained
-    "RUSTSEC-2025-0081", # unic-ucd-ident unmaintained
-    "RUSTSEC-2025-0098", # unic-char-range unmaintained
-    "RUSTSEC-2025-0100", # unic-char-property unmaintained
-    "RUSTSEC-2025-0141", # ml-dsa timing side-channel
-    "RUSTSEC-2025-0144", # rsa marvin attack
+  "RUSTSEC-2023-0071", # bincode unmaintained
+  "RUSTSEC-2024-0436", # paste unmaintained
+  "RUSTSEC-2025-0075", # unic-common unmaintained
+  "RUSTSEC-2025-0080", # unic-ucd-version unmaintained
+  "RUSTSEC-2025-0081", # unic-ucd-ident unmaintained
+  "RUSTSEC-2025-0098", # unic-char-range unmaintained
+  "RUSTSEC-2025-0100", # unic-char-property unmaintained
+  "RUSTSEC-2025-0141", # ml-dsa timing side-channel
+  "RUSTSEC-2025-0144", # rsa marvin attack
 ]
 
 [licenses]
 version = 2
 allow = [
-    "Apache-2.0",
-    "Apache-2.0 WITH LLVM-exception",
-    "BSD-2-Clause",
-    "BSD-3-Clause",
-    "BSL-1.0",
-    "CC0-1.0",
-    "CDLA-Permissive-2.0",
-    "ISC",
-    "MIT",
-    "MIT-0",
-    "MPL-2.0",
-    "NCSA",
-    "Unicode-3.0",
-    "Zlib",
+  "Apache-2.0",
+  "Apache-2.0 WITH LLVM-exception",
+  "BSD-2-Clause",
+  "BSD-3-Clause",
+  "BSL-1.0",
+  "CC0-1.0",
+  "CDLA-Permissive-2.0",
+  "ISC",
+  "MIT",
+  "MIT-0",
+  "MPL-2.0",
+  "NCSA",
+  "Unicode-3.0",
+  "Zlib",
 ]
 
 [bans]

--- a/taplo.toml
+++ b/taplo.toml
@@ -1,0 +1,7 @@
+exclude = ["benchmarks/**"]
+
+[formatting]
+array_auto_collapse = false
+array_auto_expand = false
+align_comments = false
+column_width = 120

--- a/typos.toml
+++ b/typos.toml
@@ -1,9 +1,5 @@
 [files]
-extend-exclude = [
-    "target/",
-    "Cargo.lock",
-    "tests/fixtures/",
-]
+extend-exclude = ["target/", "Cargo.lock", "tests/fixtures/"]
 
 [default]
 extend-ignore-identifiers-re = ["^[0-9a-f]{7,10}$"]


### PR DESCRIPTION
## Summary

Introduce [Taplo](https://taplo.tamasfe.dev/) as the repository's TOML formatter/linter and wire it into CI. Prevents formatting drift across `Cargo.toml` / `deny.toml` / `typos.toml` and similar config files, and reduces diff noise in dependency bump PRs.

## Related issues

N/A

## Test Plan

- `actionlint` on `.github/workflows/ci.yml`
- Ran `taplo fmt --check

## Checklist

- [x] Ran `cargo fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
- [x] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed
- [x] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it