### PR TITLE
fix(crawl): wire --selector and --json through to CrawlOptions

### DIFF
--- a/crates/servo-fetch-cli/src/commands/crawl.rs
+++ b/crates/servo-fetch-cli/src/commands/crawl.rs
@@ -7,31 +7,7 @@ use crate::progress::Progress;
 
 /// Crawl a site starting from `args.url` and stream results to stdout.
 pub(crate) fn run(args: &CrawlArgs) -> anyhow::Result<()> {
-    let opts = servo_fetch::CrawlOptions::new(&args.url)
-        .limit(args.limit)
-        .max_depth(args.max_depth)
-        .timeout(std::time::Duration::from_secs(args.timeout))
-        .settle(std::time::Duration::from_millis(args.settle))
-        .concurrency(usize::try_from(args.concurrency).unwrap_or(usize::MAX))
-        .delay(if args.delay_ms == 0 {
-            None
-        } else {
-            Some(std::time::Duration::from_millis(args.delay_ms))
-        });
-    let opts = if args.include.is_empty() {
-        opts
-    } else {
-        opts.include(&args.include.iter().map(String::as_str).collect::<Vec<_>>())
-    };
-    let opts = if args.exclude.is_empty() {
-        opts
-    } else {
-        opts.exclude(&args.exclude.iter().map(String::as_str).collect::<Vec<_>>())
-    };
-    let opts = match args.user_agent {
-        Some(ref ua) => opts.user_agent(ua),
-        None => opts,
-    };
+    let opts = build_crawl_options(args);
 
     let progress = Progress::new();
     let mut completed = 0usize;
@@ -56,6 +32,34 @@ pub(crate) fn run(args: &CrawlArgs) -> anyhow::Result<()> {
         return Err(e.into());
     }
     Ok(())
+}
+
+fn build_crawl_options(args: &CrawlArgs) -> servo_fetch::CrawlOptions {
+    let mut opts = servo_fetch::CrawlOptions::new(&args.url)
+        .limit(args.limit)
+        .max_depth(args.max_depth)
+        .timeout(std::time::Duration::from_secs(args.timeout))
+        .settle(std::time::Duration::from_millis(args.settle))
+        .concurrency(usize::try_from(args.concurrency).unwrap_or(usize::MAX))
+        .delay(if args.delay_ms == 0 {
+            None
+        } else {
+            Some(std::time::Duration::from_millis(args.delay_ms))
+        })
+        .json(args.json);
+    if !args.include.is_empty() {
+        opts = opts.include(&args.include.iter().map(String::as_str).collect::<Vec<_>>());
+    }
+    if !args.exclude.is_empty() {
+        opts = opts.exclude(&args.exclude.iter().map(String::as_str).collect::<Vec<_>>());
+    }
+    if let Some(ref s) = args.selector {
+        opts = opts.selector(s);
+    }
+    if let Some(ref ua) = args.user_agent {
+        opts = opts.user_agent(ua);
+    }
+    opts
 }
 
 fn emit_json(result: &servo_fetch::CrawlResult) -> io::Result<()> {

--- a/crates/servo-fetch-cli/tests/cli.rs
+++ b/crates/servo-fetch-cli/tests/cli.rs
@@ -213,6 +213,102 @@ fn crawl_produces_ndjson() {
 }
 
 #[test]
+#[ignore = "e2e: requires Servo engine"]
+fn crawl_selector_scopes_content() {
+    block_on(async {
+        let s = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/"))
+            .respond_with(mock_page(
+                "<html><head><title>T</title></head><body><h1>Kept</h1><p>Dropped paragraph</p></body></html>",
+            ))
+            .mount(&s)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/robots.txt"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&s)
+            .await;
+        let output = servo_fetch()
+            .args([
+                "crawl",
+                &s.uri(),
+                "--selector",
+                "h1",
+                "--limit",
+                "1",
+                "--max-depth",
+                "0",
+                "--timeout",
+                "30",
+                "--allow-private-addresses",
+            ])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let text = std::str::from_utf8(&output).unwrap();
+        assert!(text.contains("Kept"), "selector should keep h1 text, got: {text}");
+        assert!(
+            !text.contains("Dropped paragraph"),
+            "selector should scope away from <p>, got: {text}"
+        );
+    });
+}
+
+#[test]
+#[ignore = "e2e: requires Servo engine"]
+fn crawl_json_embeds_structured_content() {
+    block_on(async {
+        let s = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/"))
+            .respond_with(mock_page(
+                "<html><head><title>JSONCrawl</title></head><body><article>Structured body content for extraction.</article></body></html>",
+            ))
+            .mount(&s)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/robots.txt"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&s)
+            .await;
+        let output = servo_fetch()
+            .args([
+                "crawl",
+                &s.uri(),
+                "--json",
+                "--limit",
+                "1",
+                "--max-depth",
+                "0",
+                "--timeout",
+                "30",
+                "--allow-private-addresses",
+            ])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let line = std::str::from_utf8(&output)
+            .unwrap()
+            .lines()
+            .next()
+            .expect("expected NDJSON line");
+        let outer: serde_json::Value = serde_json::from_str(line).expect("outer NDJSON must parse");
+        let content_str = outer["content"].as_str().expect("content must be a string");
+        let inner: serde_json::Value =
+            serde_json::from_str(content_str).expect("content must be structured JSON, not markdown");
+        assert!(
+            inner.get("title").is_some(),
+            "inner JSON should have a 'title' field, got: {content_str}"
+        );
+    });
+}
+
+#[test]
 fn crawl_rejects_private_ip() {
     servo_fetch()
         .args(["crawl", "http://127.0.0.1/"])

--- a/crates/servo-fetch-cli/tests/common.rs
+++ b/crates/servo-fetch-cli/tests/common.rs
@@ -5,7 +5,5 @@
 use wiremock::ResponseTemplate;
 
 pub fn mock_page(html: impl Into<String>) -> ResponseTemplate {
-    ResponseTemplate::new(200)
-        .insert_header("content-type", "text/html")
-        .set_body_string(html.into())
+    ResponseTemplate::new(200).set_body_raw(html.into().into_bytes(), "text/html; charset=utf-8")
 }


### PR DESCRIPTION
## Summary

Wire --selector and --json through to `CrawlOptions`.

## Related issues

N/A

## Test Plan

- `cargo test --workspace --locked`: all passed

## Checklist

- [x] Ran `cargo fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
- [x] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed
- [x] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it
