### PR TITLE
docs(python): add usage examples

### DIFF
--- a/bindings/python/examples/async_crawl.py
+++ b/bindings/python/examples/async_crawl.py
@@ -1,0 +1,18 @@
+"""Crawl a site asynchronously, streaming results as they arrive."""
+
+import asyncio
+
+from servo_fetch import AsyncClient
+
+
+async def main():
+    async with AsyncClient(user_agent="example-bot/1.0") as client:
+        async for result in client.crawl_stream(
+            "https://example.com",
+            max_pages=5,
+            max_depth=1,
+        ):
+            print(f"[depth={result.depth}] {result.url} — {result.title}")
+
+
+asyncio.run(main())

--- a/bindings/python/examples/basic_fetch.py
+++ b/bindings/python/examples/basic_fetch.py
@@ -1,0 +1,9 @@
+"""Basic fetch: render a page and access all representations."""
+
+import servo_fetch
+
+page = servo_fetch.fetch("https://example.com")
+print(f"Title: {page.title}")
+print(f"HTML length: {len(page.html)}")
+print(f"Text: {page.inner_text[:100]}...")
+print(f"\nMarkdown:\n{page.markdown[:200]}...")

--- a/bindings/python/examples/client_batch.py
+++ b/bindings/python/examples/client_batch.py
@@ -1,0 +1,14 @@
+"""Fetch multiple URLs with shared client configuration."""
+
+from servo_fetch import Client
+
+urls = [
+    "https://example.com",
+    "https://example.org",
+]
+
+client = Client(timeout=30, user_agent="batch-bot/1.0")
+
+for url in urls:
+    page = client.fetch(url)
+    print(f"{url}: {page.title} ({len(page.html)} bytes)")

--- a/bindings/python/examples/schema_extraction.py
+++ b/bindings/python/examples/schema_extraction.py
@@ -1,0 +1,17 @@
+"""Extract structured data from a page using a CSS-selector schema."""
+
+import json
+
+from servo_fetch import Field, Schema, fetch
+
+schema = Schema(
+    base_selector="article.product_pod",
+    fields=[
+        Field(name="title", selector="h3 a", type="attribute", attribute="title"),
+        Field(name="price", selector=".price_color", type="text"),
+        Field(name="url", selector="h3 a", type="attribute", attribute="href"),
+    ],
+)
+
+page = fetch("https://books.toscrape.com", schema=schema)
+print(json.dumps(page.extracted[:3], indent=2))  # first 3 products


### PR DESCRIPTION
## Summary

Add `bindings/python/examples/` with 4 runnable scripts covering the main use cases:
- `basic_fetch.py` — page properties (html, text, markdown, title)
- `schema_extraction.py` — Schema + Field for structured data
- `async_crawl.py` — AsyncClient + crawl_stream
- `client_batch.py` — Client with shared config for multiple URLs

## Test Plan

Ran each example locally with `uv run python examples/<file>.py` — all produce expected output.

## Checklist

- [x] Ran `cargo fmt`, `cargo clippy`, and `cargo test` locally
- [x] Documentation updated (examples added)
- [x] Tests added or updated (N/A — examples are documentation, not tests)
- [x] Commit messages follow Conventional Commits
- [x] I have read the AI usage policy in CONTRIBUTING.md and followed it