### PR TITLE
feat(extract): visibility-aware filtering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6551,6 +6551,8 @@ name = "servo-fetch"
 version = "0.10.1"
 dependencies = [
  "anyhow",
+ "bitflags 2.11.1",
+ "cssparser",
  "dom_query",
  "dom_smoothie",
  "dpi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,8 @@ servo-fetch = { path = "crates/servo-fetch", version = "0.10.1" }
 servo = { version = "0.1.0", default-features = false, features = ["baked-in-resources", "js_jit"] }
 anyhow = "1"
 base64 = "0.22"
+bitflags = "2"
+cssparser = "0.36"
 dom_query = "0.26"
 dom_smoothie = "0.16"
 dpi = "0.1"

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ print(page.markdown)
 
 - **Zero dependencies** — single binary, no Chromium, no API key
 - **Real JS execution** — SpiderMonkey runs JavaScript, parallel CSS engine computes layout
-- **Layout-aware extraction** — strips navbars, sidebars, footers by actual rendered position
+- **Layout- and visibility-aware extraction** — strips navbars, sidebars, footers by rendered position, plus cookie banners, modals, and CSS-hidden content (`opacity:0`, `aria-hidden`, sr-only)
 - **Schema-driven JSON** — declarative CSS-selector schema pulls structured data
 - **Parallel batch fetch** — multiple URLs fetched concurrently
 - **Site crawling** — BFS link traversal with robots.txt, same-site scope, and rate limiting
@@ -53,9 +53,9 @@ Apple M3 Pro, versus Playwright (the typical AI-agent stack):
 | Time — spa-heavy    |     ~331 ms |              ~798 ms |
 | Memory (peak RSS)   |    51–64 MB |           300–328 MB |
 
-Extraction quality: mean word-F1 0.823 vs Readability's 0.723 across
-seven page-type fixtures, with `without[]` boilerplate removal at 96.4%
-vs 82.1%. Direct-binary engine peers (chrome-headless-shell, Lightpanda,
+Extraction quality: mean word-F1 0.819 vs Readability's 0.728 across
+eight page-type fixtures, with `without[]` boilerplate removal at 95.0%
+vs 78.6%. Direct-binary engine peers (chrome-headless-shell, Lightpanda,
 curl) are opt-in.
 
 Methodology, three-axis breakdown, per-fixture F1, and raw JSON:

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -80,16 +80,19 @@ Full matrix with stddev and `curl` floor: [`results/published-time.md`](results/
 | Memory — static-small (peak)  |       64 MB |              328 MB  |
 | Memory — spa-heavy (peak)     |      ~96 MB |              350 MB  |
 
-### Axis 3 — Extraction quality (mean across 7 page-type fixtures)
+### Axis 3 — Extraction quality (mean across 8 page-type fixtures)
 
-| Metric      | servo-fetch (layout-aware) | Readability (DOM-only) |
-| ----------- | -------------------------: | ---------------------: |
-| Word-F1     |                      0.823 |                  0.723 |
-| `with[]`    |                      88.6% |                  62.9% |
-| `without[]` |                      96.4% |                  82.1% |
+| Metric      | servo-fetch (moderate) | servo-fetch (strict) | Readability (DOM-only) |
+| ----------- | ---------------------: | -------------------: | ---------------------: |
+| Word-F1     |                  0.819 |                0.823 |                  0.728 |
+| `with[]`    |                  90.0% |                90.0% |                  67.5% |
+| `without[]` |                  95.0% |                96.9% |                  78.6% |
 
-servo-fetch's advantage concentrates on boilerplate-heavy pages —
-navbar/sidebar/footer removal (the `without[]` metric). Per-fixture
+`moderate` (default) strips CSS- and ARIA-hidden content (`opacity:0`,
+`aria-hidden`, cookie banners, modal dialogs); `strict` additionally drops
+screen-reader-only content. The published per-fixture report also includes
+an `off` baseline that disables flag-based filtering — useful for
+isolating the visibility module's incremental contribution. Per-fixture
 breakdown: [`results/published-extraction-layout.md`](results/published-extraction-layout.md).
 
 ## Quick start

--- a/benchmarks/fixtures/extraction/golden/visibility-spam.expect
+++ b/benchmarks/fixtures/extraction/golden/visibility-spam.expect
@@ -1,0 +1,17 @@
+with = sharp shift in flavor profile
+with = harvest of 2026 was unusually wet
+with = adjusting their grind settings
+with = slightly coarser grind
+without = Skip to main navigation
+without = Hidden modal description for assistive technology
+without = Inline visibility hidden
+without = Cheap coffee beans buy now click here
+without = Hidden keyword stuffing for search engines
+without = This paragraph is hidden via the HTML hidden attribute
+without = Aria-hidden text for screen reader bypass
+without = We use cookies to enhance your browsing
+without = OneTrust cookie consent
+without = Cookiebot consent dialog
+without = Didomi consent
+without = Subscribe to our weekly newsletter
+without = Do not sell my personal information

--- a/benchmarks/fixtures/extraction/golden/visibility-spam.txt
+++ b/benchmarks/fixtures/extraction/golden/visibility-spam.txt
@@ -1,0 +1,5 @@
+Cafés in major cities reported a sharp shift in flavor profile over the past seven days, attributed to a new shipment of Brazilian Arabica beans. Roasters say the harvest of 2026 was unusually wet, producing beans with lower acidity and a heavier mouthfeel.
+
+Industry analysts at the Specialty Coffee Association expect the trend to last through the end of the quarter. Cafés have begun adjusting their grind settings and brew temperatures to compensate. Most chains report no change to retail prices, absorbing the import cost differences into existing margins.
+
+For home brewers, experts recommend a slightly coarser grind and a five-degree drop in water temperature to bring out the new flavor characteristics. The change is most noticeable in pour-over methods, where extraction time is sensitive to bean density.

--- a/benchmarks/fixtures/extraction/visibility-spam.html
+++ b/benchmarks/fixtures/extraction/visibility-spam.html
@@ -1,0 +1,125 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Coffee market shift · servo-fetch bench</title>
+  <style>
+    body { margin: 0; font-family: sans-serif; }
+    main { max-width: 720px; margin: 40px auto; padding: 0 24px; }
+    /* Bootstrap 4-style sr-only */
+    .sr-only {
+      position: absolute; width: 1px; height: 1px; overflow: hidden;
+      clip: rect(0, 0, 0, 0); white-space: nowrap;
+    }
+    /* TPGi / Bootstrap 5 canonical visually-hidden */
+    .visually-hidden {
+      position: absolute; width: 1px; height: 1px; overflow: hidden;
+      clip-path: inset(50%); white-space: nowrap;
+    }
+    .seo-hidden-opacity { opacity: 0; height: 0; overflow: hidden; }
+    .seo-hidden-text-indent { text-indent: -9999px; }
+    .cookie-banner {
+      position: fixed; bottom: 0; left: 0; right: 0;
+      background: #1a1a1a; color: white; padding: 16px;
+      font-family: sans-serif;
+    }
+    .newsletter-popup {
+      position: fixed; top: 50%; left: 50%;
+      background: white; padding: 24px;
+      border: 1px solid #ccc; box-shadow: 0 4px 24px rgba(0,0,0,0.2);
+    }
+    footer { padding: 60px 24px; background: #f7f7f7; color: #555; }
+  </style>
+</head>
+<body>
+  <nav>Home · Markets · Subscribe · Login</nav>
+
+  <main>
+    <article>
+      <h1>Why your morning coffee tastes different this week</h1>
+
+      <p>
+        Cafés in major cities reported a sharp shift in flavor profile over
+        the past seven days, attributed to a new shipment of Brazilian
+        Arabica beans. Roasters say the harvest of 2026 was unusually wet,
+        producing beans with lower acidity and a heavier mouthfeel.
+      </p>
+
+      <p>
+        Industry analysts at the Specialty Coffee Association expect the
+        trend to last through the end of the quarter. Cafés have begun
+        adjusting their grind settings and brew temperatures to compensate.
+        Most chains report no change to retail prices, absorbing the import
+        cost differences into existing margins.
+      </p>
+
+      <p>
+        For home brewers, experts recommend a slightly coarser grind and a
+        five-degree drop in water temperature to bring out the new flavor
+        characteristics. The change is most noticeable in pour-over methods,
+        where extraction time is sensitive to bean density.
+      </p>
+
+      <p class="sr-only">Skip to main navigation. Skip to footer.</p>
+
+      <p class="visually-hidden">Hidden modal description for assistive technology.</p>
+
+      <p style="visibility: hidden">
+        Inline visibility hidden — toggled-off modal copy that should not leak.
+      </p>
+
+      <p class="seo-hidden-opacity">
+        Cheap coffee beans buy now click here best deals discount coupon
+        promo code save big limited time offer free shipping order today.
+      </p>
+
+      <p class="seo-hidden-text-indent">
+        Hidden keyword stuffing for search engines: coffee, espresso, latte,
+        cappuccino, americano, mocha, frappuccino, cold brew, drip, french press.
+      </p>
+
+      <p hidden>
+        This paragraph is hidden via the HTML hidden attribute and should
+        not appear in extracted output.
+      </p>
+
+      <p aria-hidden="true">
+        Aria-hidden text for screen reader bypass; not exposed to assistive
+        technology and irrelevant to extraction.
+      </p>
+    </article>
+  </main>
+
+  <div class="cookie-banner">
+    We use cookies to enhance your browsing experience and analyze traffic.
+    By continuing to browse you accept our cookie policy and terms of service.
+    <button>Accept all</button>
+    <button>Manage preferences</button>
+  </div>
+
+  <div id="onetrust-banner-sdk">
+    OneTrust cookie consent: This website uses cookies for analytics and marketing.
+    <button>Accept</button>
+  </div>
+
+  <div id="CybotCookiebotDialog">
+    Cookiebot consent dialog: We use cookies to personalize content.
+  </div>
+
+  <div id="didomi-host">
+    Didomi consent: choose your preferences for tracking technologies.
+  </div>
+
+  <div role="dialog" aria-modal="true" class="newsletter-popup">
+    <h3>Subscribe to our weekly newsletter</h3>
+    <p>Get the best stories on the global coffee market delivered to your inbox.</p>
+    <input type="email" placeholder="your@email.com">
+    <button>Subscribe now</button>
+  </div>
+
+  <footer>
+    © 2026 Coffee Times · Privacy policy · Terms of service · Contact us
+    · Do not sell my personal information · Cookie preferences
+  </footer>
+</body>
+</html>

--- a/benchmarks/results/published-extraction-layout.md
+++ b/benchmarks/results/published-extraction-layout.md
@@ -1,70 +1,97 @@
 # Environment
-- date                  : 2026-05-06T06:03:35Z
+- date                  : 2026-05-21T05:52:36Z
 - host OS               : macOS 26.3 (darwin 25.3.0)
 - arch                  : arm64
 - CPU                   : Apple M3 Pro (11P / 11L)
 - memory                : 18.0 GiB
 - hyperfine             : hyperfine 1.20.0
 - node                  : v24.15.0
-- servo-fetch           : servo-fetch 0.7.1
+- servo-fetch           : servo-fetch 0.10.1
 - Playwright            : 1.59.1
 - chrome-headless-shell : Google Chrome for Testing 148.0.7778.96
 - lightpanda            : unknown
 
 # Extraction quality — page-type fixtures
 
+_`visibility=off` disables flag-based filtering (baseline); `moderate` (default) strips CSS- and ARIA-hidden content; `strict` additionally drops screen-reader-only nodes._
+
 ## `article-footer-heavy`
 
 | Extractor | F1 | with[] | without[] |
 |-|-:|-:|-:|
-| servo-fetch (layout-aware) | 0.851 | 100% | 100% |
+| servo-fetch (visibility=off) | 0.851 | 100% | 100% |
+| servo-fetch (visibility=moderate) | 0.851 | 100% | 100% |
+| servo-fetch (visibility=strict) | 0.851 | 100% | 100% |
 | Readability (DOM-only) | 0.982 | 100% | 100% |
 
 ## `documentation-sidebar`
 
 | Extractor | F1 | with[] | without[] |
 |-|-:|-:|-:|
-| servo-fetch (layout-aware) | 0.858 | 100% | 100% |
+| servo-fetch (visibility=off) | 0.858 | 100% | 100% |
+| servo-fetch (visibility=moderate) | 0.858 | 100% | 100% |
+| servo-fetch (visibility=strict) | 0.858 | 100% | 100% |
 | Readability (DOM-only) | 0.984 | 100% | 100% |
 
 ## `service-multi-section`
 
 | Extractor | F1 | with[] | without[] |
 |-|-:|-:|-:|
-| servo-fetch (layout-aware) | 0.862 | 100% | 100% |
+| servo-fetch (visibility=off) | 0.862 | 100% | 100% |
+| servo-fetch (visibility=moderate) | 0.862 | 100% | 100% |
+| servo-fetch (visibility=strict) | 0.862 | 100% | 100% |
 | Readability (DOM-only) | 0.026 | 0% | 0% |
 
 ## `forum-thread`
 
 | Extractor | F1 | with[] | without[] |
 |-|-:|-:|-:|
-| servo-fetch (layout-aware) | 0.974 | 100% | 100% |
+| servo-fetch (visibility=off) | 0.974 | 100% | 100% |
+| servo-fetch (visibility=moderate) | 0.974 | 100% | 100% |
+| servo-fetch (visibility=strict) | 0.974 | 100% | 100% |
 | Readability (DOM-only) | 0.961 | 80% | 100% |
 
 ## `product-jsonld`
 
 | Extractor | F1 | with[] | without[] |
 |-|-:|-:|-:|
-| servo-fetch (layout-aware) | 0.312 | 20% | 75% |
+| servo-fetch (visibility=off) | 0.312 | 20% | 75% |
+| servo-fetch (visibility=moderate) | 0.312 | 20% | 75% |
+| servo-fetch (visibility=strict) | 0.312 | 20% | 75% |
 | Readability (DOM-only) | 0.136 | 0% | 75% |
 
 ## `collection-grid`
 
 | Extractor | F1 | with[] | without[] |
 |-|-:|-:|-:|
-| servo-fetch (layout-aware) | 0.932 | 100% | 100% |
+| servo-fetch (visibility=off) | 0.932 | 100% | 100% |
+| servo-fetch (visibility=moderate) | 0.932 | 100% | 100% |
+| servo-fetch (visibility=strict) | 0.932 | 100% | 100% |
 | Readability (DOM-only) | 0.977 | 80% | 100% |
 
 ## `listing-cards`
 
 | Extractor | F1 | with[] | without[] |
 |-|-:|-:|-:|
-| servo-fetch (layout-aware) | 0.974 | 100% | 100% |
+| servo-fetch (visibility=off) | 0.974 | 100% | 100% |
+| servo-fetch (visibility=moderate) | 0.974 | 100% | 100% |
+| servo-fetch (visibility=strict) | 0.974 | 100% | 100% |
 | Readability (DOM-only) | 0.992 | 80% | 100% |
 
-## Summary — mean across 7 fixtures
+## `visibility-spam`
+
+| Extractor | F1 | with[] | without[] |
+|-|-:|-:|-:|
+| servo-fetch (visibility=off) | 0.672 | 100% | 54% |
+| servo-fetch (visibility=moderate) | 0.788 | 100% | 85% |
+| servo-fetch (visibility=strict) | 0.820 | 100% | 100% |
+| Readability (DOM-only) | 0.769 | 100% | 54% |
+
+## Summary — mean across 8 fixtures
 
 | Extractor | Mean F1 | Mean with[] | Mean without[] |
 |-|-:|-:|-:|
-| servo-fetch (layout-aware) | 0.823 | 88.6% | 96.4% |
-| Readability (DOM-only) | 0.723 | 62.9% | 82.1% |
+| servo-fetch (visibility=off) | 0.804 | 90.0% | 91.1% |
+| servo-fetch (visibility=moderate) | 0.819 | 90.0% | 95.0% |
+| servo-fetch (visibility=strict) | 0.823 | 90.0% | 96.9% |
+| Readability (DOM-only) | 0.728 | 67.5% | 78.6% |

--- a/benchmarks/src/servo_fetch_bench/cli.py
+++ b/benchmarks/src/servo_fetch_bench/cli.py
@@ -381,7 +381,10 @@ def extract_layout(ctx: typer.Context) -> None:
     _write_report(
         cfg.results_dir / "extraction-layout.md", cfg,
         "Extraction quality — page-type fixtures",
-        "\n".join(sections)
+        "_`visibility=off` disables flag-based filtering (baseline); "
+        "`moderate` (default) strips CSS- and ARIA-hidden content; "
+        "`strict` additionally drops screen-reader-only nodes._\n\n"
+        + "\n".join(sections)
         + f"\n## Summary — mean across {len(EXTRACTION_FIXTURES)} fixtures\n\n"
         + reporting.md_table(
             ["Extractor", "Mean F1", "Mean with[]", "Mean without[]"],

--- a/benchmarks/src/servo_fetch_bench/runners.py
+++ b/benchmarks/src/servo_fetch_bench/runners.py
@@ -26,6 +26,7 @@ EXTRACTION_FIXTURES: tuple[str, ...] = (
     "product-jsonld",
     "collection-grid",
     "listing-cards",
+    "visibility-spam",
 )
 
 
@@ -117,8 +118,12 @@ def speed_runners(cfg: Config) -> list[Runner]:
 def extract_runners(cfg: Config) -> list[Runner]:
     """Extraction-quality runners (servo-fetch vs DOM-only baseline)."""
     return [
-        Runner("servo-fetch (layout-aware)",
-               [str(cfg.servo_fetch_bin), "-q"], kind="extract"),
+        Runner("servo-fetch (visibility=off)",
+               [str(cfg.servo_fetch_bin), "-q", "--visibility=off"], kind="extract"),
+        Runner("servo-fetch (visibility=moderate)",
+               [str(cfg.servo_fetch_bin), "-q", "--visibility=moderate"], kind="extract"),
+        Runner("servo-fetch (visibility=strict)",
+               [str(cfg.servo_fetch_bin), "-q", "--visibility=strict"], kind="extract"),
         Runner("Readability (DOM-only)",
                [cfg.node_bin, str(cfg.tools_dir / "readability-runner.js")],
                env=_node_env(cfg), kind="extract"),

--- a/benchmarks/tests/test_config_runner.py
+++ b/benchmarks/tests/test_config_runner.py
@@ -271,6 +271,11 @@ def test_peer_runners_use_html_output_format_and_single_url_mode(
     assert by_label[engine].single_url is True
 
 
-def test_extract_runners_contain_only_servo_fetch_and_readability(cfg: Config) -> None:
+def test_extract_runners_cover_visibility_policies_and_readability(cfg: Config) -> None:
     labels = [r.label for r in runners_mod.extract_runners(cfg)]
-    assert labels == ["servo-fetch (layout-aware)", "Readability (DOM-only)"]
+    assert labels == [
+        "servo-fetch (visibility=off)",
+        "servo-fetch (visibility=moderate)",
+        "servo-fetch (visibility=strict)",
+        "Readability (DOM-only)",
+    ]

--- a/crates/servo-fetch-cli/README.md
+++ b/crates/servo-fetch-cli/README.md
@@ -60,6 +60,19 @@ servo-fetch "https://example.com" --selector "article"
 servo-fetch "https://example.com" --selector ".main-content" --json
 ```
 
+### Visibility filtering
+
+Hidden patterns (cookie banners, modals, `aria-hidden`, `opacity:0`, sr-only)
+are stripped under the default `moderate` policy. Use `strict` to also drop
+screen-reader-only content, or `off` to disable flag-based stripping (semantic
+hides like `[hidden]` / modal dialogs always apply).
+
+```bash
+servo-fetch "https://example.com" --visibility moderate   # default
+servo-fetch "https://example.com" --visibility strict
+servo-fetch "https://example.com" --visibility off
+```
+
 ### Structured extraction (schema)
 
 Pull a declarative set of fields into JSON using CSS selectors — no LLM required. Define a schema once, reuse it across URLs:

--- a/crates/servo-fetch-cli/src/cli.rs
+++ b/crates/servo-fetch-cli/src/cli.rs
@@ -1,6 +1,7 @@
 //! CLI argument parsing.
 
-use clap::Parser;
+use clap::builder::NonEmptyStringValueParser;
+use clap::{ArgAction, Args, Parser, Subcommand, ValueEnum, value_parser};
 
 #[derive(Parser)]
 #[command(
@@ -16,7 +17,7 @@ pub(crate) struct Cli {
     pub fetch: FetchArgs,
 
     /// Increase log verbosity (`-v` info, `-vv` debug, `-vvv` trace)
-    #[arg(short = 'v', long, action = clap::ArgAction::Count, global = true, conflicts_with = "quiet")]
+    #[arg(short = 'v', long, action = ArgAction::Count, global = true, conflicts_with = "quiet")]
     pub verbose: u8,
 
     /// Suppress all logs except errors
@@ -28,7 +29,7 @@ pub(crate) struct Cli {
     pub allow_private_addresses: bool,
 }
 
-#[derive(clap::Args, Debug)]
+#[derive(Args, Debug)]
 pub(crate) struct FetchArgs {
     /// URLs to fetch (one or more)
     #[arg(num_args = 1..)]
@@ -51,15 +52,15 @@ pub(crate) struct FetchArgs {
     pub js: Option<String>,
 
     /// Timeout in seconds for page load
-    #[arg(short = 't', long, default_value_t = 30, value_parser = clap::value_parser!(u64).range(1..), value_name = "SECS")]
+    #[arg(short = 't', long, default_value_t = 30, value_parser = value_parser!(u64).range(1..), value_name = "SECS")]
     pub timeout: u64,
 
     /// Extra wait in ms after the `load` event, for SPAs that keep hydrating.
-    #[arg(long, default_value_t = 0, value_parser = clap::value_parser!(u64).range(0..=10_000), value_name = "MS")]
+    #[arg(long, default_value_t = 0, value_parser = value_parser!(u64).range(0..=10_000), value_name = "MS")]
     pub settle: u64,
 
     /// CSS selector to extract a specific section
-    #[arg(long, value_name = "CSS", value_parser = clap::builder::NonEmptyStringValueParser::new())]
+    #[arg(long, value_name = "CSS", value_parser = NonEmptyStringValueParser::new())]
     pub selector: Option<String>,
 
     /// Output raw HTML or plain text instead of Readability extraction
@@ -73,10 +74,35 @@ pub(crate) struct FetchArgs {
     /// Path to a CSS-selector schema file for structured JSON extraction
     #[arg(long, value_name = "FILE", conflicts_with_all = ["screenshot", "js", "raw", "selector"])]
     pub schema: Option<std::path::PathBuf>,
+
+    /// Visibility-aware filtering policy.
+    #[arg(long, value_name = "POLICY", value_enum, default_value_t = VisibilityArg::Moderate)]
+    pub visibility: VisibilityArg,
+}
+
+/// Visibility filtering policy.
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub(crate) enum VisibilityArg {
+    /// Strip CSS-, ARIA-, and geometry-hidden content (default).
+    Moderate,
+    /// Moderate plus screen-reader-only content.
+    Strict,
+    /// No flag-based stripping. ARIA/HTML semantic hides still apply.
+    Off,
+}
+
+impl VisibilityArg {
+    pub(crate) fn to_policy(self) -> servo_fetch::VisibilityPolicy {
+        match self {
+            Self::Moderate => servo_fetch::VisibilityPolicy::moderate(),
+            Self::Strict => servo_fetch::VisibilityPolicy::strict(),
+            Self::Off => servo_fetch::VisibilityPolicy::off(),
+        }
+    }
 }
 
 /// Raw output mode.
-#[derive(Debug, Clone, Copy, clap::ValueEnum)]
+#[derive(Debug, Clone, Copy, ValueEnum)]
 pub(crate) enum RawMode {
     /// Raw HTML
     Html,
@@ -85,7 +111,7 @@ pub(crate) enum RawMode {
 }
 
 /// Available subcommands.
-#[derive(clap::Subcommand)]
+#[derive(Subcommand)]
 pub(crate) enum Command {
     /// Start MCP server (stdio transport by default, or HTTP with --port)
     Mcp(McpArgs),
@@ -97,14 +123,14 @@ pub(crate) enum Command {
     Map(MapArgs),
 }
 
-#[derive(clap::Args, Debug)]
+#[derive(Args, Debug)]
 pub(crate) struct McpArgs {
     /// Port for Streamable HTTP transport. Omit for stdio.
     #[arg(long, value_name = "PORT")]
     pub port: Option<u16>,
 }
 
-#[derive(clap::Args, Debug)]
+#[derive(Args, Debug)]
 pub(crate) struct ServeArgs {
     /// Host to bind on.
     #[arg(long, value_name = "HOST", default_value = "127.0.0.1")]
@@ -115,7 +141,7 @@ pub(crate) struct ServeArgs {
     pub port: u16,
 }
 
-#[derive(clap::Args, Debug)]
+#[derive(Args, Debug)]
 pub(crate) struct CrawlArgs {
     /// Starting URL to crawl
     pub url: String,
@@ -141,23 +167,23 @@ pub(crate) struct CrawlArgs {
     pub json: bool,
 
     /// CSS selector to extract a specific section per page
-    #[arg(long, value_name = "CSS", value_parser = clap::builder::NonEmptyStringValueParser::new())]
+    #[arg(long, value_name = "CSS", value_parser = NonEmptyStringValueParser::new())]
     pub selector: Option<String>,
 
     /// Timeout in seconds per page
-    #[arg(short = 't', long, default_value_t = 30, value_parser = clap::value_parser!(u64).range(1..), value_name = "SECS")]
+    #[arg(short = 't', long, default_value_t = 30, value_parser = value_parser!(u64).range(1..), value_name = "SECS")]
     pub timeout: u64,
 
     /// Extra wait in ms after load event per page
-    #[arg(long, default_value_t = 0, value_parser = clap::value_parser!(u64).range(0..=10_000), value_name = "MS")]
+    #[arg(long, default_value_t = 0, value_parser = value_parser!(u64).range(0..=10_000), value_name = "MS")]
     pub settle: u64,
 
     /// Maximum parallel page fetches. Yields in completion order when greater than 1.
-    #[arg(long, default_value_t = 1, value_parser = clap::value_parser!(u64).range(1..=64), value_name = "N")]
+    #[arg(long, default_value_t = 1, value_parser = value_parser!(u64).range(1..=64), value_name = "N")]
     pub concurrency: u64,
 
     /// Minimum dispatch interval in ms (0 to disable).
-    #[arg(long, default_value_t = 500, value_parser = clap::value_parser!(u64).range(0..=60_000), value_name = "MS")]
+    #[arg(long, default_value_t = 500, value_parser = value_parser!(u64).range(0..=60_000), value_name = "MS")]
     pub delay_ms: u64,
 
     /// Override the User-Agent string
@@ -165,7 +191,7 @@ pub(crate) struct CrawlArgs {
     pub user_agent: Option<String>,
 }
 
-#[derive(clap::Args, Debug)]
+#[derive(Args, Debug)]
 pub(crate) struct MapArgs {
     /// Starting URL to discover links from
     pub url: String,
@@ -195,7 +221,7 @@ pub(crate) struct MapArgs {
     pub user_agent: Option<String>,
 
     /// Timeout in seconds per HTTP request
-    #[arg(short = 't', long, default_value_t = 30, value_parser = clap::value_parser!(u64).range(1..), value_name = "SECS")]
+    #[arg(short = 't', long, default_value_t = 30, value_parser = value_parser!(u64).range(1..), value_name = "SECS")]
     pub timeout: u64,
 }
 
@@ -205,7 +231,7 @@ mod tests {
 
     #[test]
     fn raw_mode_from_str() {
-        use clap::ValueEnum;
+        use ValueEnum;
         assert!(RawMode::from_str("html", true).is_ok());
         assert!(RawMode::from_str("text", true).is_ok());
         assert!(RawMode::from_str("xml", true).is_err());

--- a/crates/servo-fetch-cli/src/commands/fetch.rs
+++ b/crates/servo-fetch-cli/src/commands/fetch.rs
@@ -55,10 +55,12 @@ async fn run_batch(args: &FetchArgs, urls: &[String]) -> Result<()> {
         let settle = args.settle;
         let user_agent = args.user_agent.clone();
         let schema = schema.clone();
+        let visibility = args.visibility.to_policy();
         tokio::task::spawn_blocking(move || {
             let mut opts = FetchOptions::new(&url_str)
                 .timeout(Duration::from_secs(timeout))
-                .settle(Duration::from_millis(settle));
+                .settle(Duration::from_millis(settle))
+                .visibility(visibility);
             if let Some(ua) = user_agent {
                 opts = opts.user_agent(ua);
             }
@@ -149,7 +151,8 @@ fn build_fetch_options(args: &FetchArgs, url: &str) -> Result<FetchOptions> {
     };
     let opts = base
         .timeout(Duration::from_secs(args.timeout))
-        .settle(Duration::from_millis(args.settle));
+        .settle(Duration::from_millis(args.settle))
+        .visibility(args.visibility.to_policy());
     let opts = match args.user_agent {
         Some(ref ua) => opts.user_agent(ua),
         None => opts,

--- a/crates/servo-fetch/Cargo.toml
+++ b/crates/servo-fetch/Cargo.toml
@@ -15,6 +15,8 @@ include = ["src/**/*", "Cargo.toml", "LICENSE-MIT", "LICENSE-APACHE", "README.md
 [dependencies]
 servo = { workspace = true }
 anyhow = { workspace = true }
+bitflags = { workspace = true }
+cssparser = { workspace = true }
 dom_query = { workspace = true }
 dom_smoothie = { workspace = true }
 dpi = { workspace = true }

--- a/crates/servo-fetch/README.md
+++ b/crates/servo-fetch/README.md
@@ -11,7 +11,7 @@ Looking for the CLI? See [`servo-fetch-cli`](https://crates.io/crates/servo-fetc
 ## Features
 
 - **Real JS execution** — SpiderMonkey runs JavaScript, parallel CSS engine computes layout
-- **Layout-aware extraction** — strips navbars, sidebars, footers by rendered position
+- **Layout- and visibility-aware extraction** — strips navbars/footers by rendered position, plus cookie banners, modals, and CSS-hidden content
 - **Schema-driven JSON** — declarative CSS-selector schema pulls structured data, no LLM
 - **Sync API** — no async runtime required; wrap with `spawn_blocking` for async contexts
 - **PDF auto-detection** — URLs returning PDF are automatically extracted as text

--- a/crates/servo-fetch/src/bridge.rs
+++ b/crates/servo-fetch/src/bridge.rs
@@ -15,6 +15,7 @@ use servo::{
 };
 
 use crate::layout;
+use crate::visibility;
 
 const JS_EVAL_TIMEOUT: Duration = Duration::from_secs(10);
 
@@ -31,16 +32,12 @@ pub(crate) fn default_user_agent() -> &'static str {
 /// Max wait before we re-check time-based conditions.
 pub(crate) const FALLBACK_WAIT: Duration = Duration::from_millis(5);
 const LAYOUT_JS: &str = include_str!("js/layout.js");
+const VISIBILITY_JS: &str = include_str!("js/visibility.js");
 const MAX_CONSOLE_MESSAGES: usize = 100;
 const MAX_CONSOLE_MESSAGE_LEN: usize = 4096;
 const MAX_A11Y_NODES: usize = 100_000;
 
-const NOISE_REMOVAL_CSS: &str = "\
-[aria-label*=\"cookie\" i], [aria-label*=\"consent\" i], \
-[class*=\"cookie-banner\" i], [class*=\"cookie-consent\" i], \
-[id*=\"cookie\" i][class*=\"banner\" i], \
-[class*=\"newsletter-popup\" i], [class*=\"subscribe-modal\" i] \
-{ display: none !important; }";
+const NOISE_REMOVAL_CSS: &str = visibility::USER_STYLESHEET;
 
 /// Shared wake signal — `notify_all` signals, `wait_and_take` consumes.
 #[derive(Default)]
@@ -240,9 +237,11 @@ pub(crate) struct ServoPage {
     pub html: String,
     pub inner_text: Option<String>,
     pub layout_json: Option<String>,
+    pub visibility_json: Option<String>,
     pub screenshot: Option<RgbaImage>,
     pub js_result: Option<String>,
     pub accessibility_tree: Option<String>,
+    pub a11y: Option<HashMap<servo::accesskit::NodeId, servo::accesskit::Node>>,
     pub console_messages: Vec<ConsoleMessage>,
 }
 
@@ -546,6 +545,10 @@ fn finish_fetch(servo: &servo::Servo, p: &PendingFetch) -> Result<ServoPage> {
         wait_for_ready_state(servo, &p.webview, p.deadline);
     }
 
+    let inner_text = eval_js(servo, &p.webview, "document.body.innerText").ok();
+    let layout_json = eval_js(servo, &p.webview, LAYOUT_JS).ok();
+    let visibility_json = eval_js(servo, &p.webview, VISIBILITY_JS).ok();
+
     let html = match eval_js(servo, &p.webview, "document.documentElement.outerHTML") {
         Ok(h) if !h.is_empty() => h,
         _ if timed_out => {
@@ -560,8 +563,6 @@ fn finish_fetch(servo: &servo::Servo, p: &PendingFetch) -> Result<ServoPage> {
     if timed_out {
         tracing::warn!("page load did not complete; returning best-effort content");
     }
-    let inner_text = eval_js(servo, &p.webview, "document.body.innerText").ok();
-    let layout_json = eval_js(servo, &p.webview, LAYOUT_JS).ok();
 
     let (screenshot, js_result) = match &p.request.mode {
         FetchMode::Screenshot { full_page } => (
@@ -572,17 +573,19 @@ fn finish_fetch(servo: &servo::Servo, p: &PendingFetch) -> Result<ServoPage> {
         FetchMode::Content { .. } => (None, None),
     };
 
-    let accessibility_tree = {
+    let (a11y, accessibility_tree) = {
         let mut nodes = p.state.a11y_nodes.borrow_mut();
         if nodes.is_empty() {
-            None
+            (None, None)
         } else {
             for node in nodes.values_mut() {
                 if node.role() == servo::accesskit::Role::PasswordInput {
                     node.clear_value();
                 }
             }
-            serde_json::to_string(&*nodes).ok()
+            let json = serde_json::to_string(&*nodes).ok();
+            let typed = std::mem::take(&mut *nodes);
+            (Some(typed), json)
         }
     };
 
@@ -590,9 +593,11 @@ fn finish_fetch(servo: &servo::Servo, p: &PendingFetch) -> Result<ServoPage> {
         html,
         inner_text,
         layout_json,
+        visibility_json,
         screenshot,
         js_result,
         accessibility_tree,
+        a11y,
         console_messages: p.state.console_messages.borrow_mut().drain(..).collect(),
     })
 }
@@ -746,9 +751,11 @@ mod tests {
         assert!(page.html.is_empty());
         assert!(page.inner_text.is_none());
         assert!(page.layout_json.is_none());
+        assert!(page.visibility_json.is_none());
         assert!(page.screenshot.is_none());
         assert!(page.js_result.is_none());
         assert!(page.accessibility_tree.is_none());
+        assert!(page.a11y.is_none());
         assert!(page.console_messages.is_empty());
     }
 

--- a/crates/servo-fetch/src/extract.rs
+++ b/crates/servo-fetch/src/extract.rs
@@ -1,14 +1,17 @@
 //! Content extraction — converts raw HTML into readable Markdown or structured JSON.
 
 use std::borrow::Cow;
+use std::collections::HashMap;
 use std::fmt::Write;
 
 use dom_query::Document;
 use dom_smoothie::Readability;
 use htmd::HtmlToMarkdown;
 use serde::Serialize;
+use servo::accesskit::{Node, NodeId};
 
 use crate::layout::{self, LayoutElement};
+use crate::visibility::{self, A11yIndex, VisibilityPolicy};
 
 /// Errors that can occur during content extraction.
 #[derive(Debug, thiserror::Error)]
@@ -70,10 +73,16 @@ pub struct ExtractInput<'a> {
     pub url: &'a str,
     /// JSON-serialized layout data from the injected JS, if available.
     pub layout_json: Option<&'a str>,
+    /// JSON-serialized visibility data from the injected JS, if available.
+    pub visibility_json: Option<&'a str>,
+    /// AccessKit accessibility tree, if available.
+    pub a11y: Option<&'a HashMap<NodeId, Node>>,
     /// `document.body.innerText` fallback, if available.
     pub inner_text: Option<&'a str>,
     /// CSS selector to extract a specific section instead of using Readability.
     pub selector: Option<&'a str>,
+    /// Visibility policy controlling which hidden content is stripped.
+    pub visibility: VisibilityPolicy,
 }
 
 impl<'a> ExtractInput<'a> {
@@ -84,8 +93,11 @@ impl<'a> ExtractInput<'a> {
             html,
             url,
             layout_json: None,
+            visibility_json: None,
+            a11y: None,
             inner_text: None,
             selector: None,
+            visibility: VisibilityPolicy::default(),
         }
     }
 
@@ -93,6 +105,20 @@ impl<'a> ExtractInput<'a> {
     #[must_use]
     pub fn with_layout_json(mut self, layout_json: Option<&'a str>) -> Self {
         self.layout_json = layout_json;
+        self
+    }
+
+    /// Set the visibility JSON data.
+    #[must_use]
+    pub fn with_visibility_json(mut self, visibility_json: Option<&'a str>) -> Self {
+        self.visibility_json = visibility_json;
+        self
+    }
+
+    /// Set the typed accessibility tree.
+    #[must_use]
+    pub fn with_a11y(mut self, a11y: Option<&'a HashMap<NodeId, Node>>) -> Self {
+        self.a11y = a11y;
         self
     }
 
@@ -109,17 +135,21 @@ impl<'a> ExtractInput<'a> {
         self.selector = selector;
         self
     }
+
+    /// Set the visibility policy.
+    #[must_use]
+    pub fn with_visibility(mut self, policy: VisibilityPolicy) -> Self {
+        self.visibility = policy;
+        self
+    }
 }
 
 /// Extract readable content as Markdown text.
-///
-/// # Errors
-/// Returns [`ExtractError::Fmt`] if Markdown assembly fails.
 pub fn extract_text(input: &ExtractInput<'_>) -> Result<String, ExtractError> {
     if let Some(selector) = input.selector {
-        return extract_by_selector(input.html, input.layout_json, selector);
+        return extract_by_selector(input, selector);
     }
-    let article = parse_article(input.html, input.url, input.layout_json, input.inner_text);
+    let article = parse_article(input);
 
     let mut out = String::new();
     if !article.title.is_empty() {
@@ -136,12 +166,9 @@ pub fn extract_text(input: &ExtractInput<'_>) -> Result<String, ExtractError> {
 }
 
 /// Extract readable content as JSON.
-///
-/// # Errors
-/// Returns [`ExtractError::Json`] if JSON serialization fails.
 pub fn extract_json(input: &ExtractInput<'_>) -> Result<String, ExtractError> {
     if let Some(selector) = input.selector {
-        let text = extract_by_selector(input.html, input.layout_json, selector)?;
+        let text = extract_by_selector(input, selector)?;
         let data = ArticleData {
             title: String::new(),
             content: String::new(),
@@ -153,7 +180,7 @@ pub fn extract_json(input: &ExtractInput<'_>) -> Result<String, ExtractError> {
         };
         return Ok(serde_json::to_string_pretty(&data)?);
     }
-    let article = parse_article(input.html, input.url, input.layout_json, input.inner_text);
+    let article = parse_article(input);
     let data = ArticleData {
         title: article.title,
         content: article.content,
@@ -180,11 +207,11 @@ fn is_nextjs_error_page(text: &str) -> bool {
     t.contains("client-side exception has occurred") || t.contains("Application error: a")
 }
 
-fn parse_article(html: &str, url: &str, layout_json: Option<&str>, inner_text: Option<&str>) -> ParsedArticle {
-    let filtered = filter(html, layout_json);
+fn parse_article(input: &ExtractInput<'_>) -> ParsedArticle {
+    let filtered = filter(input);
 
     let doc = Document::from(filtered.as_ref());
-    if let Ok(mut readability) = Readability::with_document(doc, Some(url), None) {
+    if let Ok(mut readability) = Readability::with_document(doc, Some(input.url), None) {
         if let Ok(article) = readability.parse() {
             if !is_nextjs_error_page(&article.text_content) {
                 let converter = HtmlToMarkdown::builder().build();
@@ -203,16 +230,23 @@ fn parse_article(html: &str, url: &str, layout_json: Option<&str>, inner_text: O
         }
     }
 
-    // Readability failed or returned an error page — fall back to innerText.
+    // Readability failed or returned an error page — fall back to the filtered
+    // document's text content.
     let doc = Document::from(filtered.as_ref());
+    doc.select("script, style, noscript").remove();
     let title = doc.select("title").text().to_string();
-    let body_text = inner_text.filter(|s| !s.trim().is_empty()).map_or_else(
-        || {
-            tracing::warn!(r#"could not extract content; try --js "document.body.innerText" for JS-heavy sites"#);
-            String::new()
-        },
-        String::from,
-    );
+    let filtered_text = doc.select("body").text().to_string();
+    let body_text = if filtered_text.trim().is_empty() {
+        input.inner_text.filter(|s| !s.trim().is_empty()).map_or_else(
+            || {
+                tracing::warn!(r#"could not extract content; try --js "document.body.innerText" for JS-heavy sites"#);
+                String::new()
+            },
+            String::from,
+        )
+    } else {
+        filtered_text
+    };
     ParsedArticle {
         title,
         content: String::new(),
@@ -223,9 +257,9 @@ fn parse_article(html: &str, url: &str, layout_json: Option<&str>, inner_text: O
     }
 }
 
-fn extract_by_selector(html: &str, layout_json: Option<&str>, selector: &str) -> Result<String, ExtractError> {
+fn extract_by_selector(input: &ExtractInput<'_>, selector: &str) -> Result<String, ExtractError> {
     let matcher = dom_query::Matcher::new(selector).map_err(|_| ExtractError::InvalidSelector)?;
-    let filtered = filter(html, layout_json);
+    let filtered = filter(input);
     let doc = Document::from(filtered.as_ref());
     let selected = doc.select_matcher(&matcher);
     let fragment = selected.html();
@@ -239,20 +273,36 @@ fn extract_by_selector(html: &str, layout_json: Option<&str>, selector: &str) ->
     Ok(clean_markdown(&markdown))
 }
 
-fn filter<'a>(html: &'a str, layout_json: Option<&str>) -> Cow<'a, str> {
-    layout_json
-        .and_then(|lj| serde_json::from_str::<Vec<LayoutElement>>(lj).ok())
-        .map_or(Cow::Borrowed(html), |els| {
-            let sels = layout::selectors_to_strip(&els);
-            if sels.is_empty() {
-                return Cow::Borrowed(html);
-            }
-            let doc = Document::from(html);
-            for sel in &sels {
-                doc.select(sel).remove();
-            }
-            Cow::Owned(doc.html().to_string())
-        })
+fn filter<'a>(input: &'a ExtractInput<'a>) -> Cow<'a, str> {
+    let mut selectors: Vec<String> = Vec::new();
+
+    if let Some(lj) = input.layout_json
+        && let Ok(els) = serde_json::from_str::<Vec<LayoutElement>>(lj)
+    {
+        selectors.extend(layout::selectors_to_strip(&els));
+    }
+
+    let a11y_index = input.a11y.map(A11yIndex::new);
+
+    selectors.extend(visibility::selectors_to_strip(
+        input.visibility,
+        a11y_index.as_ref(),
+        input.visibility_json,
+    ));
+
+    let needs_attr_cleanup = input.visibility_json.is_some() || input.html.contains("data-vf-id=");
+    if selectors.is_empty() && !needs_attr_cleanup {
+        return Cow::Borrowed(input.html);
+    }
+
+    let doc = Document::from(input.html);
+    for sel in &selectors {
+        doc.select(sel).remove();
+    }
+    if needs_attr_cleanup {
+        doc.select("[data-vf-id]").remove_attr("data-vf-id");
+    }
+    Cow::Owned(doc.html().to_string())
 }
 
 // Collapse runs of 3+ blank lines down to 2.
@@ -307,28 +357,56 @@ mod tests {
     }
 
     #[test]
-    fn filter_without_layout_returns_original() {
-        let html = "<html><body>hello</body></html>";
-        let result = filter(html, None);
-        assert_eq!(result.as_ref(), html);
+    fn filter_off_policy_keeps_visible_content() {
+        let input = ExtractInput::new("<html><body>hello</body></html>", "").with_visibility(VisibilityPolicy::off());
+        let result = filter(&input);
+        assert!(result.contains("hello"));
     }
 
     #[test]
     fn filter_strips_footer() {
         let html = r#"<html><body><footer style="position:static">nav</footer><p>content</p></body></html>"#;
         let layout = r#"[{"tag":"FOOTER","role":null,"w":1280,"h":100,"position":"static"}]"#;
-        let result = filter(html, Some(layout));
+        let input = ExtractInput::new(html, "")
+            .with_layout_json(Some(layout))
+            .with_visibility(VisibilityPolicy::off());
+        let result = filter(&input);
         assert!(!result.contains("<footer"));
         assert!(result.contains("content"));
+    }
+
+    #[test]
+    fn filter_strips_visibility_flagged_element() {
+        let html = r#"<html><body><p data-vf-id="1">drop</p><p data-vf-id="2">keep</p></body></html>"#;
+        let visibility = r#"[{"id":"1","flags":16}]"#;
+        let input = ExtractInput::new(html, "")
+            .with_visibility_json(Some(visibility))
+            .with_visibility(VisibilityPolicy::moderate());
+        let result = filter(&input);
+        assert!(!result.contains("drop"));
+        assert!(result.contains("keep"));
+    }
+
+    #[test]
+    fn filter_removes_data_vf_id_from_output() {
+        let html = r#"<html><body><p data-vf-id="1">keep</p></body></html>"#;
+        let input = ExtractInput::new(html, "")
+            .with_layout_json(Some("[]"))
+            .with_visibility(VisibilityPolicy::off());
+        let result = filter(&input);
+        assert!(!result.contains("data-vf-id"));
     }
 
     #[test]
     fn extract_input_builder() {
         let input = ExtractInput::new("<html></html>", "https://example.com")
             .with_layout_json(Some("[]"))
+            .with_visibility_json(Some(r"[]"))
             .with_inner_text(Some("hello"))
-            .with_selector(Some("article"));
+            .with_selector(Some("article"))
+            .with_visibility(VisibilityPolicy::strict());
         assert_eq!(input.layout_json, Some("[]"));
+        assert_eq!(input.visibility_json, Some("[]"));
         assert_eq!(input.inner_text, Some("hello"));
         assert_eq!(input.selector, Some("article"));
     }

--- a/crates/servo-fetch/src/fetch.rs
+++ b/crates/servo-fetch/src/fetch.rs
@@ -1,6 +1,10 @@
 //! Single-page fetching and rendered content extraction.
 
+use std::collections::HashMap;
+use std::sync::Arc;
 use std::time::Duration;
+
+use servo::accesskit::{Node, NodeId};
 
 use crate::error::Error;
 use crate::net::sanitize_user_agent;
@@ -18,19 +22,29 @@ pub struct Page {
     /// Parsed layout data from the injected CSS heuristics script.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub layout_json: Option<String>,
+    /// Per-node visibility flags from the visibility-aware extraction pass.
+    #[serde(skip)]
+    visibility_json: Option<String>,
     /// Result of JavaScript evaluation, if [`FetchOptions::javascript`] was used.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub js_result: Option<String>,
     /// Browser console messages captured during page load.
     pub console_messages: Vec<ConsoleMessage>,
-    /// Accessibility tree (AccessKit), if requested.
+    /// Accessibility tree (AccessKit), serialized as JSON, if requested.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub accessibility_tree: Option<String>,
     /// Structured data extracted via [`FetchOptions::schema`].
     #[serde(skip_serializing_if = "Option::is_none")]
     pub extracted: Option<serde_json::Value>,
+    /// PNG-encoded screenshot bytes — read via [`Page::screenshot_png`].
     #[serde(skip)]
     screenshot_png: Option<Vec<u8>>,
+    /// Typed AccessKit tree, shared cheaply across [`Page`] clones.
+    #[serde(skip)]
+    a11y: Option<Arc<HashMap<NodeId, Node>>>,
+    /// Visibility policy that was active when this page was fetched.
+    #[serde(skip)]
+    visibility_policy: crate::visibility::VisibilityPolicy,
 }
 
 impl Page {
@@ -41,10 +55,7 @@ impl Page {
 
     /// Extract readable Markdown, using the original URL for link resolution.
     pub fn markdown_with_url(&self, url: &str) -> crate::error::Result<String> {
-        let input = crate::extract::ExtractInput::new(&self.html, url)
-            .with_layout_json(self.layout_json.as_deref())
-            .with_inner_text(Some(&self.inner_text));
-        Ok(crate::extract::extract_text(&input)?)
+        Ok(crate::extract::extract_text(&self.extract_input(url, None))?)
     }
 
     /// Extract structured JSON from this page.
@@ -54,34 +65,33 @@ impl Page {
 
     /// Extract structured JSON, using the original URL for link resolution.
     pub fn extract_json_with_url(&self, url: &str) -> crate::error::Result<String> {
-        let input = crate::extract::ExtractInput::new(&self.html, url)
-            .with_layout_json(self.layout_json.as_deref())
-            .with_inner_text(Some(&self.inner_text));
-        Ok(crate::extract::extract_json(&input)?)
+        Ok(crate::extract::extract_json(&self.extract_input(url, None))?)
     }
 
     /// Extract readable Markdown from the subtree matched by a CSS selector.
     pub fn markdown_with_selector(&self, url: &str, selector: &str) -> crate::error::Result<String> {
-        let input = crate::extract::ExtractInput::new(&self.html, url)
-            .with_layout_json(self.layout_json.as_deref())
-            .with_inner_text(Some(&self.inner_text))
-            .with_selector(Some(selector));
-        Ok(crate::extract::extract_text(&input)?)
+        Ok(crate::extract::extract_text(&self.extract_input(url, Some(selector)))?)
     }
 
     /// Extract structured JSON from the subtree matched by a CSS selector.
     pub fn extract_json_with_selector(&self, url: &str, selector: &str) -> crate::error::Result<String> {
-        let input = crate::extract::ExtractInput::new(&self.html, url)
-            .with_layout_json(self.layout_json.as_deref())
-            .with_inner_text(Some(&self.inner_text))
-            .with_selector(Some(selector));
-        Ok(crate::extract::extract_json(&input)?)
+        Ok(crate::extract::extract_json(&self.extract_input(url, Some(selector)))?)
     }
 
     /// PNG screenshot bytes, if captured via [`FetchOptions::screenshot`].
     #[must_use]
     pub fn screenshot_png(&self) -> Option<&[u8]> {
         self.screenshot_png.as_deref()
+    }
+
+    fn extract_input<'a>(&'a self, url: &'a str, selector: Option<&'a str>) -> crate::extract::ExtractInput<'a> {
+        crate::extract::ExtractInput::new(&self.html, url)
+            .with_layout_json(self.layout_json.as_deref())
+            .with_visibility_json(self.visibility_json.as_deref())
+            .with_a11y(self.a11y.as_deref())
+            .with_inner_text(Some(&self.inner_text))
+            .with_selector(selector)
+            .with_visibility(self.visibility_policy)
     }
 
     pub(crate) fn from_servo(page: crate::bridge::ServoPage) -> Self {
@@ -100,6 +110,7 @@ impl Page {
             inner_text: page.inner_text.unwrap_or_default(),
             title,
             layout_json: page.layout_json,
+            visibility_json: page.visibility_json,
             js_result: page.js_result,
             console_messages: page
                 .console_messages
@@ -118,7 +129,9 @@ impl Page {
                 .collect(),
             screenshot_png,
             accessibility_tree: page.accessibility_tree,
+            a11y: page.a11y.map(Arc::new),
             extracted: None,
+            visibility_policy: crate::visibility::VisibilityPolicy::default(),
         }
     }
 }
@@ -193,6 +206,7 @@ pub struct FetchOptions {
     pub(crate) mode: FetchMode,
     pub(crate) user_agent: Option<String>,
     pub(crate) extract_schema: Option<crate::schema::ExtractSchema>,
+    pub(crate) visibility: crate::visibility::VisibilityPolicy,
 }
 
 impl FetchOptions {
@@ -205,6 +219,7 @@ impl FetchOptions {
             mode: FetchMode::Content,
             user_agent: None,
             extract_schema: None,
+            visibility: crate::visibility::VisibilityPolicy::default(),
         }
     }
 
@@ -245,6 +260,12 @@ impl FetchOptions {
     /// Extract structured data from the rendered page using the given schema.
     pub fn schema(mut self, schema: crate::schema::ExtractSchema) -> Self {
         self.extract_schema = Some(schema);
+        self
+    }
+
+    /// Visibility-filtering policy applied during extraction.
+    pub fn visibility(mut self, policy: crate::visibility::VisibilityPolicy) -> Self {
+        self.visibility = policy;
         self
     }
 }
@@ -294,6 +315,7 @@ pub fn fetch(opts: FetchOptions) -> crate::error::Result<Page> {
     })?;
 
     let mut page = Page::from_servo(servo_page);
+    page.visibility_policy = opts.visibility;
     if let Some(schema) = opts.extract_schema.as_ref() {
         page.extracted = Some(schema.extract_from(&page.html));
     }
@@ -614,9 +636,11 @@ mod tests {
                 html: "<html><head><title>T</title></head><body>B</body></html>".into(),
                 inner_text: Some("B".into()),
                 layout_json: Some("[]".into()),
+                visibility_json: Some("[]".into()),
                 screenshot: Some(synthetic_image(2, 2)),
                 js_result: Some("42".into()),
                 accessibility_tree: Some("{}".into()),
+                a11y: None,
                 console_messages: vec![bridge::ConsoleMessage {
                     level: bridge::ConsoleLevel::Log,
                     message: "x".into(),

--- a/crates/servo-fetch/src/js/visibility.js
+++ b/crates/servo-fetch/src/js/visibility.js
@@ -1,0 +1,82 @@
+// Reports CSS visibility signals AccessKit doesn't expose.
+
+(() => {
+  // Capture native APIs — page main world is exposed to prototype tampering.
+  const _gcs = window.getComputedStyle.bind(window);
+  const _qsa = Document.prototype.querySelectorAll;
+  const _setAttr = Element.prototype.setAttribute;
+  const _gbcr = Element.prototype.getBoundingClientRect;
+
+  const SELECTOR =
+    "div,section,article,main,aside,nav,header,footer," +
+    "p,h1,h2,h3,h4,h5,h6,ul,ol,li,table,pre,blockquote,figure,span,a,button," +
+    "details,dialog";
+
+  const F_OPACITY_ZERO              = 1 << 4;
+  const F_CLIPPED                   = 1 << 5;
+  const F_CONTENT_VISIBILITY_HIDDEN = 1 << 6;
+  const F_TEXT_INDENT_OFFSCREEN     = 1 << 7;
+  const F_SR_ONLY                   = 1 << 8;
+  const F_VISIBILITY_HIDDEN         = 1 << 9;
+
+  const MAX = 5000;
+  const reports = [];
+
+  const isClipped = (cs) =>
+    cs.clip === "rect(0px, 0px, 0px, 0px)" ||
+    cs.clip === "rect(1px, 1px, 1px, 1px)" ||
+    cs.clipPath === "inset(100%)" ||
+    cs.clipPath === "inset(50%)" ||
+    cs.clipPath === "circle(0px)";
+
+  // Iterative to avoid stack overflow on deep DOM (10k+ nesting).
+  const cumOpacity = new WeakMap();
+  const cumOpacityOf = (el) => {
+    if (cumOpacity.has(el)) return cumOpacity.get(el);
+    const chain = [];
+    let cur = el;
+    while (cur && !cumOpacity.has(cur)) {
+      chain.push(cur);
+      cur = cur.parentElement;
+    }
+    let acc = cur ? cumOpacity.get(cur) : 1;
+    for (let i = chain.length - 1; i >= 0; i--) {
+      acc *= parseFloat(_gcs(chain[i]).opacity);
+      cumOpacity.set(chain[i], acc);
+    }
+    return acc;
+  };
+
+  const looksSrOnly = (cs, r) => {
+    if (r.width > 1.5 || r.height > 1.5) return false;
+    return (isClipped(cs) || cs.overflow === "hidden") && cs.position === "absolute";
+  };
+
+  let nextId = 0;
+  for (const el of _qsa.call(document, SELECTOR)) {
+    if (++nextId > MAX) break;
+
+    const cs = _gcs(el);
+    const r = _gbcr.call(el);
+    let flags = 0;
+
+    // transform:scale(0) and display:none ancestors yield degenerate rects.
+    if (cumOpacityOf(el) < 0.01 || (r.width < 0.5 && r.height < 0.5)) flags |= F_OPACITY_ZERO;
+    if (cs.visibility === "hidden") flags |= F_VISIBILITY_HIDDEN;
+    if (cs.contentVisibility === "hidden") flags |= F_CONTENT_VISIBILITY_HIDDEN;
+    if (parseInt(cs.textIndent, 10) <= -9999) flags |= F_TEXT_INDENT_OFFSCREEN;
+    if (looksSrOnly(cs, r)) {
+      flags |= F_SR_ONLY;
+    } else if (isClipped(cs)) {
+      flags |= F_CLIPPED;
+    }
+
+    if (flags !== 0) {
+      const id = String(nextId);
+      _setAttr.call(el, "data-vf-id", id);
+      reports.push({ id, flags });
+    }
+  }
+
+  return JSON.stringify(reports);
+})()

--- a/crates/servo-fetch/src/lib.rs
+++ b/crates/servo-fetch/src/lib.rs
@@ -11,6 +11,7 @@
 pub mod extract;
 pub mod sanitize;
 pub mod schema;
+pub mod visibility;
 
 pub(crate) mod bridge;
 pub(crate) mod crawl;
@@ -31,6 +32,7 @@ pub use error::{Error, Result};
 pub use fetch::{ConsoleLevel, ConsoleMessage, FetchOptions, Page, extract_json, fetch, markdown, text};
 pub use map::{MapOptions, MappedUrl, map};
 pub use net::{NetworkPolicy, validate_url};
+pub use visibility::{VisibilityFlags, VisibilityPolicy};
 
 /// Set the network policy. Must be called at most once, before any engine use.
 pub fn init(policy: NetworkPolicy) {

--- a/crates/servo-fetch/src/visibility.rs
+++ b/crates/servo-fetch/src/visibility.rs
@@ -1,0 +1,171 @@
+//! Visibility-aware extraction.
+
+mod a11y;
+mod js;
+mod selectors;
+
+pub(crate) use self::a11y::A11yIndex;
+pub(crate) use self::selectors::selectors_to_strip;
+
+use bitflags::bitflags;
+
+/// User stylesheet applied before render to enforce ARIA, HTML, and modal
+/// semantics so matched nodes never produce boxes.
+pub(crate) const USER_STYLESHEET: &str = concat!(
+    "[hidden] { display: none !important; }\n",
+    "[aria-hidden=\"true\"] { display: none !important; }\n",
+    "[role=\"dialog\"][aria-modal=\"true\"] { display: none !important; }\n",
+    "[role=\"alertdialog\"] { display: none !important; }\n",
+    "[role=\"tabpanel\"][aria-hidden=\"true\"] { display: none !important; }\n",
+    "[aria-label*=\"cookie\" i], [aria-label*=\"consent\" i],\n",
+    "[class*=\"cookie-banner\" i], [class*=\"cookie-consent\" i],\n",
+    "[id*=\"cookie\" i][class*=\"banner\" i],\n",
+    "[class*=\"newsletter-popup\" i], [class*=\"subscribe-modal\" i],\n",
+    "#onetrust-banner-sdk, #onetrust-pc-sdk,\n",
+    "#CybotCookiebotDialog, #CybotCookiebotDialogBodyUnderlay,\n",
+    "#qc-cmp2-container, [id^=\"sp_message_container_\"],\n",
+    "#didomi-host, #usercentrics-root,\n",
+    "#truste-consent-track { display: none !important; }\n",
+);
+
+bitflags! {
+    /// Reasons a DOM node may be considered hidden.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+    pub struct VisibilityFlags: u32 {
+        /// Box has zero or near-zero area (AccessKit bounds).
+        const ZERO_SIZE                 = 1 << 0;
+        /// Box positioned outside the viewport (AccessKit bounds).
+        const OFFSCREEN                 = 1 << 1;
+        /// Computed font-size below 1px (AccessKit).
+        const FONT_SIZE_ZERO            = 1 << 2;
+        /// Tab panel with `aria-selected="false"` (AccessKit).
+        const TAB_PANEL_INACTIVE        = 1 << 3;
+        /// Cumulative opacity below 0.01 (computed CSS via JS).
+        const OPACITY_ZERO              = 1 << 4;
+        /// `clip` or `clip-path` set to a fully-clipped value (computed CSS via JS).
+        const CLIPPED                   = 1 << 5;
+        /// `content-visibility: hidden` (computed CSS via JS).
+        const CONTENT_VISIBILITY_HIDDEN = 1 << 6;
+        /// `text-indent` below `-9999px` while box is otherwise visible.
+        const TEXT_INDENT_OFFSCREEN     = 1 << 7;
+        /// Likely a "screen reader only" pattern (1px clip absolute).
+        const SR_ONLY                   = 1 << 8;
+        /// `visibility: hidden` (computed CSS via JS).
+        const VISIBILITY_HIDDEN         = 1 << 9;
+    }
+}
+
+/// Controls which visibility violations result in nodes being stripped from
+/// the extraction input.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct VisibilityPolicy {
+    pub(crate) strip_if_any: VisibilityFlags,
+}
+
+impl VisibilityPolicy {
+    /// Strip CSS-, ARIA-, and geometry-hidden content while preserving sr-only.
+    #[must_use]
+    pub fn moderate() -> Self {
+        Self {
+            strip_if_any: VisibilityFlags::ZERO_SIZE
+                | VisibilityFlags::OFFSCREEN
+                | VisibilityFlags::FONT_SIZE_ZERO
+                | VisibilityFlags::TAB_PANEL_INACTIVE
+                | VisibilityFlags::OPACITY_ZERO
+                | VisibilityFlags::CLIPPED
+                | VisibilityFlags::CONTENT_VISIBILITY_HIDDEN
+                | VisibilityFlags::TEXT_INDENT_OFFSCREEN
+                | VisibilityFlags::VISIBILITY_HIDDEN,
+        }
+    }
+
+    /// [`Self::moderate`] plus sr-only stripping.
+    #[must_use]
+    pub fn strict() -> Self {
+        let mut p = Self::moderate();
+        p.strip_if_any |= VisibilityFlags::SR_ONLY;
+        p
+    }
+
+    /// Disable visibility-flag-based stripping.
+    #[must_use]
+    pub fn off() -> Self {
+        Self {
+            strip_if_any: VisibilityFlags::empty(),
+        }
+    }
+}
+
+impl Default for VisibilityPolicy {
+    fn default() -> Self {
+        Self::moderate()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn moderate_policy_strips_common_hides() {
+        let p = VisibilityPolicy::moderate();
+        assert!(p.strip_if_any.contains(VisibilityFlags::ZERO_SIZE));
+        assert!(p.strip_if_any.contains(VisibilityFlags::OPACITY_ZERO));
+        assert!(p.strip_if_any.contains(VisibilityFlags::TAB_PANEL_INACTIVE));
+        assert!(!p.strip_if_any.contains(VisibilityFlags::SR_ONLY));
+    }
+
+    #[test]
+    fn strict_policy_adds_sr_only() {
+        let p = VisibilityPolicy::strict();
+        assert!(p.strip_if_any.contains(VisibilityFlags::SR_ONLY));
+    }
+
+    #[test]
+    fn off_policy_strips_nothing_directly() {
+        let p = VisibilityPolicy::off();
+        assert!(p.strip_if_any.is_empty());
+    }
+
+    #[test]
+    fn default_is_moderate() {
+        assert_eq!(
+            VisibilityPolicy::default().strip_if_any,
+            VisibilityPolicy::moderate().strip_if_any,
+        );
+    }
+
+    #[test]
+    fn user_stylesheet_targets_aria_hidden_and_hidden_attr() {
+        assert!(USER_STYLESHEET.contains("[hidden]"));
+        assert!(USER_STYLESHEET.contains("[aria-hidden=\"true\"]"));
+        assert!(USER_STYLESHEET.contains("[role=\"dialog\"][aria-modal=\"true\"]"));
+    }
+
+    #[test]
+    fn user_stylesheet_targets_major_cookie_consent_providers() {
+        // Major GDPR / CCPA cookie consent platforms by ID.
+        // Adding new providers here requires no other changes — render-time hide
+        // surfaces them via the `OPACITY_ZERO` flag in visibility.js, and they
+        // are stripped by `moderate` policy.
+        assert!(USER_STYLESHEET.contains("#onetrust-banner-sdk"));
+        assert!(USER_STYLESHEET.contains("#CybotCookiebotDialog"));
+        assert!(USER_STYLESHEET.contains("#qc-cmp2-container"));
+        assert!(USER_STYLESHEET.contains("#didomi-host"));
+        assert!(USER_STYLESHEET.contains("#usercentrics-root"));
+        assert!(USER_STYLESHEET.contains("[id^=\"sp_message_container_\"]"));
+        assert!(USER_STYLESHEET.contains("#truste-consent-track"));
+    }
+
+    /// Guards bit-value synchronisation with `js/visibility.js`.
+    #[test]
+    fn js_flag_constants_match_rust() {
+        assert_eq!(VisibilityFlags::OPACITY_ZERO.bits(), 1 << 4);
+        assert_eq!(VisibilityFlags::CLIPPED.bits(), 1 << 5);
+        assert_eq!(VisibilityFlags::CONTENT_VISIBILITY_HIDDEN.bits(), 1 << 6);
+        assert_eq!(VisibilityFlags::TEXT_INDENT_OFFSCREEN.bits(), 1 << 7);
+        assert_eq!(VisibilityFlags::SR_ONLY.bits(), 1 << 8);
+        assert_eq!(VisibilityFlags::VISIBILITY_HIDDEN.bits(), 1 << 9);
+    }
+}

--- a/crates/servo-fetch/src/visibility/a11y.rs
+++ b/crates/servo-fetch/src/visibility/a11y.rs
@@ -1,0 +1,227 @@
+//! AccessKit tree indexing for visibility flags and boilerplate detection.
+
+use std::collections::{BTreeSet, HashMap};
+
+use servo::accesskit::{Node, NodeId, Rect, Role};
+
+use super::{VisibilityFlags, VisibilityPolicy, selectors::make_selector};
+
+/// Threshold matching common off-screen hide patterns.
+const OFFSCREEN_THRESHOLD_PX: f64 = 99_999.0;
+
+/// Indexed view of an AccessKit tree for boilerplate role and flag lookups.
+#[derive(Debug)]
+pub(crate) struct A11yIndex<'a> {
+    nodes: &'a HashMap<NodeId, Node>,
+    flags: HashMap<NodeId, VisibilityFlags>,
+    by_role: HashMap<Role, Vec<NodeId>>,
+}
+
+impl<'a> A11yIndex<'a> {
+    pub(crate) fn new(nodes: &'a HashMap<NodeId, Node>) -> Self {
+        let mut flags = HashMap::new();
+        let mut by_role: HashMap<Role, Vec<NodeId>> = HashMap::new();
+
+        for (id, node) in nodes {
+            by_role.entry(node.role()).or_default().push(*id);
+            let f = compute_flags(node);
+            if !f.is_empty() {
+                flags.insert(*id, f);
+            }
+        }
+
+        Self { nodes, flags, by_role }
+    }
+
+    /// CSS selectors targeting boilerplate roles in the tree.
+    pub(crate) fn boilerplate_selectors(&self) -> BTreeSet<String> {
+        const ROLES: &[Role] = &[Role::Navigation, Role::Banner, Role::ContentInfo, Role::Complementary];
+        let mut out: BTreeSet<String> = ROLES
+            .iter()
+            .filter_map(|r| self.by_role.get(r))
+            .flatten()
+            .filter_map(|id| {
+                let node = self.nodes.get(id)?;
+                Some(make_selector(node.html_tag()?, node.class_name()))
+            })
+            .collect();
+
+        if let Some(ids) = self.by_role.get(&Role::Search) {
+            out.extend(ids.iter().filter_map(|id| {
+                let node = self.nodes.get(id)?;
+                let tag = node.html_tag()?;
+                tag.eq_ignore_ascii_case("form")
+                    .then(|| make_selector(tag, node.class_name()))
+            }));
+        }
+        out
+    }
+
+    /// CSS selectors for nodes whose AccessKit-derived flags intersect the policy.
+    pub(crate) fn flagged_selectors(&self, policy: VisibilityPolicy) -> BTreeSet<String> {
+        if policy.strip_if_any.is_empty() {
+            return BTreeSet::new();
+        }
+        self.flags
+            .iter()
+            .filter(|(_, f)| policy.strip_if_any.intersects(**f))
+            .filter_map(|(id, _)| {
+                let node = self.nodes.get(id)?;
+                let tag = node.html_tag()?;
+                let class = node.class_name();
+                Some(make_selector(tag, class))
+            })
+            .collect()
+    }
+}
+
+fn is_zero_size(r: &Rect) -> bool {
+    (r.x1 - r.x0) < 1.0 && (r.y1 - r.y0) < 1.0
+}
+
+fn is_offscreen(r: &Rect) -> bool {
+    r.x1 < 0.0 || r.y1 < 0.0 || r.x0 > OFFSCREEN_THRESHOLD_PX || r.y0 > OFFSCREEN_THRESHOLD_PX
+}
+
+/// Pure mapping from an AccessKit node to the visibility flags it implies.
+fn compute_flags(node: &Node) -> VisibilityFlags {
+    let mut f = VisibilityFlags::empty();
+    if matches!(node.role(), Role::TabPanel) && node.is_selected() == Some(false) {
+        f |= VisibilityFlags::TAB_PANEL_INACTIVE;
+    }
+    if let Some(size) = node.font_size()
+        && size < 1.0
+    {
+        f |= VisibilityFlags::FONT_SIZE_ZERO;
+    }
+    if let Some(rect) = node.bounds() {
+        if is_zero_size(&rect) {
+            f |= VisibilityFlags::ZERO_SIZE;
+        }
+        if is_offscreen(&rect) {
+            f |= VisibilityFlags::OFFSCREEN;
+        }
+    }
+    f
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn node_with_tag(role: Role) -> Node {
+        let mut n = Node::new(role);
+        n.set_html_tag("nav");
+        n
+    }
+
+    #[test]
+    fn flags_far_below_node_as_offscreen() {
+        let mut nodes = HashMap::new();
+        let mut n = node_with_tag(Role::GenericContainer);
+        n.set_bounds(Rect {
+            x0: 0.0,
+            y0: 100_000.0,
+            x1: 100.0,
+            y1: 100_100.0,
+        });
+        nodes.insert(NodeId(1), n);
+        let index = A11yIndex::new(&nodes);
+        assert!(
+            index
+                .flags
+                .get(&NodeId(1))
+                .unwrap()
+                .contains(VisibilityFlags::OFFSCREEN)
+        );
+    }
+
+    #[test]
+    fn flags_inactive_tab_panel() {
+        let mut nodes = HashMap::new();
+        let mut n = Node::new(Role::TabPanel);
+        n.set_selected(false);
+        nodes.insert(NodeId(1), n);
+        let index = A11yIndex::new(&nodes);
+        assert!(
+            index
+                .flags
+                .get(&NodeId(1))
+                .unwrap()
+                .contains(VisibilityFlags::TAB_PANEL_INACTIVE)
+        );
+    }
+
+    #[test]
+    fn flags_zero_font_size() {
+        let mut nodes = HashMap::new();
+        let mut n = node_with_tag(Role::Paragraph);
+        n.set_font_size(0.0);
+        nodes.insert(NodeId(1), n);
+        let index = A11yIndex::new(&nodes);
+        assert!(
+            index
+                .flags
+                .get(&NodeId(1))
+                .unwrap()
+                .contains(VisibilityFlags::FONT_SIZE_ZERO)
+        );
+    }
+
+    #[test]
+    fn flags_offscreen_left_of_viewport() {
+        let mut nodes = HashMap::new();
+        let mut n = node_with_tag(Role::GenericContainer);
+        n.set_bounds(Rect {
+            x0: -10_000.0,
+            y0: 0.0,
+            x1: -9_900.0,
+            y1: 100.0,
+        });
+        nodes.insert(NodeId(1), n);
+        let index = A11yIndex::new(&nodes);
+        assert!(
+            index
+                .flags
+                .get(&NodeId(1))
+                .unwrap()
+                .contains(VisibilityFlags::OFFSCREEN)
+        );
+    }
+
+    #[test]
+    fn boilerplate_selectors_are_sorted_and_unique() {
+        let mut nodes = HashMap::new();
+        let mut nav = node_with_tag(Role::Navigation);
+        nav.set_class_name("primary");
+        nodes.insert(NodeId(1), nav);
+        let mut footer = Node::new(Role::ContentInfo);
+        footer.set_html_tag("footer");
+        nodes.insert(NodeId(2), footer);
+        let mut nav2 = node_with_tag(Role::Navigation);
+        nav2.set_class_name("primary");
+        nodes.insert(NodeId(3), nav2);
+
+        let index = A11yIndex::new(&nodes);
+        let sels = index.boilerplate_selectors();
+        assert_eq!(sels, BTreeSet::from(["footer".to_owned(), "nav.primary".to_owned()]));
+    }
+
+    #[test]
+    fn search_role_strips_form_but_keeps_search_results_page() {
+        let mut nodes = HashMap::new();
+        let mut search_form = Node::new(Role::Search);
+        search_form.set_html_tag("form");
+        search_form.set_class_name("site-search");
+        nodes.insert(NodeId(1), search_form);
+
+        let mut search_main = Node::new(Role::Search);
+        search_main.set_html_tag("main");
+        nodes.insert(NodeId(2), search_main);
+
+        let index = A11yIndex::new(&nodes);
+        let sels = index.boilerplate_selectors();
+        assert!(sels.contains("form.site-search"));
+        assert!(!sels.iter().any(|s| s.starts_with("main")));
+    }
+}

--- a/crates/servo-fetch/src/visibility/js.rs
+++ b/crates/servo-fetch/src/visibility/js.rs
@@ -1,0 +1,52 @@
+//! JSON payload reported by `js/visibility.js`.
+
+use super::VisibilityFlags;
+
+/// One element's report from the JS visibility pass.
+#[derive(Debug, serde::Deserialize)]
+pub(crate) struct JsReport {
+    pub(crate) id: String,
+    #[serde(rename = "flags")]
+    pub(crate) bits: u32,
+}
+
+impl JsReport {
+    pub(crate) fn flags(&self) -> VisibilityFlags {
+        VisibilityFlags::from_bits_truncate(self.bits)
+    }
+}
+
+/// Parse the JSON payload returned by `js/visibility.js`.
+pub(crate) fn parse_js_payload(payload: &str) -> Vec<JsReport> {
+    serde_json::from_str(payload).unwrap_or_else(|err| {
+        tracing::warn!(?err, "failed to parse visibility JS payload");
+        Vec::new()
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn js_report_decodes_flags_truncating_unknown_bits() {
+        let r = JsReport {
+            id: "1".into(),
+            bits: 0xFFFF,
+        };
+        assert!(r.flags().contains(VisibilityFlags::OPACITY_ZERO));
+    }
+
+    #[test]
+    fn parse_js_payload_returns_empty_on_invalid_json() {
+        assert!(parse_js_payload("garbage").is_empty());
+    }
+
+    #[test]
+    fn parse_js_payload_accepts_well_formed_input() {
+        let reports = parse_js_payload(r#"[{"id":"1","flags":16},{"id":"2","flags":32}]"#);
+        assert_eq!(reports.len(), 2);
+        assert!(reports[0].flags().contains(VisibilityFlags::OPACITY_ZERO));
+        assert!(reports[1].flags().contains(VisibilityFlags::CLIPPED));
+    }
+}

--- a/crates/servo-fetch/src/visibility/selectors.rs
+++ b/crates/servo-fetch/src/visibility/selectors.rs
@@ -1,0 +1,152 @@
+//! CSS selector synthesis for visibility-driven stripping.
+
+use std::collections::BTreeSet;
+
+use super::VisibilityPolicy;
+use super::a11y::A11yIndex;
+use super::js::parse_js_payload;
+
+/// DOM mirror of [`super::USER_STYLESHEET`].
+const ALWAYS_STRIP_SELECTORS: &[&str] = &[
+    "[hidden]",
+    "[aria-hidden=\"true\"]",
+    "[role=\"dialog\"][aria-modal=\"true\"]",
+    "[role=\"alertdialog\"]",
+    "[role=\"tabpanel\"][aria-hidden=\"true\"]",
+];
+
+/// Compute the CSS selectors to strip, merging policy, A11y, and JS signals.
+pub(crate) fn selectors_to_strip(
+    policy: VisibilityPolicy,
+    a11y: Option<&A11yIndex<'_>>,
+    js_payload: Option<&str>,
+) -> Vec<String> {
+    let mut out: BTreeSet<String> = ALWAYS_STRIP_SELECTORS.iter().map(|s| (*s).to_owned()).collect();
+
+    if let Some(a11y) = a11y {
+        out.extend(a11y.boilerplate_selectors());
+        out.extend(a11y.flagged_selectors(policy));
+    }
+
+    if let Some(payload) = js_payload {
+        for report in parse_js_payload(payload) {
+            if policy.strip_if_any.intersects(report.flags()) {
+                out.insert(data_vf_id_selector(&report.id));
+            }
+        }
+    }
+
+    out.into_iter().collect()
+}
+
+/// Build a `[data-vf-id="..."]` selector with the value safely escaped.
+fn data_vf_id_selector(id: &str) -> String {
+    let mut sel = String::with_capacity("[data-vf-id=]".len() + id.len() + 2);
+    sel.push_str("[data-vf-id=");
+    cssparser::serialize_string(id, &mut sel).expect("write to String never fails");
+    sel.push(']');
+    sel
+}
+
+/// Bytes one CSS hex escape adds.
+const ESCAPE_MARGIN: usize = 4;
+
+/// Build a CSS selector from an HTML tag and an optional class attribute value.
+pub(super) fn make_selector(tag: &str, class: Option<&str>) -> String {
+    let classes: Vec<&str> = class.map(|c| c.split_whitespace().collect()).unwrap_or_default();
+    let extra: usize = classes.iter().map(|c| 1 + c.len() + ESCAPE_MARGIN).sum();
+    let mut out = String::with_capacity(tag.len() + extra);
+    out.push_str(tag);
+    out.make_ascii_lowercase();
+    for cls in classes {
+        out.push('.');
+        cssparser::serialize_identifier(cls, &mut out).expect("String write never fails");
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use servo::accesskit::{Node, NodeId, Role};
+
+    use super::*;
+
+    #[test]
+    fn returns_data_vf_id_for_matching_flags() {
+        let policy = VisibilityPolicy::moderate();
+        let payload = r#"[{"id":"1","flags":16}]"#;
+        let sels = selectors_to_strip(policy, None, Some(payload));
+        assert!(sels.contains(&"[data-vf-id=\"1\"]".to_owned()));
+    }
+
+    #[test]
+    fn skips_flags_outside_policy() {
+        let policy = VisibilityPolicy::moderate();
+        let payload = r#"[{"id":"1","flags":256}]"#;
+        let sels = selectors_to_strip(policy, None, Some(payload));
+        assert!(!sels.iter().any(|s| s.contains("data-vf-id")));
+    }
+
+    #[test]
+    fn includes_boilerplate_when_a11y_provided() {
+        let mut nodes = HashMap::new();
+        let mut nav = Node::new(Role::Navigation);
+        nav.set_html_tag("nav");
+        nav.set_class_name("site-nav");
+        nodes.insert(NodeId(1), nav);
+        let index = A11yIndex::new(&nodes);
+        let policy = VisibilityPolicy::moderate();
+        let sels = selectors_to_strip(policy, Some(&index), None);
+        assert!(sels.contains(&"nav.site-nav".to_owned()));
+    }
+
+    #[test]
+    fn always_strip_selectors_present_regardless_of_inputs() {
+        let policy = VisibilityPolicy::off();
+        let sels = selectors_to_strip(policy, None, None);
+        assert!(sels.contains(&"[hidden]".to_owned()));
+        assert!(sels.contains(&"[aria-hidden=\"true\"]".to_owned()));
+        assert!(sels.contains(&"[role=\"dialog\"][aria-modal=\"true\"]".to_owned()));
+    }
+
+    #[test]
+    fn malicious_js_id_is_escaped_within_selector_value() {
+        let policy = VisibilityPolicy::moderate();
+        let payload = r#"[{"id":"1\"]:has(*)","flags":16}]"#;
+        let sels = selectors_to_strip(policy, None, Some(payload));
+        let injected = sels.iter().find(|s| s.contains("data-vf-id")).unwrap();
+        assert!(injected.contains(r#"\""#), "unescaped quote in selector: {injected}");
+        assert!(injected.starts_with("[data-vf-id="));
+        assert!(injected.ends_with(']'));
+        let matcher = dom_query::Matcher::new(injected).expect("selector parses");
+        let doc = dom_query::Document::from(r#"<p data-vf-id="1">x</p>"#);
+        assert!(doc.select_matcher(&matcher).is_empty());
+    }
+
+    #[test]
+    fn make_selector_uses_all_classes_for_specificity() {
+        assert_eq!(make_selector("DIV", Some("a b c")), "div.a.b.c");
+        assert_eq!(make_selector("nav", Some("site-nav main")), "nav.site-nav.main");
+    }
+
+    #[test]
+    fn make_selector_falls_back_to_tag_when_no_class() {
+        assert_eq!(make_selector("FOOTER", None), "footer");
+        assert_eq!(make_selector("FOOTER", Some("")), "footer");
+        assert_eq!(make_selector("FOOTER", Some("   ")), "footer");
+    }
+
+    #[test]
+    fn make_selector_escapes_special_chars_in_class() {
+        assert_eq!(make_selector("div", Some("foo:bar")), r"div.foo\:bar");
+        assert_eq!(make_selector("div", Some("normal-class_1")), "div.normal-class_1");
+    }
+
+    #[test]
+    fn make_selector_escapes_leading_digit_in_class() {
+        assert_eq!(make_selector("div", Some("3col")), r"div.\33 col");
+        assert_eq!(make_selector("div", Some("9")), r"div.\39 ");
+    }
+}

--- a/crates/servo-fetch/tests/extract.rs
+++ b/crates/servo-fetch/tests/extract.rs
@@ -1,5 +1,4 @@
-//! Content extraction integration tests — validates the full extraction pipeline
-//! using HTML fixtures. These tests do NOT require Servo.
+//! Content extraction integration tests.
 
 use servo_fetch::extract::{self, ExtractInput};
 

--- a/crates/servo-fetch/tests/visibility.rs
+++ b/crates/servo-fetch/tests/visibility.rs
@@ -1,0 +1,82 @@
+//! Visibility-aware extraction integration tests.
+
+use servo_fetch::{FetchOptions, NetworkPolicy, VisibilityPolicy, fetch};
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+const HTML: &str = r#"<!DOCTYPE html>
+<html>
+<head>
+<title>Visibility E2E</title>
+<style>
+.opacity-0 { opacity: 0; }
+.clipped { clip-path: inset(100%); position: absolute; }
+.cv-hidden { content-visibility: hidden; }
+.text-indent-off { text-indent: -9999px; }
+.sr-only { position: absolute; width: 1px; height: 1px; overflow: hidden; clip: rect(0, 0, 0, 0); }
+</style>
+</head>
+<body>
+<nav class="site-nav"><p>NAV-MARKER</p></nav>
+<header role="banner"><p>BANNER-MARKER</p></header>
+<main>
+  <article>
+    <h1>Article Title</h1>
+    <p>VISIBLE-MARKER and some additional words to satisfy Readability heuristics for content density.</p>
+    <p>VISIBLE-MARKER-2 second paragraph with enough text to be considered article content by the extractor.</p>
+    <p class="opacity-0">OPACITY-ZERO-MARKER</p>
+    <p class="clipped">CLIPPED-MARKER</p>
+    <p class="cv-hidden">CV-HIDDEN-MARKER</p>
+    <p class="text-indent-off">TEXT-INDENT-MARKER</p>
+    <p class="sr-only">SR-ONLY-MARKER</p>
+    <p hidden>HIDDEN-ATTR-MARKER</p>
+    <p aria-hidden="true">ARIA-HIDDEN-MARKER</p>
+  </article>
+</main>
+<footer role="contentinfo"><p>FOOTER-MARKER</p></footer>
+<div role="dialog" aria-modal="true"><p>MODAL-MARKER</p></div>
+</body>
+</html>"#;
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "e2e: spawns the Servo engine; Linux CI sees SIGSEGV during destructor cleanup"]
+async fn moderate_policy_filters_hidden_content() {
+    servo_fetch::init(NetworkPolicy::PERMISSIVE);
+
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(HTML.as_bytes(), "text/html; charset=utf-8"))
+        .mount(&server)
+        .await;
+    let url = format!("{}/", server.uri());
+
+    let md = tokio::task::spawn_blocking(move || {
+        fetch(FetchOptions::new(&url).visibility(VisibilityPolicy::moderate()))
+            .expect("fetch")
+            .markdown()
+            .expect("markdown")
+    })
+    .await
+    .expect("spawn_blocking");
+
+    assert!(md.contains("VISIBLE-MARKER"), "main content missing:\n{md}");
+    assert!(md.contains("SR-ONLY-MARKER"), "moderate must keep sr-only:\n{md}");
+
+    for marker in [
+        "HIDDEN-ATTR-MARKER",
+        "ARIA-HIDDEN-MARKER",
+        "MODAL-MARKER",
+        "FOOTER-MARKER",
+        "OPACITY-ZERO-MARKER",
+        "CLIPPED-MARKER",
+        "TEXT-INDENT-MARKER",
+    ] {
+        assert!(!md.contains(marker), "{marker} leaked into markdown:\n{md}");
+    }
+
+    // Tracked limitations: a11y tree fires only on dynamic updates.
+    for marker in ["NAV-MARKER", "BANNER-MARKER", "CV-HIDDEN-MARKER"] {
+        assert!(md.contains(marker), "{marker} now stripped — gap closed?\n{md}");
+    }
+}


### PR DESCRIPTION
## Summary

Filter CSS/ARIA-hidden content (cookie banners, modals, sr-only, opacity:0, text-indent, content-visibility, visibility:hidden) using three signals: AccessKit a11y tree, an injected JS visibility pass.

**API**

- `VisibilityPolicy::{off, moderate, strict}` (moderate is default)
- `FetchOptions::visibility(policy)` builder
- `--visibility=<off|moderate|strict>` CLI flag

**Bench (`visibility-spam` fixture, 13 hidden patterns)**

| policy   | without[] |
|----------|----------:|
| off      |       54% |
| moderate |       85% |
| strict   |      100% |

## Test Plan

- `cargo test --workspace` — all tests pass
- `cargo test --workspace -- --include-ignored` — all e2e tests pass
- `./benchmarks/bench extract layout` — no regression, new fixture proves +31pt at moderate / +46pt at strict
- CLI smoke (`--visibility=off|moderate|strict` × `visibility-spam` fixture) — 33 invariants verified

## Checklist

- [x] Ran `cargo fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
- [x] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed
- [x] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it