### PR TITLE
refactor(tests): use set_body_raw for explicit mime types in map tests

### DIFF
--- a/crates/servo-fetch/src/map.rs
+++ b/crates/servo-fetch/src/map.rs
@@ -770,7 +770,7 @@ mod tests {
             let xml = r#"<?xml version="1.0"?><urlset><url><loc>https://example.com/a</loc></url></urlset>"#;
             Mock::given(method("GET"))
                 .and(path("/sitemap.xml"))
-                .respond_with(ResponseTemplate::new(200).set_body_string(xml))
+                .respond_with(ResponseTemplate::new(200).set_body_raw(xml.as_bytes().to_vec(), "application/xml"))
                 .mount(&server)
                 .await;
 
@@ -789,9 +789,10 @@ mod tests {
             let server = MockServer::start().await;
             Mock::given(method("GET"))
                 .and(path("/sitemap.xml"))
-                .respond_with(
-                    ResponseTemplate::new(200).set_body_string("<!DOCTYPE html><html><body>Not Found</body></html>"),
-                )
+                .respond_with(ResponseTemplate::new(200).set_body_raw(
+                    b"<!DOCTYPE html><html><body>Not Found</body></html>".to_vec(),
+                    "text/html; charset=utf-8",
+                ))
                 .mount(&server)
                 .await;
 
@@ -836,11 +837,7 @@ mod tests {
 
             Mock::given(method("GET"))
                 .and(path("/sitemap.xml.gz"))
-                .respond_with(
-                    ResponseTemplate::new(200)
-                        .set_body_bytes(compressed)
-                        .insert_header("content-type", "application/gzip"),
-                )
+                .respond_with(ResponseTemplate::new(200).set_body_raw(compressed, "application/gzip"))
                 .mount(&server)
                 .await;
 
@@ -859,9 +856,10 @@ mod tests {
             let server = MockServer::start().await;
             Mock::given(method("GET"))
                 .and(path("/"))
-                .respond_with(
-                    ResponseTemplate::new(200).set_body_string(r#"<html><body><a href="/link">x</a></body></html>"#),
-                )
+                .respond_with(ResponseTemplate::new(200).set_body_raw(
+                    br#"<html><body><a href="/link">x</a></body></html>"#.to_vec(),
+                    "text/html; charset=utf-8",
+                ))
                 .mount(&server)
                 .await;
 


### PR DESCRIPTION
## Summary

Replace `set_body_string` / `set_body_bytes + insert_header` patterns with `set_body_raw(body, mime)` across `map.rs` integration tests so the mocked `Content-Type` actually matches the payload (XML, HTML, gzip).

## Related issues

Refs #159

## Test Plan

- `cargo test -p servo-fetch --lib map::` — 24/24 passed (all map unit + integration tests)
- `cargo nextest run -p servo-fetch-cli --run-ignored only --locked --profile ci-e2e`

## Checklist

- [x] Ran `cargo fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
- [x] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed — _N/A, test-only change_
- [x] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it