### PR TITLE
test: add edge-case HTML fixtures for extraction tests

### DIFF
--- a/crates/servo-fetch/tests/extract.rs
+++ b/crates/servo-fetch/tests/extract.rs
@@ -80,6 +80,31 @@ fn empty_body_without_inner_text_returns_empty() {
 }
 
 #[test]
+fn empty_title_still_extracts_body_content() {
+    let html = fixture("empty_title.html");
+    let text = extract::extract_text(&input(&html)).unwrap();
+    assert!(text.contains("Visible Heading"));
+    assert!(text.contains("readability algorithm"));
+}
+
+#[test]
+fn missing_body_tag_still_extracts_content() {
+    let html = fixture("missing_body.html");
+    let text = extract::extract_text(&input(&html)).unwrap();
+    assert!(text.contains("Heading Outside Body"));
+    assert!(text.contains("hoist content into an implicit body"));
+}
+
+#[test]
+fn script_only_page_does_not_leak_script_source() {
+    let html = fixture("script_only.html");
+    let text = extract::extract_text(&input(&html)).unwrap();
+    assert!(!text.contains("__DATA__"));
+    assert!(!text.contains("should not be extracted"));
+    assert!(!text.contains("console.log"));
+}
+
+#[test]
 fn byline_and_excerpt_rendered_in_markdown() {
     let html = fixture("article_with_meta.html");
     let text = extract::extract_text(&input(&html)).unwrap();

--- a/crates/servo-fetch/tests/fixtures/empty_title.html
+++ b/crates/servo-fetch/tests/fixtures/empty_title.html
@@ -1,0 +1,11 @@
+<html>
+<head><title></title></head>
+<body>
+<article>
+  <h1>Visible Heading</h1>
+  <p>This paragraph contains enough text for the readability algorithm to consider this section the main content of the page.</p>
+  <p>A second paragraph adds more weight so Readability scores this article above any boilerplate elements that might be present.</p>
+  <p>The third paragraph ensures we are well above the threshold for content extraction even when the title element is empty.</p>
+</article>
+</body>
+</html>

--- a/crates/servo-fetch/tests/fixtures/missing_body.html
+++ b/crates/servo-fetch/tests/fixtures/missing_body.html
@@ -1,0 +1,9 @@
+<html>
+<head><title>Missing Body</title></head>
+<article>
+  <h1>Heading Outside Body</h1>
+  <p>HTML5 parsers must hoist content into an implicit body so extraction can still find readable text when the source omits the body tag.</p>
+  <p>A second paragraph gives Readability enough material to identify this section as the primary content of the page.</p>
+  <p>The third paragraph keeps the score above the extraction threshold even without an explicit body element wrapping the article.</p>
+</article>
+</html>

--- a/crates/servo-fetch/tests/fixtures/script_only.html
+++ b/crates/servo-fetch/tests/fixtures/script_only.html
@@ -1,0 +1,7 @@
+<html>
+<head><title>Script Only</title></head>
+<body>
+<script>window.__DATA__ = { secret: "should not be extracted" };</script>
+<script>console.log("more script noise")</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Adds three HTML fixtures and three extraction tests covering edge cases the existing suite did not exercise: empty `<title>`, missing `<body>` tag, and script-only pages.

## Related issues

Closes #80

## Test Plan

- `cargo test -p servo-fetch --test extract` - all passed

## Checklist

- [x] Ran `cargo fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
- [x] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed
- [x] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it