### PR TITLE
fix(build): drop +crt-static on Windows to match mozjs-sys CRT

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,7 +3,7 @@ rustflags = ["-C", "symbol-mangling-version=v0"]
 
 [target.'cfg(all(target_env = "msvc", target_os = "windows"))']
 linker = "rust-lld"
-rustflags = ["-C", "target-feature=+crt-static", "-C", "link-arg=/Brepro"]
+rustflags = ["-C", "link-arg=/Brepro"]
 
 [env]
 MACOSX_DEPLOYMENT_TARGET = "13.0"


### PR DESCRIPTION
## Summary

Drop +crt-static on Windows to match mozjs-sys CRT.

## Related issues

Related: https://github.com/konippi/servo-fetch/actions/runs/25651323871/job/75290026135

## Test Plan

N/A

## Checklist

- [x] Ran `cargo fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
- [x] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed
- [x] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it
