### PR TITLE
feat(release): add aarch64 Linux wheel build

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -21,9 +21,15 @@ env:
 
 jobs:
   build-linux:
-    name: Build / x86_64-unknown-linux-gnu
-    runs-on: ubuntu-24.04
+    name: Build / ${{ matrix.target }}
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { runner: ubuntu-24.04, target: x86_64-unknown-linux-gnu }
+          - { runner: ubuntu-24.04-arm, target: aarch64-unknown-linux-gnu }
     permissions:
       contents: read
     steps:
@@ -32,7 +38,7 @@ jobs:
           persist-credentials: false
       - uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
         with:
-          target: x86_64-unknown-linux-gnu
+          target: ${{ matrix.target }}
           manylinux: "2_28"
           args: --release --strip --locked --out dist --manifest-path bindings/python/Cargo.toml
           before-script-linux: |
@@ -40,7 +46,7 @@ jobs:
               openssl-devel glib2-devel mesa-libEGL-devel
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: wheels-x86_64-unknown-linux-gnu
+          name: wheels-${{ matrix.target }}
           path: dist/*.whl
 
   build-macos:


### PR DESCRIPTION
## Summary

Add aarch64 Linux wheel build to `release-python.yml`. Uses native ARM runner (`ubuntu-24.04-arm`) with manylinux_2_28 Docker (latest image ships GCC 14 in PATH). Same `before-script-linux` as x86_64 — no `gcc-toolset` needed.

## Test Plan

Previous failure was caused by installing `gcc-toolset-15` which shadowed the image's default GCC 14 PATH.

## Checklist

- [x] Ran `cargo fmt`, `cargo clippy`, and `cargo test` locally
- [x] Documentation updated (N/A — CI only)
- [x] Tests added or updated (N/A — release workflow)
- [x] Commit messages follow Conventional Commits
- [x] I have read the AI usage policy in CONTRIBUTING.md and followed it