### PR TITLE
fix(docker): bump debian:trixie-slim digest to 13.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7
 
-FROM debian:trixie-slim@sha256:109e2c65005bf160609e4ba6acf7783752f8502ad218e298253428690b9eaa4b
+FROM debian:trixie-slim@sha256:b6e2a152f22a40ff69d92cb397223c906017e1391a73c952b588e51af8883bf8
 
 ARG TARGETARCH
 ARG VERSION=dev
@@ -16,7 +16,7 @@ LABEL org.opencontainers.image.title="servo-fetch" \
       org.opencontainers.image.revision="${REVISION}" \
       org.opencontainers.image.licenses="MIT OR Apache-2.0" \
       org.opencontainers.image.base.name="debian:trixie-slim" \
-      org.opencontainers.image.base.digest="sha256:109e2c65005bf160609e4ba6acf7783752f8502ad218e298253428690b9eaa4b"
+      org.opencontainers.image.base.digest="sha256:b6e2a152f22a40ff69d92cb397223c906017e1391a73c952b588e51af8883bf8"
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
       curl ca-certificates \


### PR DESCRIPTION
## Summary

Bump the pinned `debian:trixie-slim` base image digest from `sha256:109e2c65…` (debian 13.4) to `sha256:b6e2a152…` (debian 13.5, [released 2026-05-16](https://www.debian.org/News/2026/20260516)), which carries the patches for the 3 HIGH CVEs flagged in #197:

| Library | CVE | Fixed in |
|---|---|---|
| libcap2 | CVE-2026-4878 | 1:2.75-10+deb13u1 |
| libsystemd0 | CVE-2026-29111 | 257.13-1~deb13u1 |
| libudev1 | CVE-2026-29111 | 257.13-1~deb13u1 |

Both occurrences of the digest are updated: the `FROM` line and the `org.opencontainers.image.base.digest` OCI label.

## Related issues

Closes #197

## Test Plan

Built the Docker image locally with the new digest and ran trivy with the exact same flags as the `trivy-scan` job in `release.yml`:

```bash
docker buildx build --platform linux/amd64 -t servo-fetch:trivy-local --load .
docker run --rm -v /var/run/docker.sock:/var/run/docker.sock \
  -e TRIVY_DB_REPOSITORY=public.ecr.aws/aquasecurity/trivy-db:2 \
  aquasec/trivy:latest image \
  --severity CRITICAL,HIGH --ignore-unfixed --exit-code 1 \
  servo-fetch:trivy-local
```

Result:

```
Detected OS: debian 13.5
Packages scanned: 150
Vulnerabilities (CRITICAL,HIGH, --ignore-unfixed): 0
trivy exit code: 0
```

## Checklist

- [x] Ran `cargo fmt`, `cargo clippy`, and `cargo test` locally — N/A (no Rust changes)
- [x] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed — N/A (digest pin only)
- [x] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it