### PR TITLE
fix(release): llvm path

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -42,8 +42,7 @@ jobs:
           manylinux: "2_28"
           args: --release --strip --locked --out dist --manifest-path bindings/python/Cargo.toml
           before-script-linux: |
-            source /opt/rh/gcc-toolset-14/enable
-            dnf install -y cmake pkg-config fontconfig-devel freetype-devel \
+            dnf install -y clang llvm cmake pkg-config fontconfig-devel freetype-devel \
               openssl-devel glib2-devel mesa-libEGL-devel
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -42,6 +42,7 @@ jobs:
           manylinux: "2_28"
           args: --release --strip --locked --out dist --manifest-path bindings/python/Cargo.toml
           before-script-linux: |
+            source /opt/rh/gcc-toolset-14/enable
             dnf install -y cmake pkg-config fontconfig-devel freetype-devel \
               openssl-devel glib2-devel mesa-libEGL-devel
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
## Summary

Add `llvm` to `dnf install` in `before-script-linux` for `llvm-objdump` (required by mozjs source build on aarch64). Also keeps `clang` for `libclang.so` (required by bindgen/mozangle on x86_64).

Verified locally via `docker run quay.io/pypa/manylinux_2_28_x86_64` that `dnf install -y clang llvm` provides both `/usr/lib64/libclang.so` and `/usr/bin/llvm-objdump`.

## Test Plan

Will be validated by next `v0.10.0` tag push.

## Checklist

- [x] Ran `cargo fmt`, `cargo clippy`, and `cargo test` locally
- [x] Documentation updated (N/A — CI only)
- [x] Tests added or updated (N/A — release workflow fix)
- [x] Commit messages follow Conventional Commits
- [x] I have read the AI usage policy in CONTRIBUTING.md and followed it