### PR TITLE
feat(schema): add CSS-selector schema extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ let md = servo_fetch::markdown("https://example.com")?;  // Library: one-liner
 - **Zero dependencies** — single binary, no Chromium, no API key
 - **Real JS execution** — SpiderMonkey runs JavaScript, parallel CSS engine computes layout
 - **Layout-aware extraction** — strips navbars, sidebars, footers by actual rendered position
+- **Schema-driven JSON** — declarative CSS-selector schema pulls structured data
 - **Parallel batch fetch** — multiple URLs fetched concurrently
 - **Site crawling** — BFS link traversal with robots.txt, same-site scope, and rate limiting
 - **URL discovery** — sitemap-based URL mapping without rendering (fast, lightweight)
@@ -91,6 +92,7 @@ servo-fetch "https://example.com"                        # Markdown (default)
 servo-fetch "https://example.com" --json                 # Structured JSON
 servo-fetch "https://example.com" --screenshot page.png  # PNG screenshot
 servo-fetch "https://example.com" --js "document.title"  # Run JavaScript
+servo-fetch "https://example.com" --schema schema.json   # Schema-driven JSON
 servo-fetch URL1 URL2 URL3                               # Parallel batch
 servo-fetch crawl "https://docs.example.com" --limit 20  # Crawl a site
 servo-fetch map "https://example.com"                    # Discover URLs via sitemap

--- a/crates/servo-fetch-cli/README.md
+++ b/crates/servo-fetch-cli/README.md
@@ -60,6 +60,28 @@ servo-fetch "https://example.com" --selector "article"
 servo-fetch "https://example.com" --selector ".main-content" --json
 ```
 
+### Structured extraction (schema)
+
+Pull a declarative set of fields into JSON using CSS selectors — no LLM required. Define a schema once, reuse it across URLs:
+
+```bash
+servo-fetch "https://shop.example.com" --schema schema.json
+servo-fetch URL1 URL2 URL3 --schema schema.json     # batch → NDJSON
+```
+
+```json
+{
+  "base_selector": ".product",
+  "fields": [
+    { "name": "title", "selector": "h2", "type": "text" },
+    { "name": "price", "selector": ".price", "type": "text" },
+    { "name": "url", "selector": "a", "type": "attribute", "attribute": "href" }
+  ]
+}
+```
+
+Field `type` values: `text`, `attribute`, `html`, `inner_html`, `nested_list`. See [`servo_fetch::schema`](https://docs.rs/servo-fetch/latest/servo_fetch/schema/) for the full reference.
+
 ### Crawl a site
 
 ```bash
@@ -108,6 +130,7 @@ See [HTTP API server](#http-api-server) below for the endpoint reference.
 | `--js <EXPR>` | Execute JavaScript and print result |
 | `--selector <CSS>` | Extract specific section by CSS selector |
 | `--raw html\|text` | Raw HTML or plain text output |
+| `--schema <FILE>` | Extract structured JSON using a CSS-selector schema file |
 | `-t, --timeout <SECS>` | Page load timeout in seconds (default: 30) |
 | `--settle <MS>` | Extra wait after load event in ms (default: 0, max: 10000) |
 | `--user-agent <UA>` | Override the User-Agent string |

--- a/crates/servo-fetch-cli/src/cli.rs
+++ b/crates/servo-fetch-cli/src/cli.rs
@@ -69,6 +69,10 @@ pub(crate) struct FetchArgs {
     /// Override the User-Agent string
     #[arg(long, value_name = "UA")]
     pub user_agent: Option<String>,
+
+    /// Path to a CSS-selector schema file for structured JSON extraction
+    #[arg(long, value_name = "FILE", conflicts_with_all = ["screenshot", "js", "raw", "selector"])]
+    pub schema: Option<std::path::PathBuf>,
 }
 
 /// Raw output mode.
@@ -251,5 +255,14 @@ mod cli_tests {
             .assert()
             .failure()
             .stderr(predicate::str::contains("--screenshot"));
+    }
+
+    #[test]
+    fn schema_conflicts_with_selector() {
+        servo_fetch()
+            .args(["--schema", "s.json", "--selector", "div", "https://example.com"])
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains("cannot be used with"));
     }
 }

--- a/crates/servo-fetch-cli/src/commands/fetch.rs
+++ b/crates/servo-fetch-cli/src/commands/fetch.rs
@@ -30,7 +30,7 @@ fn run_single(args: &FetchArgs, url_str: &str) -> Result<()> {
     let progress = Progress::new();
     progress.ticker(&format!("Fetching {url_str}..."));
 
-    let opts = build_fetch_options(args, url_str);
+    let opts = build_fetch_options(args, url_str)?;
     let page = servo_fetch::fetch(opts).map_err(anyhow::Error::from);
     progress.clear();
     let page = page?;
@@ -42,6 +42,8 @@ async fn run_batch(args: &FetchArgs, urls: &[String]) -> Result<()> {
     let progress = Progress::new();
     progress.header(&format!("Fetching {total} URLs..."));
 
+    let schema = args.schema.as_ref().map(|p| load_schema(p)).transpose()?;
+
     let sem = std::sync::Arc::new(tokio::sync::Semaphore::new(4));
     let (tx, mut rx) = tokio::sync::mpsc::channel::<(String, std::result::Result<Page, servo_fetch::Error>)>(total);
 
@@ -52,14 +54,17 @@ async fn run_batch(args: &FetchArgs, urls: &[String]) -> Result<()> {
         let timeout = args.timeout;
         let settle = args.settle;
         let user_agent = args.user_agent.clone();
+        let schema = schema.clone();
         tokio::task::spawn_blocking(move || {
-            let opts = FetchOptions::new(&url_str)
+            let mut opts = FetchOptions::new(&url_str)
                 .timeout(Duration::from_secs(timeout))
                 .settle(Duration::from_millis(settle));
-            let opts = match user_agent {
-                Some(ua) => opts.user_agent(ua),
-                None => opts,
-            };
+            if let Some(ua) = user_agent {
+                opts = opts.user_agent(ua);
+            }
+            if let Some(s) = schema {
+                opts = opts.schema(s);
+            }
             let result = servo_fetch::fetch(opts);
             let _ = tx.blocking_send((url_str, result));
             drop(permit);
@@ -90,6 +95,9 @@ async fn run_batch(args: &FetchArgs, urls: &[String]) -> Result<()> {
 }
 
 fn batch_emit(args: &FetchArgs, page: &Page, url: &str) -> Result<()> {
+    if args.schema.is_some() {
+        return output::Extracted { page, url }.execute_compact();
+    }
     if args.json {
         output::Json {
             page,
@@ -120,6 +128,9 @@ fn dispatch_output(args: &FetchArgs, page: &Page, url: &str) -> Result<()> {
     if let Some(mode) = args.raw.as_ref() {
         return output::Raw { page, mode }.execute();
     }
+    if args.schema.is_some() {
+        return output::Extracted { page, url }.execute();
+    }
     let selector = args.selector.as_deref();
     if args.json {
         output::Json { page, url, selector }.execute()
@@ -128,7 +139,7 @@ fn dispatch_output(args: &FetchArgs, page: &Page, url: &str) -> Result<()> {
     }
 }
 
-fn build_fetch_options(args: &FetchArgs, url: &str) -> FetchOptions {
+fn build_fetch_options(args: &FetchArgs, url: &str) -> Result<FetchOptions> {
     let base = if args.screenshot.is_some() {
         FetchOptions::screenshot(url, args.full_page)
     } else if let Some(expr) = args.js.as_deref() {
@@ -139,8 +150,17 @@ fn build_fetch_options(args: &FetchArgs, url: &str) -> FetchOptions {
     let opts = base
         .timeout(Duration::from_secs(args.timeout))
         .settle(Duration::from_millis(args.settle));
-    match args.user_agent {
+    let opts = match args.user_agent {
         Some(ref ua) => opts.user_agent(ua),
         None => opts,
-    }
+    };
+    let opts = match args.schema {
+        Some(ref path) => opts.schema(load_schema(path)?),
+        None => opts,
+    };
+    Ok(opts)
+}
+
+fn load_schema(path: &std::path::Path) -> Result<servo_fetch::schema::ExtractSchema> {
+    servo_fetch::schema::ExtractSchema::from_path(path).map_err(|e| anyhow::anyhow!("schema '{}': {e}", path.display()))
 }

--- a/crates/servo-fetch-cli/src/output.rs
+++ b/crates/servo-fetch-cli/src/output.rs
@@ -98,6 +98,33 @@ impl JsEval<'_> {
     }
 }
 
+pub(crate) struct Extracted<'a> {
+    pub page: &'a Page,
+    pub url: &'a str,
+}
+
+impl Extracted<'_> {
+    pub(crate) fn execute(&self) -> Result<()> {
+        let body = serde_json::to_string_pretty(&self.payload())?;
+        writeln!(std::io::stdout(), "{}", servo_fetch::sanitize::sanitize(&body))?;
+        Ok(())
+    }
+
+    /// Emit a single-line NDJSON record for batch output.
+    pub(crate) fn execute_compact(&self) -> Result<()> {
+        let line = serde_json::to_string(&self.payload())?;
+        writeln!(std::io::stdout(), "{}", servo_fetch::sanitize::sanitize(&line))?;
+        Ok(())
+    }
+
+    fn payload(&self) -> serde_json::Value {
+        serde_json::json!({
+            "url": self.url,
+            "extracted": self.page.extracted.as_ref().unwrap_or(&serde_json::Value::Null),
+        })
+    }
+}
+
 pub(crate) struct Raw<'a> {
     pub page: &'a Page,
     pub mode: &'a crate::cli::RawMode,

--- a/crates/servo-fetch/README.md
+++ b/crates/servo-fetch/README.md
@@ -12,6 +12,7 @@ Looking for the CLI? See [`servo-fetch-cli`](https://crates.io/crates/servo-fetc
 
 - **Real JS execution** — SpiderMonkey runs JavaScript, parallel CSS engine computes layout
 - **Layout-aware extraction** — strips navbars, sidebars, footers by rendered position
+- **Schema-driven JSON** — declarative CSS-selector schema pulls structured data, no LLM
 - **Sync API** — no async runtime required; wrap with `spawn_blocking` for async contexts
 - **PDF auto-detection** — URLs returning PDF are automatically extracted as text
 - **Typed errors** — `Error::Timeout`, `Error::InvalidUrl`, etc. for match-based retry logic
@@ -75,6 +76,35 @@ crawl_each(
 )?;
 ```
 
+### Schema-driven JSON extraction
+
+```rust
+use servo_fetch::{fetch, FetchOptions};
+use servo_fetch::schema::ExtractSchema;
+
+// Load a schema from a file...
+let product_schema = ExtractSchema::from_path("schema.json")?;
+
+// ...or from an inline string.
+let product_schema = ExtractSchema::from_json(r#"{
+    "base_selector": ".product",
+    "fields": [
+        { "name": "title", "selector": "h2", "type": "text" },
+        { "name": "price", "selector": ".price", "type": "text" }
+    ]
+}"#)?;
+
+let page = fetch(FetchOptions::new("https://shop.example.com").schema(product_schema))?;
+if let Some(value) = &page.extracted {
+    println!("{}", serde_json::to_string_pretty(value)?);
+}
+```
+
+Field `type` values: `text`, `attribute`, `html`, `inner_html`, `nested_list`.
+An empty `selector` (`""`) reads from the matched element itself — useful
+inside `nested_list` to grab each item's own text or attribute. For
+programmatic construction, see [`ExtractSchema::builder()`].
+
 ### Error handling
 
 ```rust
@@ -113,6 +143,7 @@ let page = tokio::task::spawn_blocking(|| {
 | `crawl(opts)` | Crawl site → `Vec<CrawlResult>` |
 | `crawl_each(opts, cb)` | Crawl site, streaming results |
 | `map(opts)` | Discover URLs via sitemaps → `Vec<MappedUrl>` |
+| `schema.extract_from(html)` | Apply a CSS-selector schema to HTML → `serde_json::Value` |
 
 See [docs.rs](https://docs.rs/servo-fetch) for the full API reference and [`examples/`](examples/) for complete runnable programs.
 

--- a/crates/servo-fetch/examples/schema_extract.rs
+++ b/crates/servo-fetch/examples/schema_extract.rs
@@ -1,0 +1,26 @@
+//! Extract structured JSON from a page using a CSS-selector schema.
+
+use servo_fetch::schema::ExtractSchema;
+use servo_fetch::{FetchOptions, fetch};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let product_schema = ExtractSchema::from_json(
+        r#"{
+        "base_selector": ".product",
+        "fields": [
+            { "name": "title", "selector": "h2", "type": "text" },
+            { "name": "price", "selector": ".price", "type": "text" },
+            { "name": "url", "selector": "a", "type": "attribute", "attribute": "href" }
+        ]
+    }"#,
+    )?;
+
+    let page = fetch(FetchOptions::new("https://shop.example.com").schema(product_schema))?;
+
+    match page.extracted {
+        Some(value) => println!("{}", serde_json::to_string_pretty(&value)?),
+        None => println!("no structured data extracted"),
+    }
+
+    Ok(())
+}

--- a/crates/servo-fetch/src/error.rs
+++ b/crates/servo-fetch/src/error.rs
@@ -47,6 +47,10 @@ pub enum Error {
     #[error(transparent)]
     Extract(#[from] crate::extract::ExtractError),
 
+    /// Schema-based structured extraction failed.
+    #[error(transparent)]
+    Schema(#[from] crate::schema::SchemaError),
+
     /// An I/O error occurred.
     #[error(transparent)]
     Io(#[from] std::io::Error),

--- a/crates/servo-fetch/src/fetch.rs
+++ b/crates/servo-fetch/src/fetch.rs
@@ -26,6 +26,9 @@ pub struct Page {
     /// Accessibility tree (AccessKit), if requested.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub accessibility_tree: Option<String>,
+    /// Structured data extracted via [`FetchOptions::schema`].
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extracted: Option<serde_json::Value>,
     #[serde(skip)]
     screenshot_png: Option<Vec<u8>>,
 }
@@ -115,6 +118,7 @@ impl Page {
                 .collect(),
             screenshot_png,
             accessibility_tree: page.accessibility_tree,
+            extracted: None,
         }
     }
 }
@@ -188,6 +192,7 @@ pub struct FetchOptions {
     pub(crate) settle: Duration,
     pub(crate) mode: FetchMode,
     pub(crate) user_agent: Option<String>,
+    pub(crate) extract_schema: Option<crate::schema::ExtractSchema>,
 }
 
 impl FetchOptions {
@@ -199,6 +204,7 @@ impl FetchOptions {
             settle: Duration::ZERO,
             mode: FetchMode::Content,
             user_agent: None,
+            extract_schema: None,
         }
     }
 
@@ -233,6 +239,12 @@ impl FetchOptions {
     /// Override the User-Agent string for this request.
     pub fn user_agent(mut self, ua: impl Into<String>) -> Self {
         self.user_agent = Some(sanitize_user_agent(ua.into()));
+        self
+    }
+
+    /// Extract structured data from the rendered page using the given schema.
+    pub fn schema(mut self, schema: crate::schema::ExtractSchema) -> Self {
+        self.extract_schema = Some(schema);
         self
     }
 }
@@ -281,7 +293,11 @@ pub fn fetch(opts: FetchOptions) -> crate::error::Result<Page> {
         }
     })?;
 
-    Ok(Page::from_servo(servo_page))
+    let mut page = Page::from_servo(servo_page);
+    if let Some(schema) = opts.extract_schema.as_ref() {
+        page.extracted = Some(schema.extract_from(&page.html));
+    }
+    Ok(page)
 }
 
 /// Fetch a URL and return readable Markdown.

--- a/crates/servo-fetch/src/lib.rs
+++ b/crates/servo-fetch/src/lib.rs
@@ -10,6 +10,7 @@
 
 pub mod extract;
 pub mod sanitize;
+pub mod schema;
 
 pub(crate) mod bridge;
 pub(crate) mod crawl;

--- a/crates/servo-fetch/src/schema.rs
+++ b/crates/servo-fetch/src/schema.rs
@@ -1,0 +1,826 @@
+//! CSS-selector schema extraction.
+
+use dom_query::{Document, Matcher, Selection};
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+
+/// Maximum `NestedList` nesting depth allowed in a schema.
+const MAX_NESTING_DEPTH: usize = 64;
+
+/// Schema parse or validation error.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum SchemaError {
+    /// A CSS selector failed to parse.
+    #[error("invalid CSS selector '{selector}' in field '{field}'")]
+    InvalidSelector {
+        /// Field whose selector failed.
+        field: String,
+        /// The offending selector text.
+        selector: String,
+    },
+    /// The schema JSON itself is malformed.
+    #[error("failed to parse schema: {0}")]
+    Parse(#[from] serde_json::Error),
+    /// Failed to read the schema file from disk.
+    #[error("failed to read schema file: {0}")]
+    Io(#[from] std::io::Error),
+    /// Schema nesting exceeds [`MAX_NESTING_DEPTH`].
+    #[error("schema nesting too deep at field '{field}' ({depth} levels, max {max})")]
+    TooDeep {
+        /// Dotted path to the field that tripped the limit.
+        field: String,
+        /// Depth at which the limit was tripped.
+        depth: usize,
+        /// Maximum depth allowed.
+        max: usize,
+    },
+}
+
+/// Declarative extraction schema.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct ExtractSchema {
+    /// Repeated container selector; each match produces one object.
+    #[serde(default, alias = "baseSelector")]
+    pub(crate) base_selector: Option<String>,
+    /// Fields to read from each container.
+    pub(crate) fields: Vec<ExtractField>,
+}
+
+impl ExtractSchema {
+    /// Parse a schema from JSON and validate every selector eagerly.
+    pub fn from_json(json: &str) -> Result<Self, SchemaError> {
+        let schema: Self = serde_json::from_str(json)?;
+        schema.validate()?;
+        Ok(schema)
+    }
+
+    /// Load a schema from a JSON file on disk.
+    pub fn from_path(path: impl AsRef<std::path::Path>) -> Result<Self, SchemaError> {
+        let content = std::fs::read_to_string(path)?;
+        Self::from_json(&content)
+    }
+
+    /// Start building a schema programmatically.
+    #[must_use]
+    pub fn builder() -> SchemaBuilder {
+        SchemaBuilder::default()
+    }
+
+    /// Validate every selector in the schema (including nested fields).
+    pub fn validate(&self) -> Result<(), SchemaError> {
+        if let Some(sel) = &self.base_selector {
+            check_selector("<base>", sel)?;
+        }
+        for f in &self.fields {
+            f.validate("", 0)?;
+        }
+        Ok(())
+    }
+
+    /// Repeated container selector, if any.
+    #[must_use]
+    pub fn base_selector(&self) -> Option<&str> {
+        self.base_selector.as_deref()
+    }
+
+    /// Fields defined in this schema.
+    #[must_use]
+    pub fn fields(&self) -> &[ExtractField] {
+        &self.fields
+    }
+}
+
+/// A single field in an [`ExtractSchema`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct ExtractField {
+    /// Output key for this field.
+    pub(crate) name: String,
+    /// CSS selector relative to the current container.
+    pub(crate) selector: String,
+    /// How to extract the value.
+    #[serde(flatten)]
+    pub(crate) kind: FieldKind,
+}
+
+impl ExtractField {
+    /// Construct a field programmatically.
+    pub fn new(name: impl Into<String>, selector: impl Into<String>, kind: FieldKind) -> Self {
+        Self {
+            name: name.into(),
+            selector: selector.into(),
+            kind,
+        }
+    }
+
+    /// Output key name for this field.
+    #[must_use]
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// CSS selector for this field.
+    #[must_use]
+    pub fn selector(&self) -> &str {
+        &self.selector
+    }
+
+    /// Extraction kind.
+    #[must_use]
+    pub fn kind(&self) -> &FieldKind {
+        &self.kind
+    }
+
+    fn validate(&self, parent: &str, depth: usize) -> Result<(), SchemaError> {
+        let path = if parent.is_empty() {
+            self.name.clone()
+        } else {
+            format!("{parent}.{}", self.name)
+        };
+        if depth > MAX_NESTING_DEPTH {
+            return Err(SchemaError::TooDeep {
+                field: path,
+                depth,
+                max: MAX_NESTING_DEPTH,
+            });
+        }
+        check_selector(&path, &self.selector)?;
+        if let FieldKind::NestedList { fields } = &self.kind {
+            for f in fields {
+                f.validate(&path, depth + 1)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Builder for [`ExtractSchema`].
+#[derive(Default, Debug, Clone)]
+pub struct SchemaBuilder {
+    base_selector: Option<String>,
+    fields: Vec<ExtractField>,
+}
+
+impl SchemaBuilder {
+    /// Set the base (repeated container) selector.
+    #[must_use]
+    pub fn base_selector(mut self, selector: impl Into<String>) -> Self {
+        self.base_selector = Some(selector.into());
+        self
+    }
+
+    /// Add a field. Accepts any [`FieldKind`] variant.
+    #[must_use]
+    pub fn field(mut self, name: impl Into<String>, selector: impl Into<String>, kind: FieldKind) -> Self {
+        self.fields.push(ExtractField::new(name, selector, kind));
+        self
+    }
+
+    /// Finalize the schema, validating every selector eagerly.
+    pub fn build(self) -> Result<ExtractSchema, SchemaError> {
+        let schema = ExtractSchema {
+            base_selector: self.base_selector,
+            fields: self.fields,
+        };
+        schema.validate()?;
+        Ok(schema)
+    }
+}
+
+/// What to read once a field selector matches.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum FieldKind {
+    /// Descendant text of the first match.
+    Text,
+    /// Named attribute on the first match.
+    #[serde(alias = "attr")]
+    Attribute {
+        /// Attribute name to read (e.g. `href`).
+        attribute: String,
+    },
+    /// Outer HTML of the first match.
+    Html,
+    /// Inner HTML of the first match.
+    #[serde(alias = "innerHtml")]
+    InnerHtml,
+    /// Repeated sub-object per match, using nested field definitions.
+    #[serde(alias = "nestedList")]
+    NestedList {
+        /// Nested field definitions.
+        fields: Vec<ExtractField>,
+    },
+}
+
+fn check_selector(field: &str, selector: &str) -> Result<(), SchemaError> {
+    // Empty selector is a sentinel for "the matched element itself" and is
+    // intentionally not a valid CSS expression; skip parsing it.
+    if selector.is_empty() {
+        return Ok(());
+    }
+    Matcher::new(selector)
+        .map(|_| ())
+        .map_err(|_| SchemaError::InvalidSelector {
+            field: field.to_string(),
+            selector: selector.to_string(),
+        })
+}
+
+impl ExtractSchema {
+    /// Apply this schema to HTML, returning structured JSON.
+    #[must_use]
+    pub fn extract_from(&self, html: &str) -> Value {
+        let doc = Document::from(html);
+        let root = doc.select("html");
+
+        match &self.base_selector {
+            None => Value::Object(extract_fields(&root, &self.fields)),
+            Some(sel) => {
+                let items: Vec<Value> = doc
+                    .select(sel)
+                    .iter()
+                    .map(|container| Value::Object(extract_fields(&container, &self.fields)))
+                    .collect();
+                Value::Array(items)
+            }
+        }
+    }
+}
+
+fn extract_fields(container: &Selection<'_>, fields: &[ExtractField]) -> Map<String, Value> {
+    fields
+        .iter()
+        .map(|f| (f.name.clone(), extract_field(container, f)))
+        .collect()
+}
+
+fn extract_field(container: &Selection<'_>, field: &ExtractField) -> Value {
+    // An empty selector is a sentinel for "the matched element itself".
+    let picked = if field.selector.is_empty() {
+        container.clone()
+    } else {
+        container.select(&field.selector)
+    };
+    if !picked.exists() {
+        return Value::Null;
+    }
+    // Scalar kinds read the first match; dom_query concatenates across all matches by default.
+    match &field.kind {
+        FieldKind::Text => Value::String(picked.first().text().to_string()),
+        FieldKind::Attribute { attribute } => picked
+            .first()
+            .attr(attribute)
+            .map_or(Value::Null, |s| Value::String(s.to_string())),
+        FieldKind::Html => Value::String(picked.first().html().to_string()),
+        FieldKind::InnerHtml => Value::String(picked.first().inner_html().to_string()),
+        FieldKind::NestedList { fields } => Value::Array(
+            picked
+                .iter()
+                .map(|sub| Value::Object(extract_fields(&sub, fields)))
+                .collect(),
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    const PRODUCTS: &str = r#"
+        <html><body>
+          <div class="product">
+            <h2>Keyboard</h2>
+            <span class="price">$99</span>
+            <a href="/kbd">details</a>
+            <img src="/kbd.png" alt="Keyboard">
+          </div>
+          <div class="product">
+            <h2>Mouse</h2>
+            <span class="price">$49</span>
+            <a href="/mouse">details</a>
+            <img src="/mouse.png" alt="Mouse">
+          </div>
+        </body></html>
+    "#;
+
+    fn schema_from(json: &Value) -> ExtractSchema {
+        ExtractSchema::from_json(&json.to_string()).expect("valid schema")
+    }
+
+    #[test]
+    fn extracts_text_fields_over_base_selector() {
+        let schema = schema_from(&json!({
+            "base_selector": ".product",
+            "fields": [
+                { "name": "title", "selector": "h2", "type": "text" },
+                { "name": "price", "selector": ".price", "type": "text" },
+            ]
+        }));
+        assert_eq!(
+            schema.extract_from(PRODUCTS),
+            json!([
+                { "title": "Keyboard", "price": "$99" },
+                { "title": "Mouse", "price": "$49" }
+            ])
+        );
+    }
+
+    #[test]
+    fn extracts_attribute() {
+        let schema = schema_from(&json!({
+            "base_selector": ".product",
+            "fields": [
+                { "name": "url", "selector": "a", "type": "attribute", "attribute": "href" },
+                { "name": "image", "selector": "img", "type": "attribute", "attribute": "src" },
+            ]
+        }));
+        assert_eq!(
+            schema.extract_from(PRODUCTS),
+            json!([
+                { "url": "/kbd", "image": "/kbd.png" },
+                { "url": "/mouse", "image": "/mouse.png" }
+            ])
+        );
+    }
+
+    #[test]
+    fn extracts_html_and_inner_html() {
+        let html = r#"<html><body><div class="card"><p><b>hi</b></p></div></body></html>"#;
+        let schema = schema_from(&json!({
+            "base_selector": ".card",
+            "fields": [
+                { "name": "outer", "selector": "p", "type": "html" },
+                { "name": "inner", "selector": "p", "type": "inner_html" },
+            ]
+        }));
+        assert_eq!(
+            schema.extract_from(html),
+            json!([{ "outer": "<p><b>hi</b></p>", "inner": "<b>hi</b>" }])
+        );
+    }
+
+    #[test]
+    fn nested_list_extracts_sub_objects() {
+        let html = r#"
+            <html><body>
+              <div class="post">
+                <h3>First</h3>
+                <ul><li>a</li><li>b</li></ul>
+              </div>
+              <div class="post">
+                <h3>Second</h3>
+                <ul><li>c</li></ul>
+              </div>
+            </body></html>
+        "#;
+        let schema = schema_from(&json!({
+            "base_selector": ".post",
+            "fields": [
+                { "name": "title", "selector": "h3", "type": "text" },
+                { "name": "items", "selector": "li", "type": "nested_list",
+                  "fields": [
+                    { "name": "label", "selector": "*", "type": "text" }
+                  ]
+                }
+            ]
+        }));
+        assert_eq!(
+            schema.extract_from(html),
+            json!([
+                { "title": "First", "items": [{ "label": null }, { "label": null }] },
+                { "title": "Second", "items": [{ "label": null }] }
+            ])
+        );
+    }
+
+    #[test]
+    fn missing_field_yields_null() {
+        let schema = schema_from(&json!({
+            "base_selector": ".product",
+            "fields": [
+                { "name": "rating", "selector": ".rating", "type": "text" }
+            ]
+        }));
+        assert_eq!(
+            schema.extract_from(PRODUCTS),
+            json!([{ "rating": null }, { "rating": null }])
+        );
+    }
+
+    #[test]
+    fn no_base_selector_returns_single_object() {
+        let schema = schema_from(&json!({
+            "fields": [
+                { "name": "first_product", "selector": ".product h2", "type": "text" }
+            ]
+        }));
+        assert_eq!(schema.extract_from(PRODUCTS), json!({ "first_product": "Keyboard" }));
+    }
+
+    #[test]
+    fn accepts_camelcase_keys() {
+        let schema = schema_from(&json!({
+            "baseSelector": ".product",
+            "fields": [
+                { "name": "t", "selector": "h2", "type": "text" },
+                { "name": "raw", "selector": "p", "type": "innerHtml" }
+            ]
+        }));
+        assert_eq!(schema.base_selector.as_deref(), Some(".product"));
+        let arr_out = schema.extract_from(PRODUCTS);
+        let arr = arr_out.as_array().unwrap();
+        assert_eq!(arr[0]["t"], "Keyboard");
+        assert_eq!(arr[0]["raw"], Value::Null);
+    }
+
+    #[test]
+    fn rejects_malformed_selector_eagerly() {
+        let json = json!({
+            "base_selector": ".product",
+            "fields": [
+                { "name": "bad", "selector": "###not[[[valid", "type": "text" }
+            ]
+        });
+        let err = ExtractSchema::from_json(&json.to_string()).unwrap_err();
+        assert!(
+            matches!(err, SchemaError::InvalidSelector { field, .. } if field == "bad"),
+            "expected InvalidSelector error for field 'bad'"
+        );
+    }
+
+    #[test]
+    fn nested_invalid_selector_reports_dotted_path() {
+        let json = json!({
+            "fields": [{
+                "name": "products",
+                "selector": ".product",
+                "type": "nested_list",
+                "fields": [{
+                    "name": "price",
+                    "selector": ".price",
+                    "type": "nested_list",
+                    "fields": [{ "name": "amount", "selector": "###bad", "type": "text" }]
+                }]
+            }]
+        });
+        let err = ExtractSchema::from_json(&json.to_string()).unwrap_err();
+        assert!(
+            matches!(&err, SchemaError::InvalidSelector { field, .. } if field == "products.price.amount"),
+            "expected dotted path, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn rejects_malformed_json() {
+        let err = ExtractSchema::from_json("{ not json").unwrap_err();
+        assert!(matches!(err, SchemaError::Parse(_)), "expected Parse error");
+    }
+
+    #[test]
+    fn from_path_surfaces_io_error() {
+        let err = ExtractSchema::from_path("/definitely/not/a/real/path.json").unwrap_err();
+        assert!(matches!(err, SchemaError::Io(_)), "expected Io error, got {err:?}");
+    }
+
+    #[test]
+    fn mixed_present_and_missing_fields() {
+        let schema = schema_from(&json!({
+            "base_selector": ".product",
+            "fields": [
+                { "name": "title", "selector": "h2", "type": "text" },
+                { "name": "rating", "selector": ".rating", "type": "text" }
+            ]
+        }));
+        assert_eq!(
+            schema.extract_from(PRODUCTS),
+            json!([
+                { "title": "Keyboard", "rating": null },
+                { "title": "Mouse", "rating": null }
+            ])
+        );
+    }
+
+    #[test]
+    fn empty_selector_reads_matched_element_text() {
+        let html = r"<html><body><ul><li>alpha</li><li>beta</li></ul></body></html>";
+        let schema = schema_from(&json!({
+            "base_selector": "li",
+            "fields": [
+                { "name": "value", "selector": "", "type": "text" }
+            ]
+        }));
+        assert_eq!(
+            schema.extract_from(html),
+            json!([{ "value": "alpha" }, { "value": "beta" }])
+        );
+    }
+
+    #[test]
+    fn empty_selector_inside_nested_list_reads_each_item() {
+        let html = r#"
+            <html><body>
+              <div class="post">
+                <h3>First</h3>
+                <ul><li>a</li><li>b</li></ul>
+              </div>
+            </body></html>
+        "#;
+        let schema = schema_from(&json!({
+            "base_selector": ".post",
+            "fields": [
+                { "name": "title", "selector": "h3", "type": "text" },
+                { "name": "items", "selector": "li", "type": "nested_list",
+                  "fields": [{ "name": "text", "selector": "", "type": "text" }] }
+            ]
+        }));
+        assert_eq!(
+            schema.extract_from(html),
+            json!([{
+                "title": "First",
+                "items": [{ "text": "a" }, { "text": "b" }]
+            }])
+        );
+    }
+
+    #[test]
+    fn empty_selector_reads_matched_element_attribute() {
+        let html = r#"<html><body><a href="/home" title="Home">Go</a></body></html>"#;
+        let schema = schema_from(&json!({
+            "base_selector": "a",
+            "fields": [
+                { "name": "href", "selector": "", "type": "attribute", "attribute": "href" },
+                { "name": "title", "selector": "", "type": "attribute", "attribute": "title" }
+            ]
+        }));
+        assert_eq!(schema.extract_from(html), json!([{ "href": "/home", "title": "Home" }]));
+    }
+
+    #[test]
+    fn builder_constructs_equivalent_schema() {
+        let built = ExtractSchema::builder()
+            .base_selector(".product")
+            .field("title", "h2", FieldKind::Text)
+            .field(
+                "url",
+                "a",
+                FieldKind::Attribute {
+                    attribute: "href".into(),
+                },
+            )
+            .build()
+            .unwrap();
+
+        let json_schema = schema_from(&json!({
+            "base_selector": ".product",
+            "fields": [
+                { "name": "title", "selector": "h2", "type": "text" },
+                { "name": "url", "selector": "a", "type": "attribute", "attribute": "href" }
+            ]
+        }));
+
+        assert_eq!(built.extract_from(PRODUCTS), json_schema.extract_from(PRODUCTS));
+    }
+
+    #[test]
+    fn builder_supports_nested_list() {
+        let schema = ExtractSchema::builder()
+            .base_selector(".post")
+            .field("title", "h3", FieldKind::Text)
+            .field(
+                "items",
+                "li",
+                FieldKind::NestedList {
+                    fields: vec![ExtractField::new("text", "", FieldKind::Text)],
+                },
+            )
+            .build()
+            .unwrap();
+        let html = r"<html><body><div class='post'><h3>A</h3><ul><li>one</li></ul></div></body></html>";
+        assert_eq!(
+            schema.extract_from(html),
+            json!([{ "title": "A", "items": [{ "text": "one" }] }])
+        );
+    }
+
+    #[test]
+    fn builder_surfaces_selector_errors() {
+        let err = ExtractSchema::builder()
+            .field("bad", "###invalid[[[", FieldKind::Text)
+            .build()
+            .unwrap_err();
+        assert!(
+            matches!(&err, SchemaError::InvalidSelector { field, .. } if field == "bad"),
+            "expected InvalidSelector, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn ignores_unknown_top_level_fields() {
+        let schema = schema_from(&json!({
+            "name": "legacy-label",
+            "base_selector": ".product",
+            "fields": [
+                { "name": "title", "selector": "h2", "type": "text" }
+            ]
+        }));
+        assert_eq!(schema.base_selector.as_deref(), Some(".product"));
+    }
+
+    #[test]
+    fn rejects_unknown_field_type_list() {
+        let json = json!({
+            "fields": [
+                { "name": "items", "selector": "li", "type": "list", "fields": [] }
+            ]
+        });
+        let err = ExtractSchema::from_json(&json.to_string()).unwrap_err();
+        assert!(
+            matches!(err, SchemaError::Parse(_)),
+            "expected Parse error for unsupported 'list' type"
+        );
+    }
+
+    #[test]
+    fn works_on_html_fragment_without_wrappers() {
+        let schema = schema_from(&json!({
+            "fields": [
+                { "name": "heading", "selector": "h1", "type": "text" }
+            ]
+        }));
+        assert_eq!(schema.extract_from("<h1>Hello</h1>"), json!({ "heading": "Hello" }));
+    }
+
+    #[test]
+    fn empty_fields_yields_empty_object() {
+        let schema = schema_from(&json!({ "fields": [] }));
+        assert_eq!(schema.extract_from(PRODUCTS), json!({}));
+    }
+
+    #[test]
+    fn empty_fields_with_base_selector_yields_empty_objects() {
+        let schema = schema_from(&json!({
+            "base_selector": ".product",
+            "fields": []
+        }));
+        assert_eq!(schema.extract_from(PRODUCTS), json!([{}, {}]));
+    }
+
+    #[test]
+    fn base_selector_matches_nothing_yields_empty_array() {
+        let schema = schema_from(&json!({
+            "base_selector": ".does-not-exist",
+            "fields": [
+                { "name": "title", "selector": "h2", "type": "text" }
+            ]
+        }));
+        assert_eq!(schema.extract_from(PRODUCTS), json!([]));
+    }
+
+    #[test]
+    fn nested_list_with_zero_matches_yields_null() {
+        let html = r#"<html><body><div class="post"><h3>Only</h3></div></body></html>"#;
+        let schema = schema_from(&json!({
+            "base_selector": ".post",
+            "fields": [
+                { "name": "title", "selector": "h3", "type": "text" },
+                { "name": "items", "selector": ".missing", "type": "nested_list",
+                  "fields": [{ "name": "label", "selector": "*", "type": "text" }] }
+            ]
+        }));
+        assert_eq!(schema.extract_from(html), json!([{ "title": "Only", "items": null }]));
+    }
+
+    #[test]
+    fn attribute_missing_but_element_present_yields_null() {
+        let html = r"<html><body><a>no href</a></body></html>";
+        let schema = schema_from(&json!({
+            "fields": [
+                { "name": "href", "selector": "a", "type": "attribute", "attribute": "href" }
+            ]
+        }));
+        assert_eq!(schema.extract_from(html), json!({ "href": null }));
+    }
+
+    #[test]
+    fn unicode_text_roundtrips() {
+        let html = r"<html><body><h1>日本語 🦀</h1></body></html>";
+        let schema = schema_from(&json!({
+            "fields": [{ "name": "t", "selector": "h1", "type": "text" }]
+        }));
+        assert_eq!(schema.extract_from(html), json!({ "t": "日本語 🦀" }));
+    }
+
+    #[test]
+    fn html_entities_are_decoded_in_text() {
+        let html = r"<html><body><p>A &amp; B &lt; C</p></body></html>";
+        let schema = schema_from(&json!({
+            "fields": [{ "name": "t", "selector": "p", "type": "text" }]
+        }));
+        assert_eq!(schema.extract_from(html), json!({ "t": "A & B < C" }));
+    }
+
+    #[test]
+    fn deeply_nested_three_levels() {
+        let html = r#"
+            <html><body>
+              <div class="cat">
+                <h2>Electronics</h2>
+                <div class="prod">
+                  <h3>Laptop</h3>
+                  <ul class="specs"><li>16GB</li><li>1TB</li></ul>
+                </div>
+              </div>
+            </body></html>
+        "#;
+        let schema = schema_from(&json!({
+            "base_selector": ".cat",
+            "fields": [
+                { "name": "name", "selector": "h2", "type": "text" },
+                { "name": "products", "selector": ".prod", "type": "nested_list",
+                  "fields": [
+                    { "name": "title", "selector": "h3", "type": "text" },
+                    { "name": "specs", "selector": ".specs li", "type": "nested_list",
+                      "fields": [{ "name": "v", "selector": "*", "type": "text" }] }
+                  ] }
+            ]
+        }));
+        assert_eq!(
+            schema.extract_from(html),
+            json!([{
+                "name": "Electronics",
+                "products": [{
+                    "title": "Laptop",
+                    "specs": [{ "v": null }, { "v": null }]
+                }]
+            }])
+        );
+    }
+
+    #[test]
+    fn empty_html_yields_nulls() {
+        let schema = schema_from(&json!({
+            "fields": [{ "name": "t", "selector": "h1", "type": "text" }]
+        }));
+        assert_eq!(schema.extract_from(""), json!({ "t": null }));
+    }
+
+    #[test]
+    fn rejects_excessive_nesting_depth() {
+        // Build a schema nested deeper than MAX_NESTING_DEPTH (64).
+        let mut kind = FieldKind::Text;
+        for i in (0..MAX_NESTING_DEPTH + 5).rev() {
+            kind = FieldKind::NestedList {
+                fields: vec![ExtractField::new(format!("l{i}"), "*", kind)],
+            };
+        }
+        let err = ExtractSchema::builder().field("root", "*", kind).build().unwrap_err();
+        assert!(matches!(
+            err,
+            SchemaError::TooDeep { depth, max, .. } if depth > max && max == MAX_NESTING_DEPTH
+        ));
+    }
+
+    #[test]
+    fn accepts_nesting_at_depth_limit() {
+        // Build a schema exactly at MAX_NESTING_DEPTH nesting.
+        let mut kind = FieldKind::Text;
+        for i in (0..MAX_NESTING_DEPTH).rev() {
+            kind = FieldKind::NestedList {
+                fields: vec![ExtractField::new(format!("l{i}"), "*", kind)],
+            };
+        }
+        let result = ExtractSchema::builder().field("root", "*", kind).build();
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn accessors_expose_schema_contents() {
+        let schema = ExtractSchema::builder()
+            .base_selector(".product")
+            .field("title", "h2", FieldKind::Text)
+            .field(
+                "url",
+                "a",
+                FieldKind::Attribute {
+                    attribute: "href".into(),
+                },
+            )
+            .build()
+            .unwrap();
+
+        assert_eq!(schema.base_selector(), Some(".product"));
+        assert_eq!(schema.fields().len(), 2);
+        assert_eq!(schema.fields()[0].name(), "title");
+        assert_eq!(schema.fields()[0].selector(), "h2");
+        assert!(matches!(schema.fields()[0].kind(), FieldKind::Text));
+        assert_eq!(schema.fields()[1].name(), "url");
+        assert!(matches!(
+            schema.fields()[1].kind(),
+            FieldKind::Attribute { attribute } if attribute == "href"
+        ));
+    }
+}

--- a/skills/servo-fetch/SKILL.md
+++ b/skills/servo-fetch/SKILL.md
@@ -128,6 +128,7 @@ servo-fetch URL1 URL2 --json                       # Parallel batch (NDJSON)
 servo-fetch https://example.com --screenshot out.png
 servo-fetch https://example.com --js "document.title"
 servo-fetch https://example.com --selector article
+servo-fetch https://example.com --schema schema.json  # Schema-driven JSON
 servo-fetch https://example.com --raw html         # Raw HTML
 servo-fetch https://example.com --raw text         # Plain text
 servo-fetch https://example.com -t 60              # Custom timeout

--- a/skills/servo-fetch/references/guide.md
+++ b/skills/servo-fetch/references/guide.md
@@ -68,6 +68,30 @@ fetch(url: "https://example.com", selector: "article")
 fetch(url: "https://example.com", selector: ".main-content", format: "json")
 ```
 
+## Schema extraction
+
+For structured data (product catalogs, listings, comment threads), use `--schema` on the CLI with a schema file. No LLM required — selectors pull fields declaratively.
+
+```bash
+servo-fetch "https://shop.example.com" --schema schema.json
+servo-fetch URL1 URL2 --schema schema.json    # batch → NDJSON
+```
+
+Schema:
+
+```json
+{
+  "base_selector": ".product",
+  "fields": [
+    { "name": "title", "selector": "h2", "type": "text" },
+    { "name": "price", "selector": ".price", "type": "text" },
+    { "name": "url", "selector": "a", "type": "attribute", "attribute": "href" }
+  ]
+}
+```
+
+Field `type` values: `text`, `attribute`, `html`, `inner_html`, `nested_list`. An empty selector (`""`) reads from the matched element itself — handy inside `nested_list` when you want each item's own text or attribute. Schema selectors are validated at load time.
+
 ## Troubleshooting
 
 | Symptom | Solution |


### PR DESCRIPTION
## Summary

Add a declarative schema extraction module that turns rendered HTML into structured JSON without an LLM.

- Library `servo_fetch::schema`: `ExtractSchema::{from_json, from_path, builder}`, `.extract_from(html)`, plus `FetchOptions::schema(schema)` + `Page::extracted` for fetch integration.
- CLI `--schema <FILE>` on the default fetch command; pretty JSON single-URL, NDJSON batch. Conflicts with `--screenshot` / `--js` / `--raw` / `--selector`.
- Field kinds: `text` / `attribute` / `html` / `inner_html` / `nested_list`. Accepts snake_case + camelCase on input. Empty selector (`""`) reads the matched element itself (handy inside `nested_list`).
- Selectors validated eagerly; nested errors use dotted paths (e.g. `products.price.amount`).
- `Error::Schema(SchemaError)` variant added; types derive `Serialize` for round-trip.

## Related issues

N/A

## Test Plan

- Local E2E with a Python `http.server` serving fixture HTML: verified `--schema` end-to-end for single URL, batch NDJSON, all four conflicts, and every error path (missing file, malformed JSON, invalid selector, unknown field type, bad URL, SSRF).
- 27 unit tests cover each field kind, base-selector semantics, null vs empty, Unicode/entities, deep nesting, self-selector, builder, `from_path`.

## Checklist

- [x] Ran `cargo fmt`, `cargo clippy`, and `cargo test` locally
- [x] Documentation updated (top README, library README, CLI README, SKILL.md, guide.md, new `examples/schema_extract.rs`)
- [x] Tests added (27 unit tests in `schema::tests` + 1 CLI conflict test)
- [x] Commit message follows Conventional Commits
- [x] I have read the AI usage policy in CONTRIBUTING.md and followed it