### PR TITLE
fix(release): add license-files to pyproject.toml for sdist

### DIFF
--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -9,6 +9,7 @@ description = "Browser engine in a library — fetch, render, and extract web co
 readme = "README.md"
 requires-python = ">=3.10"
 license = "MIT OR Apache-2.0"
+license-files = ["LICENSE-MIT", "LICENSE-APACHE"]
 authors = [{ name = "konippi" }]
 keywords = ["servo", "browser", "scraping", "extraction", "fetch"]
 classifiers = [


### PR DESCRIPTION
## Summary

Add `license-files` to `pyproject.toml` so maturin includes LICENSE files in the sdist. PyPI rejects uploads when PEP 639 `license` is set but the declared files are missing from the distribution.

## Test Plan

Will be validated by next `v0.10.0` tag push (PyPI publish step).

## Checklist

- [x] Ran `cargo fmt`, `cargo clippy`, and `cargo test` locally
- [x] Documentation updated (N/A — packaging metadata only)
- [x] Tests added or updated (N/A — release fix)
- [x] Commit messages follow Conventional Commits
- [x] I have read the AI usage policy in CONTRIBUTING.md and followed it