### PR TITLE
fix(release): use yum in manylinux container

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -51,13 +51,14 @@ jobs:
           manylinux: ${{ matrix.manylinux || 'auto' }}
           args: --release --strip --locked --manifest-path bindings/python/Cargo.toml
           before-script-linux: |
-            apt-get update
-            apt-get install -y cmake clang pkg-config libfontconfig-dev libfreetype-dev \
-              libssl-dev libglib2.0-dev libegl1-mesa-dev
+            yum install -y cmake clang pkg-config fontconfig-devel freetype-devel \
+              openssl-devel glib2-devel mesa-libEGL-devel
 
       - name: Smoke test
         if: matrix.target == 'x86_64-unknown-linux-gnu' || (matrix.target == 'aarch64-apple-darwin' && runner.os == 'macOS')
         shell: bash
+        env:
+          GLIBC_TUNABLES: glibc.rtld.optional_static_tls=16384
         run: |
           pip install --find-links target/wheels servo_fetch
           python -c "import servo_fetch; print(servo_fetch.__version__)"


### PR DESCRIPTION
## Summary

Use yum in manylinux container.

## Related issues

https://github.com/konippi/servo-fetch/actions/runs/25894811230/job/76105558308

## Checklist

- [x] Ran `cargo fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
- [x] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed
- [x] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it
