### PR TITLE
test: cover Page::from_servo and pdf::probe HTTP paths

### DIFF
--- a/crates/servo-fetch/src/fetch.rs
+++ b/crates/servo-fetch/src/fetch.rs
@@ -480,4 +480,158 @@ mod tests {
         let result = fetch(FetchOptions::new("file:///etc/passwd"));
         assert!(result.is_err());
     }
+
+    mod page_from_servo {
+        use super::super::*;
+        use crate::bridge;
+
+        fn synthetic_image(w: u32, h: u32) -> image::RgbaImage {
+            image::RgbaImage::from_pixel(w, h, image::Rgba([255, 0, 0, 255]))
+        }
+
+        fn empty_servo_page() -> bridge::ServoPage {
+            bridge::ServoPage::default()
+        }
+
+        #[test]
+        fn extracts_title_from_html() {
+            let mut sp = empty_servo_page();
+            sp.html = "<html><head><title>Hello World</title></head></html>".into();
+            let page = Page::from_servo(sp);
+            assert_eq!(page.title.as_deref(), Some("Hello World"));
+        }
+
+        #[test]
+        fn title_is_none_when_tag_missing() {
+            let mut sp = empty_servo_page();
+            sp.html = "<html><body>no title here</body></html>".into();
+            let page = Page::from_servo(sp);
+            assert!(page.title.is_none());
+        }
+
+        #[test]
+        fn title_is_none_when_tag_empty() {
+            let mut sp = empty_servo_page();
+            sp.html = "<html><head><title></title></head></html>".into();
+            let page = Page::from_servo(sp);
+            assert!(page.title.is_none());
+        }
+
+        #[test]
+        fn title_is_none_for_empty_html() {
+            let page = Page::from_servo(empty_servo_page());
+            assert!(page.title.is_none());
+        }
+
+        #[test]
+        fn inner_text_none_becomes_empty_string() {
+            let sp = empty_servo_page();
+            assert!(sp.inner_text.is_none());
+            let page = Page::from_servo(sp);
+            assert_eq!(page.inner_text, "");
+        }
+
+        #[test]
+        fn screenshot_is_encoded_as_png() {
+            let mut sp = empty_servo_page();
+            sp.screenshot = Some(synthetic_image(8, 8));
+            let page = Page::from_servo(sp);
+            let bytes = page.screenshot_png().expect("screenshot encoded");
+            assert_eq!(&bytes[..8], b"\x89PNG\r\n\x1a\n", "PNG magic bytes");
+        }
+
+        #[test]
+        fn console_messages_empty_by_default() {
+            let page = Page::from_servo(empty_servo_page());
+            assert!(page.console_messages.is_empty());
+        }
+
+        #[test]
+        fn console_messages_preserve_all_six_levels() {
+            let cases = [
+                (bridge::ConsoleLevel::Log, ConsoleLevel::Log),
+                (bridge::ConsoleLevel::Debug, ConsoleLevel::Debug),
+                (bridge::ConsoleLevel::Info, ConsoleLevel::Info),
+                (bridge::ConsoleLevel::Warn, ConsoleLevel::Warn),
+                (bridge::ConsoleLevel::Error, ConsoleLevel::Error),
+                (bridge::ConsoleLevel::Trace, ConsoleLevel::Trace),
+            ];
+            for (src, expected) in cases {
+                let mut sp = empty_servo_page();
+                sp.console_messages = vec![bridge::ConsoleMessage {
+                    level: src,
+                    message: "msg".into(),
+                }];
+                let page = Page::from_servo(sp);
+                assert_eq!(
+                    page.console_messages.len(),
+                    1,
+                    "console message lost for source level {src:?}",
+                );
+                assert_eq!(
+                    page.console_messages[0].level, expected,
+                    "level mapping wrong for source {src:?}",
+                );
+            }
+        }
+
+        #[test]
+        fn console_messages_preserve_ordering_across_levels() {
+            let mut sp = empty_servo_page();
+            sp.console_messages = vec![
+                bridge::ConsoleMessage {
+                    level: bridge::ConsoleLevel::Info,
+                    message: "first".into(),
+                },
+                bridge::ConsoleMessage {
+                    level: bridge::ConsoleLevel::Error,
+                    message: "second".into(),
+                },
+                bridge::ConsoleMessage {
+                    level: bridge::ConsoleLevel::Warn,
+                    message: "third".into(),
+                },
+            ];
+            let page = Page::from_servo(sp);
+            assert_eq!(page.console_messages.len(), 3);
+            assert_eq!(page.console_messages[0].message, "first");
+            assert_eq!(page.console_messages[1].message, "second");
+            assert_eq!(page.console_messages[2].message, "third");
+            assert_eq!(page.console_messages[0].level, ConsoleLevel::Info);
+            assert_eq!(page.console_messages[1].level, ConsoleLevel::Error);
+            assert_eq!(page.console_messages[2].level, ConsoleLevel::Warn);
+        }
+
+        #[test]
+        fn extracted_starts_as_none_until_schema_applied() {
+            let page = Page::from_servo(empty_servo_page());
+            assert!(page.extracted.is_none());
+        }
+
+        #[test]
+        fn full_round_trip_preserves_every_field() {
+            let sp = bridge::ServoPage {
+                html: "<html><head><title>T</title></head><body>B</body></html>".into(),
+                inner_text: Some("B".into()),
+                layout_json: Some("[]".into()),
+                screenshot: Some(synthetic_image(2, 2)),
+                js_result: Some("42".into()),
+                accessibility_tree: Some("{}".into()),
+                console_messages: vec![bridge::ConsoleMessage {
+                    level: bridge::ConsoleLevel::Log,
+                    message: "x".into(),
+                }],
+            };
+            let page = Page::from_servo(sp);
+            assert_eq!(page.html, "<html><head><title>T</title></head><body>B</body></html>");
+            assert_eq!(page.inner_text, "B");
+            assert_eq!(page.title.as_deref(), Some("T"));
+            assert_eq!(page.layout_json.as_deref(), Some("[]"));
+            assert_eq!(page.js_result.as_deref(), Some("42"));
+            assert_eq!(page.accessibility_tree.as_deref(), Some("{}"));
+            assert_eq!(page.console_messages.len(), 1);
+            assert!(page.screenshot_png().is_some());
+            assert!(page.extracted.is_none());
+        }
+    }
 }

--- a/crates/servo-fetch/src/pdf.rs
+++ b/crates/servo-fetch/src/pdf.rs
@@ -87,4 +87,144 @@ mod tests {
         // Suffix matches, HEAD fails quickly.
         assert!(probe("http://invalid.invalid/foo.pdf", 1).is_none());
     }
+
+    mod integration {
+        use super::super::*;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        async fn run_probe(url: String, timeout: u64) -> Option<Vec<u8>> {
+            tokio::task::spawn_blocking(move || probe(&url, timeout)).await.unwrap()
+        }
+
+        #[tokio::test]
+        async fn returns_bytes_when_head_advertises_pdf() {
+            let server = MockServer::start().await;
+            Mock::given(method("HEAD"))
+                .and(path("/doc.pdf"))
+                .respond_with(ResponseTemplate::new(200).insert_header("content-type", "application/pdf"))
+                .mount(&server)
+                .await;
+            Mock::given(method("GET"))
+                .and(path("/doc.pdf"))
+                .respond_with(ResponseTemplate::new(200).set_body_raw(b"%PDF-1.4 minimal".to_vec(), "application/pdf"))
+                .mount(&server)
+                .await;
+
+            let bytes = run_probe(format!("{}/doc.pdf", server.uri()), 5).await;
+            assert_eq!(bytes.as_deref(), Some(&b"%PDF-1.4 minimal"[..]));
+        }
+
+        #[tokio::test]
+        async fn returns_none_when_head_says_html() {
+            let server = MockServer::start().await;
+            Mock::given(method("HEAD"))
+                .and(path("/lying.pdf"))
+                .respond_with(ResponseTemplate::new(200).insert_header("content-type", "text/html"))
+                .mount(&server)
+                .await;
+
+            assert!(run_probe(format!("{}/lying.pdf", server.uri()), 5).await.is_none());
+        }
+
+        #[tokio::test]
+        async fn returns_none_when_head_lacks_content_type() {
+            let server = MockServer::start().await;
+            Mock::given(method("HEAD"))
+                .and(path("/no-ct.pdf"))
+                .respond_with(ResponseTemplate::new(200))
+                .mount(&server)
+                .await;
+
+            assert!(run_probe(format!("{}/no-ct.pdf", server.uri()), 5).await.is_none());
+        }
+
+        #[tokio::test]
+        async fn returns_none_when_head_returns_404() {
+            let server = MockServer::start().await;
+            Mock::given(method("HEAD"))
+                .and(path("/missing.pdf"))
+                .respond_with(ResponseTemplate::new(404))
+                .mount(&server)
+                .await;
+
+            assert!(run_probe(format!("{}/missing.pdf", server.uri()), 5).await.is_none());
+        }
+
+        #[tokio::test]
+        async fn skips_non_pdf_url_without_any_request() {
+            let server = MockServer::start().await;
+            Mock::given(method("HEAD"))
+                .respond_with(ResponseTemplate::new(500))
+                .expect(0)
+                .mount(&server)
+                .await;
+            Mock::given(method("GET"))
+                .respond_with(ResponseTemplate::new(500))
+                .expect(0)
+                .mount(&server)
+                .await;
+
+            assert!(run_probe(format!("{}/page.html", server.uri()), 5).await.is_none());
+        }
+
+        #[tokio::test]
+        async fn accepts_content_type_with_parameter() {
+            let server = MockServer::start().await;
+            Mock::given(method("HEAD"))
+                .and(path("/x.pdf"))
+                .respond_with(
+                    ResponseTemplate::new(200).insert_header("content-type", "application/pdf; charset=binary"),
+                )
+                .mount(&server)
+                .await;
+            Mock::given(method("GET"))
+                .and(path("/x.pdf"))
+                .respond_with(ResponseTemplate::new(200).set_body_raw(b"PDF".to_vec(), "application/pdf"))
+                .mount(&server)
+                .await;
+
+            assert_eq!(
+                run_probe(format!("{}/x.pdf", server.uri()), 5).await.as_deref(),
+                Some(&b"PDF"[..]),
+            );
+        }
+
+        #[tokio::test]
+        async fn does_not_follow_redirects() {
+            // PDF probe is configured with `max_redirects(0)` to avoid SSRF bypass via
+            // redirect to a private IP.
+            let server = MockServer::start().await;
+            Mock::given(method("HEAD"))
+                .and(path("/redirect.pdf"))
+                .respond_with(ResponseTemplate::new(302).insert_header("location", "https://example.com/"))
+                .mount(&server)
+                .await;
+
+            assert!(
+                run_probe(format!("{}/redirect.pdf", server.uri()), 5).await.is_none(),
+                "302 must not be followed (SSRF gate)",
+            );
+        }
+
+        #[tokio::test]
+        async fn head_request_actually_uses_head_method() {
+            let server = MockServer::start().await;
+            Mock::given(method("HEAD"))
+                .and(path("/big.pdf"))
+                .respond_with(ResponseTemplate::new(200).insert_header("content-type", "application/pdf"))
+                .expect(1)
+                .mount(&server)
+                .await;
+            Mock::given(method("GET"))
+                .and(path("/big.pdf"))
+                .respond_with(ResponseTemplate::new(200).set_body_raw(b"PDF".to_vec(), "application/pdf"))
+                .expect(1)
+                .mount(&server)
+                .await;
+
+            let _ = run_probe(format!("{}/big.pdf", server.uri()), 5).await;
+            // Mock expectations are verified on `MockServer` drop.
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Add unit tests to test gaps that were holding back coverage on the synchronous, engine-independent layers of `servo-fetch`.

## Related issues

N/A

## Test Plan

- `cargo test  --lib -p servo-fetch` - all passed

## Checklist

- [x] Ran `cargo fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
- [x] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed
- [x] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it