### PR TITLE
refactor(test): replace super::super::* wildcards with crate paths

### DIFF
--- a/crates/servo-fetch/src/fetch.rs
+++ b/crates/servo-fetch/src/fetch.rs
@@ -482,8 +482,8 @@ mod tests {
     }
 
     mod page_from_servo {
-        use super::super::*;
         use crate::bridge;
+        use crate::fetch::{ConsoleLevel, Page};
 
         fn synthetic_image(w: u32, h: u32) -> image::RgbaImage {
             image::RgbaImage::from_pixel(w, h, image::Rgba([255, 0, 0, 255]))

--- a/crates/servo-fetch/src/map.rs
+++ b/crates/servo-fetch/src/map.rs
@@ -760,7 +760,11 @@ mod tests {
     }
 
     mod integration {
-        use super::super::*;
+        use crate::map::{
+            MapConfig, MapEntry, build_agent, extract_links, fetch_html, fetch_sitemap, parse_sitemap, run,
+        };
+        use std::time::Duration;
+        use url::Url;
         use wiremock::matchers::{method, path};
         use wiremock::{Mock, MockServer, ResponseTemplate};
 

--- a/crates/servo-fetch/src/pdf.rs
+++ b/crates/servo-fetch/src/pdf.rs
@@ -89,7 +89,7 @@ mod tests {
     }
 
     mod integration {
-        use super::super::*;
+        use crate::pdf::probe;
         use wiremock::matchers::{method, path};
         use wiremock::{Mock, MockServer, ResponseTemplate};
 


### PR DESCRIPTION
## Summary

Replaces `use super::super::*;` with explicit `use crate::<module>::{...}` imports.

## Related issues

N/A

## Test Plan

- `cargo test  --lib -p servo-fetch` - all passed

## Checklist

- [x] Ran `cargo fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
- [x] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed
- [x] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it