### PR TITLE
feat(cli): unify output flags under --format

### DIFF
--- a/.github/workflows/test-smoke.yml
+++ b/.github/workflows/test-smoke.yml
@@ -142,7 +142,7 @@ jobs:
           [[ "$RUNNER_OS_NAME" == "Windows" ]] && BIN="$BIN.exe"
           SHOT="$RUNNER_TEMP/shot.png"
 
-          "$BIN" --json 'https://example.com' \
+          "$BIN" --format json 'https://example.com' \
             | python3 -c 'import json,sys; json.load(sys.stdin)'
           sleep 2
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ cargo build
 
 ```sh
 cargo run -- "https://example.com"                          # Markdown output
-cargo run -- "https://example.com" --json                   # JSON output
+cargo run -- "https://example.com" --format json            # JSON output
 cargo run -- "https://example.com" --screenshot page.png    # Screenshot
 cargo run -- "https://example.com" --js "document.title"    # JS execution
 cargo test                                                  # Run tests

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ xvfb-run --auto-servernum servo-fetch "https://example.com"
 
 ```bash
 servo-fetch "https://example.com"                        # Markdown (default)
-servo-fetch "https://example.com" --json                 # Structured JSON
+servo-fetch "https://example.com" --format json          # Structured JSON
 servo-fetch "https://example.com" --screenshot page.png  # PNG screenshot
 servo-fetch "https://example.com" --js "document.title"  # Run JavaScript
 servo-fetch "https://example.com" --schema schema.json   # Schema-driven JSON

--- a/benchmarks/src/servo_fetch_bench/cli.py
+++ b/benchmarks/src/servo_fetch_bench/cli.py
@@ -206,7 +206,7 @@ def parallel(
         reporting.env_header(cfg) + f"# Parallel scalability\n\nFixture: `{fixture}`.\n\n",
         encoding="utf-8",
     )
-    # Parallel uses Markdown pipeline (servo-fetch --raw text forbids multi-URL).
+    # Parallel uses Markdown pipeline (servo-fetch --format text forbids multi-URL).
     # Only multi-URL-capable runners participate.
     runners_ = [
         Runner("servo-fetch", [str(cfg.servo_fetch_bin), "-q"]),

--- a/benchmarks/src/servo_fetch_bench/runners.py
+++ b/benchmarks/src/servo_fetch_bench/runners.py
@@ -89,7 +89,7 @@ def _node_env(cfg: Config) -> dict[str, str]:
 def speed_runners(cfg: Config) -> list[Runner]:
     """Text-output runners for equivalence / time / memory / parallel."""
     runners: list[Runner] = [
-        Runner("servo-fetch", [str(cfg.servo_fetch_bin), "--raw", "text", "-q"]),
+        Runner("servo-fetch", [str(cfg.servo_fetch_bin), "--format", "text", "-q"]),
     ]
     if _has_chrome_headless_shell(cfg):
         runners.append(Runner(

--- a/crates/servo-fetch-cli/README.md
+++ b/crates/servo-fetch-cli/README.md
@@ -27,16 +27,16 @@ cargo install servo-fetch-cli    # build from source (requires Rust 1.86.0+)
 
 ```bash
 servo-fetch "https://example.com"              # Readable Markdown (default)
-servo-fetch "https://example.com" --json       # Structured JSON
-servo-fetch "https://example.com" --raw html   # Raw rendered HTML
-servo-fetch "https://example.com" --raw text   # Plain text (innerText)
+servo-fetch "https://example.com" --format json   # Structured JSON
+servo-fetch "https://example.com" --format html   # Raw rendered HTML
+servo-fetch "https://example.com" --format text   # Plain text (innerText)
 ```
 
 ### Batch fetch
 
 ```bash
 servo-fetch URL1 URL2 URL3                     # Parallel fetch, Markdown output
-servo-fetch URL1 URL2 --json                   # Parallel fetch, NDJSON output
+servo-fetch URL1 URL2 --format json            # Parallel fetch, NDJSON output
 ```
 
 ### Screenshots
@@ -57,7 +57,7 @@ servo-fetch "https://example.com" --js "document.querySelectorAll('h2').length"
 
 ```bash
 servo-fetch "https://example.com" --selector "article"
-servo-fetch "https://example.com" --selector ".main-content" --json
+servo-fetch "https://example.com" --selector ".main-content" --format json
 ```
 
 ### Visibility filtering
@@ -100,7 +100,7 @@ Field `type` values: `text`, `attribute`, `html`, `inner_html`, `nested_list`. S
 ```bash
 servo-fetch crawl "https://docs.example.com" --limit 20
 servo-fetch crawl "https://docs.example.com" --include "/docs/**" --exclude "/docs/archive/**"
-servo-fetch crawl "https://docs.example.com" --json --max-depth 5
+servo-fetch crawl "https://docs.example.com" --format json --max-depth 5
 ```
 
 ### Discover URLs (sitemap)
@@ -137,12 +137,12 @@ See [HTTP API server](#http-api-server) below for the endpoint reference.
 
 | Flag | Description |
 | ---- | ----------- |
-| `--json` | Structured JSON output (NDJSON for multiple URLs) |
+| `--format json` | Structured JSON output (NDJSON for multiple URLs) |
 | `--screenshot <FILE>` | Save PNG screenshot |
 | `--full-page` | Capture full scrollable page (requires `--screenshot`) |
 | `--js <EXPR>` | Execute JavaScript and print result |
 | `--selector <CSS>` | Extract specific section by CSS selector |
-| `--raw html\|text` | Raw HTML or plain text output |
+| `--format html\|text` | Raw HTML or plain text output |
 | `--schema <FILE>` | Extract structured JSON using a CSS-selector schema file |
 | `-t, --timeout <SECS>` | Page load timeout in seconds (default: 30) |
 | `--settle <MS>` | Extra wait after load event in ms (default: 0, max: 10000) |
@@ -152,7 +152,7 @@ See [HTTP API server](#http-api-server) below for the endpoint reference.
 
 ### JSON output
 
-`--json` returns an object with these fields:
+`--format json` returns an object with these fields:
 
 | Field | Type | Description |
 | ----- | ---- | ----------- |
@@ -174,7 +174,7 @@ See [HTTP API server](#http-api-server) below for the endpoint reference.
 | `--max-depth <N>` | Maximum link depth (default: 3) |
 | `--include <GLOB>` | URL path patterns to include |
 | `--exclude <GLOB>` | URL path patterns to exclude |
-| `--json` | Output content as JSON per page |
+| `--format json` | Output content as JSON per page |
 | `--selector <CSS>` | Extract specific section per page |
 | `--concurrency <N>` | Maximum parallel page fetches (default: 1; completion order when >1) |
 | `--delay-ms <MS>` | Minimum dispatch interval in ms (default: 500; 0 disables rate limiting) |
@@ -191,7 +191,7 @@ See [HTTP API server](#http-api-server) below for the endpoint reference.
 | `--limit <N>` | Maximum URLs to return (default: 5000) |
 | `--include <GLOB>` | URL path patterns to include |
 | `--exclude <GLOB>` | URL path patterns to exclude |
-| `--json` | Output as JSON array with lastmod metadata |
+| `--format json` | Output as JSON array with lastmod metadata |
 | `--user-agent <UA>` | Override the User-Agent string |
 | `-t, --timeout <SECS>` | HTTP request timeout in seconds (default: 30) |
 | `--no-fallback` | Skip HTML link extraction fallback |

--- a/crates/servo-fetch-cli/src/cli.rs
+++ b/crates/servo-fetch-cli/src/cli.rs
@@ -35,12 +35,13 @@ pub(crate) struct FetchArgs {
     #[arg(num_args = 1..)]
     pub urls: Vec<String>,
 
-    /// Output as structured JSON (NDJSON when multiple URLs)
-    #[arg(long, conflicts_with_all = ["screenshot", "js"])]
-    pub json: bool,
+    /// Output format
+    #[arg(long, value_enum, value_name = "FORMAT", default_value_t = Format::Markdown,
+          conflicts_with_all = ["screenshot", "js"])]
+    pub format: Format,
 
     /// Save screenshot as PNG (single URL only)
-    #[arg(long, value_name = "FILE", conflicts_with_all = ["json", "js"])]
+    #[arg(long, value_name = "FILE", conflicts_with_all = ["js"])]
     pub screenshot: Option<String>,
 
     /// Capture the full scrollable page instead of just the viewport.
@@ -48,7 +49,7 @@ pub(crate) struct FetchArgs {
     pub full_page: bool,
 
     /// Execute JavaScript and print the result (single URL only)
-    #[arg(long, value_name = "EXPR", conflicts_with_all = ["json", "screenshot"])]
+    #[arg(long, value_name = "EXPR", conflicts_with_all = ["screenshot"])]
     pub js: Option<String>,
 
     /// Timeout in seconds for page load
@@ -63,16 +64,12 @@ pub(crate) struct FetchArgs {
     #[arg(long, value_name = "CSS", value_parser = NonEmptyStringValueParser::new())]
     pub selector: Option<String>,
 
-    /// Output raw HTML or plain text instead of Readability extraction
-    #[arg(long, value_name = "MODE", value_enum, conflicts_with_all = ["json", "screenshot", "js", "selector"])]
-    pub raw: Option<RawMode>,
-
     /// Override the User-Agent string
     #[arg(long, value_name = "UA")]
     pub user_agent: Option<String>,
 
     /// Path to a CSS-selector schema file for structured JSON extraction
-    #[arg(long, value_name = "FILE", conflicts_with_all = ["screenshot", "js", "raw", "selector"])]
+    #[arg(long, value_name = "FILE", conflicts_with_all = ["screenshot", "js", "selector", "format"])]
     pub schema: Option<std::path::PathBuf>,
 
     /// Visibility-aware filtering policy.
@@ -101,13 +98,26 @@ impl VisibilityArg {
     }
 }
 
-/// Raw output mode.
-#[derive(Debug, Clone, Copy, ValueEnum)]
-pub(crate) enum RawMode {
-    /// Raw HTML
+/// Output format.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub(crate) enum Format {
+    /// Readability-extracted Markdown
+    Markdown,
+    /// Readability-extracted JSON
+    Json,
+    /// Raw rendered HTML (post-JS execution)
     Html,
-    /// Plain text (document.body.innerText)
+    /// Plain text (`document.body.innerText`)
     Text,
+}
+
+/// Crawl output format.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub(crate) enum CrawlFormat {
+    /// Readability-extracted Markdown
+    Markdown,
+    /// NDJSON
+    Json,
 }
 
 /// Available subcommands.
@@ -162,9 +172,9 @@ pub(crate) struct CrawlArgs {
     #[arg(long, value_name = "GLOB")]
     pub exclude: Vec<String>,
 
-    /// Output as NDJSON
-    #[arg(long)]
-    pub json: bool,
+    /// Output format
+    #[arg(long, value_enum, value_name = "FORMAT", default_value_t = CrawlFormat::Markdown)]
+    pub format: CrawlFormat,
 
     /// CSS selector to extract a specific section per page
     #[arg(long, value_name = "CSS", value_parser = NonEmptyStringValueParser::new())]
@@ -230,11 +240,21 @@ mod tests {
     use super::*;
 
     #[test]
-    fn raw_mode_from_str() {
+    fn format_from_str() {
         use ValueEnum;
-        assert!(RawMode::from_str("html", true).is_ok());
-        assert!(RawMode::from_str("text", true).is_ok());
-        assert!(RawMode::from_str("xml", true).is_err());
+        assert!(Format::from_str("markdown", true).is_ok());
+        assert!(Format::from_str("json", true).is_ok());
+        assert!(Format::from_str("html", true).is_ok());
+        assert!(Format::from_str("text", true).is_ok());
+        assert!(Format::from_str("xml", true).is_err());
+    }
+
+    #[test]
+    fn crawl_format_from_str() {
+        use ValueEnum;
+        assert!(CrawlFormat::from_str("markdown", true).is_ok());
+        assert!(CrawlFormat::from_str("json", true).is_ok());
+        assert!(CrawlFormat::from_str("html", true).is_err());
     }
 }
 
@@ -248,9 +268,9 @@ mod cli_tests {
     }
 
     #[test]
-    fn conflicting_json_and_screenshot() {
+    fn conflicting_format_and_screenshot() {
         servo_fetch()
-            .args(["--json", "--screenshot", "out.png", "https://example.com"])
+            .args(["--format", "json", "--screenshot", "out.png", "https://example.com"])
             .assert()
             .failure()
             .stderr(predicate::str::contains("cannot be used with"));
@@ -266,12 +286,12 @@ mod cli_tests {
     }
 
     #[test]
-    fn raw_conflicts_with_json() {
+    fn invalid_format_rejected() {
         servo_fetch()
-            .args(["--raw", "html", "--json", "https://example.com"])
+            .args(["--format", "xml", "https://example.com"])
             .assert()
             .failure()
-            .stderr(predicate::str::contains("cannot be used with"));
+            .stderr(predicate::str::contains("invalid value"));
     }
 
     #[test]
@@ -290,5 +310,34 @@ mod cli_tests {
             .assert()
             .failure()
             .stderr(predicate::str::contains("cannot be used with"));
+    }
+
+    #[test]
+    fn schema_conflicts_with_format() {
+        servo_fetch()
+            .args(["--schema", "s.json", "--format", "json", "https://example.com"])
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains("cannot be used with"));
+    }
+
+    #[test]
+    fn format_html_with_selector_errors() {
+        servo_fetch()
+            .args(["--format", "html", "--selector", "article", "https://example.com"])
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains(
+                "--selector cannot be used with --format html or text",
+            ));
+    }
+
+    #[test]
+    fn format_html_with_multi_urls_errors() {
+        servo_fetch()
+            .args(["--format", "html", "https://example.com", "https://example.org"])
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains("cannot be used with multiple URLs"));
     }
 }

--- a/crates/servo-fetch-cli/src/commands/crawl.rs
+++ b/crates/servo-fetch-cli/src/commands/crawl.rs
@@ -5,7 +5,7 @@ use std::time::Instant;
 
 use serde::Serialize;
 
-use crate::cli::CrawlArgs;
+use crate::cli::{CrawlArgs, CrawlFormat};
 use crate::progress::Progress;
 
 #[derive(Serialize)]
@@ -19,12 +19,12 @@ struct StatsRecord {
 
 /// Crawl a site starting from `args.url` and stream results to stdout.
 pub(crate) fn run(args: &CrawlArgs) -> anyhow::Result<()> {
-    let opts = build_crawl_options(args);
+    let json = matches!(args.format, CrawlFormat::Json);
+    let opts = build_crawl_options(args, json);
 
     let progress = Progress::new();
     let mut completed = 0u64;
     let mut errors = 0u64;
-    let json = args.json;
     let mut write_err: Option<io::Error> = None;
     let started = Instant::now();
 
@@ -58,7 +58,7 @@ pub(crate) fn run(args: &CrawlArgs) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn build_crawl_options(args: &CrawlArgs) -> servo_fetch::CrawlOptions {
+fn build_crawl_options(args: &CrawlArgs, json: bool) -> servo_fetch::CrawlOptions {
     let mut opts = servo_fetch::CrawlOptions::new(&args.url)
         .limit(args.limit)
         .max_depth(args.max_depth)
@@ -70,7 +70,7 @@ fn build_crawl_options(args: &CrawlArgs) -> servo_fetch::CrawlOptions {
         } else {
             Some(std::time::Duration::from_millis(args.delay_ms))
         })
-        .json(args.json);
+        .json(json);
     if !args.include.is_empty() {
         opts = opts.include(&args.include.iter().map(String::as_str).collect::<Vec<_>>());
     }

--- a/crates/servo-fetch-cli/src/commands/fetch.rs
+++ b/crates/servo-fetch-cli/src/commands/fetch.rs
@@ -7,23 +7,32 @@ use anyhow::{Result, bail};
 
 use servo_fetch::{FetchOptions, Page};
 
-use crate::cli::FetchArgs;
+use crate::cli::{FetchArgs, Format};
 use crate::output;
 use crate::progress::Progress;
 
 /// Fetch one or more URLs and write the rendered output to stdout.
 pub(crate) fn run(args: &FetchArgs) -> Result<()> {
+    validate_args(args)?;
     match args.urls.as_slice() {
         [] => bail!("URL is required. Run with --help for usage."),
         [one] => run_single(args, one),
         many => {
-            if args.screenshot.is_some() || args.js.is_some() || args.raw.is_some() {
-                bail!("--screenshot, --js, and --raw are not supported with multiple URLs");
-            }
             let rt = tokio::runtime::Runtime::new()?;
             rt.block_on(run_batch(args, many))
         }
     }
+}
+
+fn validate_args(args: &FetchArgs) -> Result<()> {
+    let raw_format = matches!(args.format, Format::Html | Format::Text);
+    if raw_format && args.selector.is_some() {
+        bail!("--selector cannot be used with --format html or text");
+    }
+    if args.urls.len() > 1 && (args.screenshot.is_some() || args.js.is_some() || raw_format) {
+        bail!("--screenshot, --js, and --format html or text cannot be used with multiple URLs");
+    }
+    Ok(())
 }
 
 fn run_single(args: &FetchArgs, url_str: &str) -> Result<()> {
@@ -100,44 +109,35 @@ fn batch_emit(args: &FetchArgs, page: &Page, url: &str) -> Result<()> {
     if args.schema.is_some() {
         return output::Extracted { page, url }.execute_compact();
     }
-    if args.json {
-        output::Json {
-            page,
-            url,
-            selector: args.selector.as_deref(),
+    let selector = args.selector.as_deref();
+    match args.format {
+        Format::Json => output::Json { page, url, selector }.execute_compact(),
+        Format::Markdown => {
+            writeln!(std::io::stdout(), "--- {url} ---")?;
+            output::Markdown { page, url, selector }.execute()?;
+            writeln!(std::io::stdout())?;
+            Ok(())
         }
-        .execute_compact()
-    } else {
-        writeln!(std::io::stdout(), "--- {url} ---")?;
-        output::Markdown {
-            page,
-            url,
-            selector: args.selector.as_deref(),
-        }
-        .execute()?;
-        writeln!(std::io::stdout())?;
-        Ok(())
+        Format::Html | Format::Text => unreachable!("guarded by run() before batch dispatch"),
     }
 }
 
 fn dispatch_output(args: &FetchArgs, page: &Page, url: &str) -> Result<()> {
     if let Some(result) = page.js_result.as_deref() {
-        return output::JsEval { result }.execute();
+        return output::js_eval(result);
     }
     if let Some(path) = args.screenshot.as_deref() {
         return output::Screenshot { page, path }.execute();
-    }
-    if let Some(mode) = args.raw.as_ref() {
-        return output::Raw { page, mode }.execute();
     }
     if args.schema.is_some() {
         return output::Extracted { page, url }.execute();
     }
     let selector = args.selector.as_deref();
-    if args.json {
-        output::Json { page, url, selector }.execute()
-    } else {
-        output::Markdown { page, url, selector }.execute()
+    match args.format {
+        Format::Markdown => output::Markdown { page, url, selector }.execute(),
+        Format::Json => output::Json { page, url, selector }.execute(),
+        Format::Html => output::raw(&page.html),
+        Format::Text => output::raw(&page.inner_text),
     }
 }
 

--- a/crates/servo-fetch-cli/src/output.rs
+++ b/crates/servo-fetch-cli/src/output.rs
@@ -87,15 +87,9 @@ impl Screenshot<'_> {
     }
 }
 
-pub(crate) struct JsEval<'a> {
-    pub result: &'a str,
-}
-
-impl JsEval<'_> {
-    pub(crate) fn execute(&self) -> Result<()> {
-        writeln!(std::io::stdout(), "{}", servo_fetch::sanitize::sanitize(self.result))?;
-        Ok(())
-    }
+pub(crate) fn js_eval(result: &str) -> Result<()> {
+    writeln!(std::io::stdout(), "{}", servo_fetch::sanitize::sanitize(result))?;
+    Ok(())
 }
 
 pub(crate) struct Extracted<'a> {
@@ -125,18 +119,7 @@ impl Extracted<'_> {
     }
 }
 
-pub(crate) struct Raw<'a> {
-    pub page: &'a Page,
-    pub mode: &'a crate::cli::RawMode,
-}
-
-impl Raw<'_> {
-    pub(crate) fn execute(&self) -> Result<()> {
-        let content = match self.mode {
-            crate::cli::RawMode::Html => self.page.html.as_str(),
-            crate::cli::RawMode::Text => &self.page.inner_text,
-        };
-        write!(std::io::stdout(), "{}", servo_fetch::sanitize::sanitize(content))?;
-        Ok(())
-    }
+pub(crate) fn raw(content: &str) -> Result<()> {
+    write!(std::io::stdout(), "{}", servo_fetch::sanitize::sanitize(content))?;
+    Ok(())
 }

--- a/crates/servo-fetch-cli/tests/cli.rs
+++ b/crates/servo-fetch-cli/tests/cli.rs
@@ -110,7 +110,7 @@ fn json_produces_valid_json() {
             .mount(&s)
             .await;
         let output = servo_fetch()
-            .args(["--json", "--allow-private-addresses", TIMEOUT, &s.uri()])
+            .args(["--format", "json", "--allow-private-addresses", TIMEOUT, &s.uri()])
             .assert()
             .success()
             .get_output()
@@ -190,7 +190,8 @@ fn crawl_produces_ndjson() {
             .args([
                 "crawl",
                 &s.uri(),
-                "--json",
+                "--format",
+                "json",
                 "--limit",
                 "1",
                 "--timeout",
@@ -279,7 +280,8 @@ fn crawl_json_embeds_structured_content() {
             .args([
                 "crawl",
                 &s.uri(),
-                "--json",
+                "--format",
+                "json",
                 "--limit",
                 "1",
                 "--max-depth",

--- a/skills/servo-fetch/SKILL.md
+++ b/skills/servo-fetch/SKILL.md
@@ -122,15 +122,15 @@ execute_js(url: "https://example.com", expression: "[...document.querySelectorAl
 
 ```bash
 servo-fetch https://example.com                    # Markdown (default)
-servo-fetch https://example.com --json             # Structured JSON
+servo-fetch https://example.com --format json             # Structured JSON
 servo-fetch URL1 URL2 URL3                         # Parallel batch (Markdown with separators)
-servo-fetch URL1 URL2 --json                       # Parallel batch (NDJSON)
+servo-fetch URL1 URL2 --format json                       # Parallel batch (NDJSON)
 servo-fetch https://example.com --screenshot out.png
 servo-fetch https://example.com --js "document.title"
 servo-fetch https://example.com --selector article
 servo-fetch https://example.com --schema schema.json  # Schema-driven JSON
-servo-fetch https://example.com --raw html         # Raw HTML
-servo-fetch https://example.com --raw text         # Plain text
+servo-fetch https://example.com --format html         # Raw HTML
+servo-fetch https://example.com --format text         # Plain text
 servo-fetch https://example.com -t 60              # Custom timeout
 servo-fetch https://example.com --settle 500       # Extra wait for SPAs
 servo-fetch crawl https://docs.example.com --limit 20  # Crawl a site (BFS)

--- a/skills/servo-fetch/references/guide.md
+++ b/skills/servo-fetch/references/guide.md
@@ -28,7 +28,7 @@ CLI equivalent:
 
 ```bash
 servo-fetch https://a.com https://b.com https://c.com          # Markdown
-servo-fetch https://a.com https://b.com https://c.com --json   # NDJSON
+servo-fetch https://a.com https://b.com https://c.com --format json   # NDJSON
 ```
 
 ## Crawling


### PR DESCRIPTION
## Summary

Unify the inconsistent set of output flags (`--json`, `--raw <html|text>`) into a single `--format <markdown|json|html|text>` flag, following the convention used by cargo (`--message-format`) and docker (`--format`). Reserves `--output FILE` for future file-output use.

## Related issues

Closes #205.

## Test Plan

- `cargo test --workspace -- --include-ignored` — all passed

## Checklist

- [x] Ran `cargo fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
- [x] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed
- [x] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it