### PR TITLE
fix(release): use gcc-toolset-15 for SpiderMonkey on manylinux

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -52,7 +52,9 @@ jobs:
           args: --release --strip --locked --manifest-path bindings/python/Cargo.toml
           before-script-linux: |
             dnf install -y cmake clang pkg-config fontconfig-devel freetype-devel \
-              openssl-devel glib2-devel mesa-libEGL-devel
+              openssl-devel glib2-devel mesa-libEGL-devel gcc-toolset-15-gcc gcc-toolset-15-gcc-c++
+            export CC=/opt/rh/gcc-toolset-15/root/usr/bin/gcc
+            export CXX=/opt/rh/gcc-toolset-15/root/usr/bin/g++
 
       - name: Smoke test
         if: matrix.target == 'x86_64-unknown-linux-gnu' || (matrix.target == 'aarch64-apple-darwin' && runner.os == 'macOS')


### PR DESCRIPTION
## Summary

Fix aarch64 Linux wheel build: SpiderMonkey requires libstdc++ >= 8 but manylinux_2_28 aarch64 defaults to GCC 8.5 with old headers. Install `gcc-toolset-15` and export `CC`/`CXX` (Apache Mahout pattern).

## Test Plan

N/A

## Checklist

- [x] Ran `cargo fmt`, `cargo clippy`, and `cargo test` locally
- [x] Documentation updated (N/A — CI only)
- [x] Tests added or updated (N/A — release workflow fix)
- [x] Commit messages follow Conventional Commits
- [x] I have read the AI usage policy in CONTRIBUTING.md and followed it