### PR TITLE
fix(release): remove dnf clang install

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -42,7 +42,7 @@ jobs:
           manylinux: "2_28"
           args: --release --strip --locked --out dist --manifest-path bindings/python/Cargo.toml
           before-script-linux: |
-            dnf install -y cmake clang pkg-config fontconfig-devel freetype-devel \
+            dnf install -y cmake pkg-config fontconfig-devel freetype-devel \
               openssl-devel glib2-devel mesa-libEGL-devel
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:


### PR DESCRIPTION
## Summary

Remove `clang` from `dnf install` in `before-script-linux`. The manylinux_2_28 container ships `/opt/clang/bin/clang` with a `.cfg` that points to `gcc-toolset-14`'s libstdc++. Installing system `clang` via dnf shadows it with `/usr/bin/clang` which references the old GCC 8 libstdc++ headers, causing SpiderMonkey's `libstdc++ not new enough` error on aarch64.

## Test Plan

Will be validated by next `v0.10.0` tag push. x86_64 was unaffected because it uses a pre-built mozjs archive.

## Checklist

- [x] Ran `cargo fmt`, `cargo clippy`, and `cargo test` locally
- [x] Documentation updated (N/A — CI only)
- [x] Tests added or updated (N/A — release workflow fix)
- [x] Commit messages follow Conventional Commits
- [x] I have read the AI usage policy in CONTRIBUTING.md and followed it