### PR TITLE
docs: use block comments in readme code snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,16 +15,19 @@ captures screenshots with a software renderer, and extracts clean content — av
 and a Python SDK.
 
 ```bash
-servo-fetch "https://example.com"                        # CLI: clean Markdown
-servo-fetch "https://example.com" --screenshot page.png  # CLI: PNG screenshot
+# CLI
+servo-fetch "https://example.com"                        # clean Markdown
+servo-fetch "https://example.com" --screenshot page.png  # PNG screenshot
 ```
 
 ```rust
-let md = servo_fetch::markdown("https://example.com")?;  // Rust: one-liner
+// Rust
+let md = servo_fetch::markdown("https://example.com")?;
 ```
 
 ```python
-page = servo_fetch.fetch("https://example.com")          # Python: full page
+# Python
+page = servo_fetch.fetch("https://example.com")
 print(page.markdown)
 ```
 


### PR DESCRIPTION
## Summary

Switch README intro code snippets from inline comments (`# CLI: clean Markdown`) to block comments (`# CLI` on its own line) for readability.

## Related issues

N/A

## Test Plan

N/A

## Checklist

- [ ] Ran `cargo fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
- [x] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed
- [ ] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it
