### PR TITLE
perf(ci): share cargo-test build cache and parallelize e2e

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,7 +198,7 @@ jobs:
 
   e2e:
     name: E2E
-    needs: [changes, cargo-test]
+    needs: [changes]
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 45
@@ -264,7 +264,7 @@ jobs:
 
   python-test:
     name: Python Test
-    needs: [changes]
+    needs: [changes, cargo-test]
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 45
@@ -296,7 +296,7 @@ jobs:
         working-directory: bindings/python
         run: |
           uv sync --group test --group lint
-          uv run maturin develop
+          uv run maturin develop --profile ci
           uv run pytest
       - name: Stubtest
         working-directory: bindings/python


### PR DESCRIPTION
## Summary

Reduces CI critical path from ~20m to ~15m by sharing `cargo-test`'s build cache with `python-test` and unblocking `e2e` from sequential execution.

## Related issues

N/A

## Test Plan

| Job | Before | Expected after |
|---|---|---|
| `python-test` (own duration) | 19m48s | ~5–7m |
| `e2e` (own duration) | 8m13s | 8m13s (unchanged) |
| Critical path (wall-clock) | ~20m | ~15m |

## Checklist

- [x] Ran `cargo fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
- [x] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed
- [x] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it