### PR TITLE
feat(cli): add -o/--output and --output-dir for file output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6603,12 +6603,14 @@ dependencies = [
  "serde",
  "serde_json",
  "servo-fetch",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tower",
  "tower-http",
  "tracing",
  "tracing-subscriber",
+ "url",
  "wiremock",
 ]
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,10 @@ servo-fetch "https://example.com" --screenshot page.png  # PNG screenshot
 servo-fetch "https://example.com" --js "document.title"  # Run JavaScript
 servo-fetch "https://example.com" --schema schema.json   # Schema-driven JSON
 servo-fetch URL1 URL2 URL3                               # Parallel batch
+servo-fetch "https://example.com" --output page.md       # Save to a single file
+servo-fetch URL1 URL2 --output-dir ./out/                # Save each URL to its own file
 servo-fetch crawl "https://docs.example.com" --limit 20  # Crawl a site
+servo-fetch crawl URL --output-dir ./pages/              # Save each crawled page to its own file
 servo-fetch map "https://example.com"                    # Discover URLs via sitemap
 servo-fetch mcp                                          # MCP server (stdio)
 servo-fetch serve                                        # HTTP API server

--- a/crates/servo-fetch-cli/Cargo.toml
+++ b/crates/servo-fetch-cli/Cargo.toml
@@ -47,12 +47,14 @@ tower = "0.5"
 tower-http = { version = "0.6", features = ["trace", "request-id"] }
 tracing = { workspace = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter", "tracing-log"] }
+url = { workspace = true }
 
 [dev-dependencies]
 assert_cmd = "2"
 predicates = "3"
 rmcp = { version = "1", features = ["client", "transport-io", "transport-child-process"] }
 futures-util = "0.3"
+tempfile = "3"
 wiremock = { workspace = true }
 
 [lints]

--- a/crates/servo-fetch-cli/README.md
+++ b/crates/servo-fetch-cli/README.md
@@ -32,11 +32,18 @@ servo-fetch "https://example.com" --format html   # Raw rendered HTML
 servo-fetch "https://example.com" --format text   # Plain text (innerText)
 ```
 
+### Single file output
+
+```bash
+servo-fetch "https://example.com" --output page.md   # Save to a single file (single URL only)
+```
+
 ### Batch fetch
 
 ```bash
 servo-fetch URL1 URL2 URL3                     # Parallel fetch, Markdown output
 servo-fetch URL1 URL2 --format json            # Parallel fetch, NDJSON output
+servo-fetch URL1 URL2 --output-dir ./out/      # One file per URL (auto-created)
 ```
 
 ### Screenshots

--- a/crates/servo-fetch-cli/src/cli.rs
+++ b/crates/servo-fetch-cli/src/cli.rs
@@ -72,6 +72,14 @@ pub(crate) struct FetchArgs {
     #[arg(long, value_name = "FILE", conflicts_with_all = ["screenshot", "js", "selector", "format"])]
     pub schema: Option<std::path::PathBuf>,
 
+    /// Save the rendered output to a single file (single URL only).
+    #[arg(short = 'o', long, value_name = "FILE", conflicts_with_all = ["screenshot", "output_dir"])]
+    pub output: Option<std::path::PathBuf>,
+
+    /// Write each URL's output to a file in this directory (auto-created).
+    #[arg(long, value_name = "DIR", conflicts_with = "screenshot")]
+    pub output_dir: Option<std::path::PathBuf>,
+
     /// Visibility-aware filtering policy.
     #[arg(long, value_name = "POLICY", value_enum, default_value_t = VisibilityArg::Moderate)]
     pub visibility: VisibilityArg,
@@ -199,6 +207,10 @@ pub(crate) struct CrawlArgs {
     /// Override the User-Agent string
     #[arg(long, value_name = "UA")]
     pub user_agent: Option<String>,
+
+    /// Write each crawled page's output to a file in this directory.
+    #[arg(long, value_name = "DIR")]
+    pub output_dir: Option<std::path::PathBuf>,
 }
 
 #[derive(Args, Debug)]
@@ -339,5 +351,50 @@ mod cli_tests {
             .assert()
             .failure()
             .stderr(predicate::str::contains("cannot be used with multiple URLs"));
+    }
+
+    #[test]
+    fn output_dir_conflicts_with_screenshot() {
+        servo_fetch()
+            .args(["--output-dir", "out", "--screenshot", "out.png", "https://example.com"])
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains("cannot be used with"));
+    }
+
+    #[test]
+    fn output_conflicts_with_screenshot() {
+        servo_fetch()
+            .args(["-o", "out.md", "--screenshot", "out.png", "https://example.com"])
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains("cannot be used with"));
+    }
+
+    #[test]
+    fn output_conflicts_with_output_dir() {
+        servo_fetch()
+            .args(["-o", "out.md", "--output-dir", "out", "https://example.com"])
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains("cannot be used with"));
+    }
+
+    #[test]
+    fn output_with_multi_urls_errors() {
+        servo_fetch()
+            .args(["-o", "out.md", "https://example.com", "https://example.org"])
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains("only valid with a single URL"));
+    }
+
+    #[test]
+    fn output_with_js_is_allowed() {
+        servo_fetch()
+            .args(["--output", "out.txt", "--js", "document.title", "https://example.com"])
+            .assert()
+            .stderr(predicate::str::contains("cannot be used with").not())
+            .stderr(predicate::str::contains("only valid with").not());
     }
 }

--- a/crates/servo-fetch-cli/src/commands/crawl.rs
+++ b/crates/servo-fetch-cli/src/commands/crawl.rs
@@ -6,6 +6,7 @@ use std::time::Instant;
 use serde::Serialize;
 
 use crate::cli::{CrawlArgs, CrawlFormat};
+use crate::output::{Ext, Sink};
 use crate::progress::Progress;
 
 #[derive(Serialize)]
@@ -17,15 +18,19 @@ struct StatsRecord {
     elapsed_ms: u64,
 }
 
-/// Crawl a site starting from `args.url` and stream results to stdout.
+/// Crawl a site starting from `args.url` and stream results to stdout or a directory.
 pub(crate) fn run(args: &CrawlArgs) -> anyhow::Result<()> {
+    if let Some(dir) = args.output_dir.as_deref() {
+        std::fs::create_dir_all(dir)?;
+    }
     let json = matches!(args.format, CrawlFormat::Json);
+    let sink = Sink::from_dir(args.output_dir.as_deref());
     let opts = build_crawl_options(args, json);
 
     let progress = Progress::new();
     let mut completed = 0u64;
     let mut errors = 0u64;
-    let mut write_err: Option<io::Error> = None;
+    let mut write_err: Option<anyhow::Error> = None;
     let started = Instant::now();
 
     servo_fetch::crawl_each(opts, |result| {
@@ -36,7 +41,11 @@ pub(crate) fn run(args: &CrawlArgs) -> anyhow::Result<()> {
         if write_err.is_some() {
             return;
         }
-        let res = if json { emit_json(result) } else { emit_markdown(result) };
+        let res = if json {
+            emit_json(result, sink)
+        } else {
+            emit_markdown(result, sink)
+        };
         if let Err(e) = res {
             write_err = Some(e);
             return;
@@ -50,10 +59,15 @@ pub(crate) fn run(args: &CrawlArgs) -> anyhow::Result<()> {
     })?;
 
     if let Some(e) = write_err {
-        return Err(e.into());
+        return Err(e);
     }
     if json {
-        emit_stats(completed, errors, started.elapsed())?;
+        let elapsed = started.elapsed();
+        if sink.is_stdout() {
+            emit_stats(&mut io::stdout(), completed, errors, elapsed)?;
+        } else {
+            emit_stats(&mut io::stderr(), completed, errors, elapsed)?;
+        }
     }
     Ok(())
 }
@@ -86,12 +100,12 @@ fn build_crawl_options(args: &CrawlArgs, json: bool) -> servo_fetch::CrawlOption
     opts
 }
 
-fn emit_json(result: &servo_fetch::CrawlResult) -> io::Result<()> {
+fn emit_json(result: &servo_fetch::CrawlResult, sink: Sink<'_>) -> anyhow::Result<()> {
     let line = serde_json::to_string(result).expect("CrawlResult is always serializable");
-    writeln!(io::stdout(), "{}", servo_fetch::sanitize::sanitize(&line))
+    sink.writeln(&result.url, Ext::Json, &line)
 }
 
-fn emit_stats(crawled: u64, errors: u64, elapsed: std::time::Duration) -> io::Result<()> {
+fn emit_stats(out: &mut impl io::Write, crawled: u64, errors: u64, elapsed: std::time::Duration) -> io::Result<()> {
     let stats = StatsRecord {
         kind: "stats",
         crawled,
@@ -99,19 +113,24 @@ fn emit_stats(crawled: u64, errors: u64, elapsed: std::time::Duration) -> io::Re
         elapsed_ms: u64::try_from(elapsed.as_millis()).unwrap_or(u64::MAX),
     };
     let line = serde_json::to_string(&stats).expect("StatsRecord is always serializable");
-    writeln!(io::stdout(), "{line}")
+    writeln!(out, "{line}")
 }
 
-fn emit_markdown(result: &servo_fetch::CrawlResult) -> io::Result<()> {
-    let mut out = io::stdout();
-    writeln!(out, "--- {} ---", result.url)?;
-    match &result.outcome {
-        Ok(page) => {
-            writeln!(out, "{}", servo_fetch::sanitize::sanitize(&page.content))?;
-        }
+fn emit_markdown(result: &servo_fetch::CrawlResult, sink: Sink<'_>) -> anyhow::Result<()> {
+    let page = match &result.outcome {
+        Ok(p) => p,
         Err(e) => {
             tracing::warn!(url = %result.url, "{e}");
+            return Ok(());
         }
+    };
+    if sink.is_stdout() {
+        let mut out = io::stdout().lock();
+        writeln!(out, "--- {} ---", result.url)?;
+        out.write_all(servo_fetch::sanitize::sanitize(&page.content).as_bytes())?;
+        writeln!(out)?;
+        Ok(())
+    } else {
+        sink.write(&result.url, Ext::Markdown, &page.content)
     }
-    writeln!(out)
 }

--- a/crates/servo-fetch-cli/src/commands/fetch.rs
+++ b/crates/servo-fetch-cli/src/commands/fetch.rs
@@ -1,6 +1,6 @@
 //! Default fetch command — single URL, batch, and PDF probe.
 
-use std::io::Write as _;
+use std::path::Path;
 use std::time::Duration;
 
 use anyhow::{Result, bail};
@@ -8,12 +8,20 @@ use anyhow::{Result, bail};
 use servo_fetch::{FetchOptions, Page};
 
 use crate::cli::{FetchArgs, Format};
-use crate::output;
+use crate::output::{self, Sink};
 use crate::progress::Progress;
 
-/// Fetch one or more URLs and write the rendered output to stdout.
+/// Fetch one or more URLs and write the rendered output to stdout, a file, or a directory.
 pub(crate) fn run(args: &FetchArgs) -> Result<()> {
     validate_args(args)?;
+    if let Some(dir) = args.output_dir.as_deref() {
+        std::fs::create_dir_all(dir)?;
+    }
+    if let Some(file) = args.output.as_deref() {
+        if let Some(parent) = file.parent().filter(|p| !p.as_os_str().is_empty()) {
+            std::fs::create_dir_all(parent)?;
+        }
+    }
     match args.urls.as_slice() {
         [] => bail!("URL is required. Run with --help for usage."),
         [one] => run_single(args, one),
@@ -29,10 +37,19 @@ fn validate_args(args: &FetchArgs) -> Result<()> {
     if raw_format && args.selector.is_some() {
         bail!("--selector cannot be used with --format html or text");
     }
-    if args.urls.len() > 1 && (args.screenshot.is_some() || args.js.is_some() || raw_format) {
-        bail!("--screenshot, --js, and --format html or text cannot be used with multiple URLs");
+    if args.urls.len() > 1 {
+        if args.output.is_some() {
+            bail!("-o/--output is only valid with a single URL; use --output-dir for multiple URLs");
+        }
+        if args.screenshot.is_some() || args.js.is_some() || raw_format {
+            bail!("--screenshot, --js, and --format html or text cannot be used with multiple URLs");
+        }
     }
     Ok(())
+}
+
+fn sink(args: &FetchArgs) -> Sink<'_> {
+    Sink::from_args(args.output.as_deref(), args.output_dir.as_deref())
 }
 
 fn run_single(args: &FetchArgs, url_str: &str) -> Result<()> {
@@ -43,7 +60,7 @@ fn run_single(args: &FetchArgs, url_str: &str) -> Result<()> {
     let page = servo_fetch::fetch(opts).map_err(anyhow::Error::from);
     progress.clear();
     let page = page?;
-    dispatch_output(args, &page, url_str)
+    dispatch_output(args, &page, url_str, sink(args))
 }
 
 async fn run_batch(args: &FetchArgs, urls: &[String]) -> Result<()> {
@@ -83,13 +100,14 @@ async fn run_batch(args: &FetchArgs, urls: &[String]) -> Result<()> {
     }
     drop(tx);
 
+    let sink = sink(args);
     let mut completed = 0usize;
     let mut failures = 0usize;
     while let Some((url, result)) = rx.recv().await {
         completed += 1;
         match result {
             Ok(page) => {
-                batch_emit(args, &page, &url)?;
+                batch_emit(args, &page, &url, sink)?;
                 progress.item_done(completed, Some(total), &url, true);
             }
             Err(err) => {
@@ -105,39 +123,48 @@ async fn run_batch(args: &FetchArgs, urls: &[String]) -> Result<()> {
     Ok(())
 }
 
-fn batch_emit(args: &FetchArgs, page: &Page, url: &str) -> Result<()> {
+fn batch_emit(args: &FetchArgs, page: &Page, url: &str, sink: Sink<'_>) -> Result<()> {
     if args.schema.is_some() {
-        return output::Extracted { page, url }.execute_compact();
+        return output::Extracted { page, url }.execute_compact(sink);
     }
     let selector = args.selector.as_deref();
     match args.format {
-        Format::Json => output::Json { page, url, selector }.execute_compact(),
+        Format::Json => output::Json { page, url, selector }.execute_compact(sink),
         Format::Markdown => {
-            writeln!(std::io::stdout(), "--- {url} ---")?;
-            output::Markdown { page, url, selector }.execute()?;
-            writeln!(std::io::stdout())?;
-            Ok(())
+            if sink.is_stdout() {
+                use std::io::Write as _;
+                writeln!(std::io::stdout(), "--- {url} ---")?;
+                output::Markdown { page, url, selector }.execute(sink)?;
+                writeln!(std::io::stdout())?;
+                Ok(())
+            } else {
+                output::Markdown { page, url, selector }.execute(sink)
+            }
         }
-        Format::Html | Format::Text => unreachable!("guarded by run() before batch dispatch"),
+        Format::Html | Format::Text => unreachable!("guarded by validate_args before batch dispatch"),
     }
 }
 
-fn dispatch_output(args: &FetchArgs, page: &Page, url: &str) -> Result<()> {
+fn dispatch_output(args: &FetchArgs, page: &Page, url: &str, sink: Sink<'_>) -> Result<()> {
     if let Some(result) = page.js_result.as_deref() {
-        return output::js_eval(result);
+        return output::js_eval(url, result, sink);
     }
     if let Some(path) = args.screenshot.as_deref() {
-        return output::Screenshot { page, path }.execute();
+        return output::Screenshot {
+            page,
+            path: Path::new(path),
+        }
+        .execute();
     }
     if args.schema.is_some() {
-        return output::Extracted { page, url }.execute();
+        return output::Extracted { page, url }.execute(sink);
     }
     let selector = args.selector.as_deref();
     match args.format {
-        Format::Markdown => output::Markdown { page, url, selector }.execute(),
-        Format::Json => output::Json { page, url, selector }.execute(),
-        Format::Html => output::raw(&page.html),
-        Format::Text => output::raw(&page.inner_text),
+        Format::Markdown => output::Markdown { page, url, selector }.execute(sink),
+        Format::Json => output::Json { page, url, selector }.execute(sink),
+        Format::Html => output::raw(url, output::Ext::Html, &page.html, sink),
+        Format::Text => output::raw(url, output::Ext::Text, &page.inner_text, sink),
     }
 }
 
@@ -164,6 +191,6 @@ fn build_fetch_options(args: &FetchArgs, url: &str) -> Result<FetchOptions> {
     Ok(opts)
 }
 
-fn load_schema(path: &std::path::Path) -> Result<servo_fetch::schema::ExtractSchema> {
+fn load_schema(path: &Path) -> Result<servo_fetch::schema::ExtractSchema> {
     servo_fetch::schema::ExtractSchema::from_path(path).map_err(|e| anyhow::anyhow!("schema '{}': {e}", path.display()))
 }

--- a/crates/servo-fetch-cli/src/output.rs
+++ b/crates/servo-fetch-cli/src/output.rs
@@ -1,10 +1,102 @@
-//! Output formatters for stdout (Markdown, JSON, screenshot, raw).
+//! Output sinks.
 
-use std::io::Write;
+use std::fs;
+use std::io::Write as _;
+use std::path::Path;
 
 use anyhow::{Result, bail};
 
 use servo_fetch::Page;
+
+/// File extension for sink-emitted content.
+#[derive(Debug, Copy, Clone)]
+pub(crate) enum Ext {
+    Markdown,
+    Json,
+    Html,
+    Text,
+}
+
+impl Ext {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Markdown => "md",
+            Self::Json => "json",
+            Self::Html => "html",
+            Self::Text => "txt",
+        }
+    }
+}
+
+impl std::fmt::Display for Ext {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Where rendered output goes.
+#[derive(Debug, Copy, Clone)]
+pub(crate) enum Sink<'a> {
+    Stdout,
+    File(&'a Path),
+    Dir(&'a Path),
+}
+
+impl<'a> Sink<'a> {
+    pub(crate) fn from_dir(dir: Option<&'a Path>) -> Self {
+        dir.map_or(Self::Stdout, Self::Dir)
+    }
+
+    pub(crate) fn from_args(file: Option<&'a Path>, dir: Option<&'a Path>) -> Self {
+        match (file, dir) {
+            (Some(p), _) => Self::File(p),
+            (_, Some(d)) => Self::Dir(d),
+            _ => Self::Stdout,
+        }
+    }
+
+    pub(crate) fn is_stdout(&self) -> bool {
+        matches!(self, Self::Stdout)
+    }
+
+    pub(crate) fn write(&self, url: &str, ext: Ext, content: &str) -> Result<()> {
+        self.emit(url, ext, content, false)
+    }
+
+    pub(crate) fn writeln(&self, url: &str, ext: Ext, content: &str) -> Result<()> {
+        self.emit(url, ext, content, true)
+    }
+
+    fn emit(&self, url: &str, ext: Ext, content: &str, ensure_newline: bool) -> Result<()> {
+        let sanitized = servo_fetch::sanitize::sanitize(content);
+        let needs_nl = ensure_newline && !sanitized.ends_with('\n');
+        match self {
+            Self::Stdout => {
+                let mut out = std::io::stdout().lock();
+                out.write_all(sanitized.as_bytes())?;
+                if needs_nl {
+                    out.write_all(b"\n")?;
+                }
+                Ok(())
+            }
+            Self::File(path) => write_to_file(url, path, sanitized.as_bytes(), needs_nl),
+            Self::Dir(dir) => {
+                let path = dir.join(slug_from_url(url, ext));
+                write_to_file(url, &path, sanitized.as_bytes(), needs_nl)
+            }
+        }
+    }
+}
+
+fn write_to_file(url: &str, path: &Path, body: &[u8], with_newline: bool) -> Result<()> {
+    let mut f = fs::File::create(path)?;
+    f.write_all(body)?;
+    if with_newline {
+        f.write_all(b"\n")?;
+    }
+    tracing::info!(url = %url, path = %path.display(), bytes = body.len(), "saved");
+    Ok(())
+}
 
 pub(crate) struct Markdown<'a> {
     pub page: &'a Page,
@@ -13,8 +105,12 @@ pub(crate) struct Markdown<'a> {
 }
 
 impl Markdown<'_> {
-    pub(crate) fn execute(&self) -> Result<()> {
-        let md = if let Some(selector) = self.selector {
+    pub(crate) fn execute(&self, sink: Sink<'_>) -> Result<()> {
+        sink.write(self.url, Ext::Markdown, &self.render()?)
+    }
+
+    fn render(&self) -> Result<String> {
+        if let Some(selector) = self.selector {
             let input = servo_fetch::extract::ExtractInput::new(&self.page.html, self.url)
                 .with_layout_json(self.page.layout_json.as_deref())
                 .with_inner_text(Some(&self.page.inner_text))
@@ -23,12 +119,10 @@ impl Markdown<'_> {
             if text.is_empty() {
                 tracing::warn!(selector, "no elements matched the selector");
             }
-            text
+            Ok(text)
         } else {
-            self.page.markdown_with_url(self.url)?
-        };
-        write!(std::io::stdout(), "{}", servo_fetch::sanitize::sanitize(&md))?;
-        Ok(())
+            Ok(self.page.markdown_with_url(self.url)?)
+        }
     }
 }
 
@@ -39,21 +133,18 @@ pub(crate) struct Json<'a> {
 }
 
 impl Json<'_> {
-    pub(crate) fn execute(&self) -> Result<()> {
-        let json = self.render()?;
-        writeln!(std::io::stdout(), "{}", servo_fetch::sanitize::sanitize(&json))?;
-        Ok(())
+    pub(crate) fn execute(&self, sink: Sink<'_>) -> Result<()> {
+        sink.writeln(self.url, Ext::Json, &self.render()?)
     }
 
     /// Emit a single-line NDJSON record for batch output.
-    pub(crate) fn execute_compact(&self) -> Result<()> {
+    pub(crate) fn execute_compact(&self, sink: Sink<'_>) -> Result<()> {
         let pretty = self.render()?;
         let line = serde_json::from_str::<serde_json::Value>(&pretty)
             .ok()
             .and_then(|v| serde_json::to_string(&v).ok())
             .unwrap_or(pretty);
-        writeln!(std::io::stdout(), "{}", servo_fetch::sanitize::sanitize(&line))?;
-        Ok(())
+        sink.writeln(self.url, Ext::Json, &line)
     }
 
     fn render(&self) -> Result<String> {
@@ -71,15 +162,15 @@ impl Json<'_> {
 
 pub(crate) struct Screenshot<'a> {
     pub page: &'a Page,
-    pub path: &'a str,
+    pub path: &'a Path,
 }
 
 impl Screenshot<'_> {
     pub(crate) fn execute(&self) -> Result<()> {
         match self.page.screenshot_png() {
             Some(png) => {
-                std::fs::write(self.path, png)?;
-                tracing::info!(path = %self.path, "screenshot saved");
+                fs::write(self.path, png)?;
+                tracing::info!(path = %self.path.display(), "screenshot saved");
                 Ok(())
             }
             None => bail!("failed to capture screenshot — the page may not have rendered correctly"),
@@ -87,9 +178,8 @@ impl Screenshot<'_> {
     }
 }
 
-pub(crate) fn js_eval(result: &str) -> Result<()> {
-    writeln!(std::io::stdout(), "{}", servo_fetch::sanitize::sanitize(result))?;
-    Ok(())
+pub(crate) fn js_eval(url: &str, result: &str, sink: Sink<'_>) -> Result<()> {
+    sink.writeln(url, Ext::Text, result)
 }
 
 pub(crate) struct Extracted<'a> {
@@ -98,17 +188,13 @@ pub(crate) struct Extracted<'a> {
 }
 
 impl Extracted<'_> {
-    pub(crate) fn execute(&self) -> Result<()> {
-        let body = serde_json::to_string_pretty(&self.payload())?;
-        writeln!(std::io::stdout(), "{}", servo_fetch::sanitize::sanitize(&body))?;
-        Ok(())
+    pub(crate) fn execute(&self, sink: Sink<'_>) -> Result<()> {
+        sink.writeln(self.url, Ext::Json, &serde_json::to_string_pretty(&self.payload())?)
     }
 
     /// Emit a single-line NDJSON record for batch output.
-    pub(crate) fn execute_compact(&self) -> Result<()> {
-        let line = serde_json::to_string(&self.payload())?;
-        writeln!(std::io::stdout(), "{}", servo_fetch::sanitize::sanitize(&line))?;
-        Ok(())
+    pub(crate) fn execute_compact(&self, sink: Sink<'_>) -> Result<()> {
+        sink.writeln(self.url, Ext::Json, &serde_json::to_string(&self.payload())?)
     }
 
     fn payload(&self) -> serde_json::Value {
@@ -119,7 +205,153 @@ impl Extracted<'_> {
     }
 }
 
-pub(crate) fn raw(content: &str) -> Result<()> {
-    write!(std::io::stdout(), "{}", servo_fetch::sanitize::sanitize(content))?;
-    Ok(())
+pub(crate) fn raw(url: &str, ext: Ext, content: &str, sink: Sink<'_>) -> Result<()> {
+    sink.write(url, ext, content)
+}
+
+/// Build a filesystem-safe filename from a URL with a stable hash suffix
+/// to keep distinct URLs in distinct files.
+fn slug_from_url(url: &str, ext: Ext) -> String {
+    const MAX_STEM: usize = 180;
+
+    let stripped = url::Url::parse(url).ok().map_or_else(
+        || url.to_owned(),
+        |u| {
+            use std::fmt::Write as _;
+            let mut s = u.host_str().unwrap_or("").to_owned();
+            if let Some(p) = u.port() {
+                let _ = write!(s, ":{p}");
+            }
+            s.push_str(u.path());
+            if let Some(q) = u.query() {
+                s.push('?');
+                s.push_str(q);
+            }
+            s
+        },
+    );
+
+    let mut stem = String::with_capacity(stripped.len());
+    let mut prev_us = true;
+    for c in stripped.chars() {
+        match c {
+            'a'..='z' | 'A'..='Z' | '0'..='9' | '.' | '-' => {
+                stem.push(c);
+                prev_us = false;
+            }
+            _ if !prev_us => {
+                stem.push('_');
+                prev_us = true;
+            }
+            _ => {}
+        }
+    }
+    let stem = stem.trim_matches(['_', '.']);
+    let stem = if stem.is_empty() { "index" } else { stem };
+
+    let end = servo_fetch::sanitize::floor_char_boundary(stem, MAX_STEM);
+    let stem = &stem[..end];
+
+    format!("{stem}-{:016x}.{ext}", fnv1a64(&stripped))
+}
+
+/// FNV-1a 64-bit. Stable across runs and platforms; collision probability is
+/// ~3e-10 at 100k URLs (vs ~1.2% for the 32-bit variant at 10k URLs).
+fn fnv1a64(s: &str) -> u64 {
+    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+    for b in s.bytes() {
+        h ^= u64::from(b);
+        h = h.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    h
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::OsStr;
+    use std::path::Path;
+
+    use super::*;
+
+    fn ext(s: &str) -> Option<&OsStr> {
+        Path::new(s).extension()
+    }
+
+    #[test]
+    fn slug_strips_scheme_and_replaces_unsafe_chars() {
+        let s = slug_from_url("https://example.com/foo/bar?x=1", Ext::Markdown);
+        assert!(s.starts_with("example.com_foo_bar_x_1-"));
+        assert_eq!(ext(&s), Some(OsStr::new("md")));
+    }
+
+    #[test]
+    fn slug_collapses_runs_and_trims_underscores() {
+        let s = slug_from_url("https://example.com//foo///bar//", Ext::Json);
+        assert!(s.starts_with("example.com_foo_bar-"));
+        assert_eq!(ext(&s), Some(OsStr::new("json")));
+    }
+
+    #[test]
+    fn slug_distinct_for_distinct_urls() {
+        let a = slug_from_url("https://a.test/x", Ext::Markdown);
+        let b = slug_from_url("https://a.test/y", Ext::Markdown);
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn slug_stable_across_calls() {
+        let a = slug_from_url("https://a.test/x", Ext::Markdown);
+        let b = slug_from_url("https://a.test/x", Ext::Markdown);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn slug_handles_empty_path() {
+        let s = slug_from_url("https://example.com", Ext::Markdown);
+        assert!(s.starts_with("example.com-"));
+    }
+
+    #[test]
+    fn slug_truncates_long_urls() {
+        let url = format!("https://example.com/{}", "a".repeat(500));
+        let s = slug_from_url(&url, Ext::Markdown);
+        assert!(s.len() < 220, "len was {}", s.len());
+        assert_eq!(ext(&s), Some(OsStr::new("md")));
+    }
+
+    #[test]
+    fn slug_handles_unicode() {
+        let s = slug_from_url("https://example.com/日本語", Ext::Markdown);
+        assert!(s.contains("example.com"));
+        assert_eq!(ext(&s), Some(OsStr::new("md")));
+    }
+
+    #[test]
+    fn slug_handles_invalid_url() {
+        let s = slug_from_url("not a url", Ext::Markdown);
+        assert!(s.contains("not_a_url"));
+        assert_eq!(ext(&s), Some(OsStr::new("md")));
+    }
+
+    #[test]
+    fn slug_strips_credentials_and_fragment() {
+        let s = slug_from_url("https://user:secret@example.com/foo#anchor", Ext::Markdown);
+        assert!(!s.contains("user"), "must not leak username, got: {s}");
+        assert!(!s.contains("secret"), "must not leak password, got: {s}");
+        assert!(!s.contains("anchor"), "must drop fragment, got: {s}");
+        assert!(s.starts_with("example.com_foo-"));
+    }
+
+    #[test]
+    fn slug_credentials_do_not_affect_filename() {
+        let with_creds = slug_from_url("https://user:secret@example.com/foo", Ext::Markdown);
+        let without_creds = slug_from_url("https://example.com/foo", Ext::Markdown);
+        assert_eq!(with_creds, without_creds, "credentials must not change filename");
+    }
+
+    #[test]
+    fn slug_includes_non_default_port() {
+        let s = slug_from_url("https://example.com:8080/foo", Ext::Markdown);
+        assert!(s.contains("8080"), "must include non-default port, got: {s}");
+    }
 }

--- a/crates/servo-fetch-cli/tests/cli.rs
+++ b/crates/servo-fetch-cli/tests/cli.rs
@@ -339,6 +339,121 @@ fn crawl_rejects_invalid_url() {
 }
 
 #[test]
+#[ignore = "e2e: requires Servo engine"]
+fn output_writes_single_file() {
+    block_on(async {
+        let s = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/"))
+            .respond_with(mock_page(
+                "<html><head><title>OutputFile</title></head><body><h1>Direct</h1></body></html>",
+            ))
+            .mount(&s)
+            .await;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let file = dir.path().join("page.md");
+        servo_fetch()
+            .args([
+                "-o",
+                file.to_str().unwrap(),
+                "--allow-private-addresses",
+                TIMEOUT,
+                &s.uri(),
+            ])
+            .assert()
+            .success();
+        let body = std::fs::read_to_string(&file).expect("file written");
+        assert!(body.contains("Direct"), "got: {body}");
+    });
+}
+
+#[test]
+#[ignore = "e2e: requires Servo engine"]
+fn output_dir_writes_single_file() {
+    block_on(async {
+        let s = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/"))
+            .respond_with(mock_page(
+                "<html><head><title>OutputDir</title></head><body><h1>Saved</h1></body></html>",
+            ))
+            .mount(&s)
+            .await;
+        let dir = tempfile::tempdir().expect("tempdir");
+        servo_fetch()
+            .args([
+                "--output-dir",
+                dir.path().to_str().unwrap(),
+                "--allow-private-addresses",
+                TIMEOUT,
+                &s.uri(),
+            ])
+            .assert()
+            .success();
+        let entries: Vec<_> = std::fs::read_dir(dir.path())
+            .expect("dir exists")
+            .filter_map(Result::ok)
+            .filter(|e| e.path().extension().is_some_and(|ext| ext == "md"))
+            .collect();
+        assert_eq!(entries.len(), 1, "expected exactly 1 .md file");
+        let body = std::fs::read_to_string(entries[0].path()).unwrap();
+        assert!(body.contains("Saved"), "got: {body}");
+    });
+}
+
+#[test]
+#[ignore = "e2e: requires Servo engine"]
+fn crawl_output_dir_writes_per_page_files() {
+    block_on(async {
+        let s = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/"))
+            .respond_with(mock_page(
+                "<html><head><title>CrawlDir</title></head><body><p>One page</p></body></html>",
+            ))
+            .mount(&s)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/robots.txt"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&s)
+            .await;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let output = servo_fetch()
+            .args([
+                "crawl",
+                &s.uri(),
+                "--format",
+                "json",
+                "--output-dir",
+                dir.path().to_str().unwrap(),
+                "--limit",
+                "1",
+                "--max-depth",
+                "0",
+                "--timeout",
+                "30",
+                "--allow-private-addresses",
+            ])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        assert!(output.is_empty(), "stdout should be silent in --output-dir mode");
+        let entries: Vec<_> = std::fs::read_dir(dir.path())
+            .expect("dir exists")
+            .filter_map(Result::ok)
+            .filter(|e| e.path().extension().is_some_and(|ext| ext == "json"))
+            .collect();
+        assert_eq!(entries.len(), 1, "expected exactly 1 .json file");
+        let line = std::fs::read_to_string(entries[0].path()).unwrap();
+        let record: serde_json::Value = serde_json::from_str(line.trim()).expect("valid JSON");
+        assert_eq!(record["type"], "page");
+    });
+}
+
+#[test]
 fn crawl_help_shows_options() {
     servo_fetch()
         .args(["crawl", "--help"])
@@ -347,7 +462,17 @@ fn crawl_help_shows_options() {
         .stdout(predicate::str::contains("--limit"))
         .stdout(predicate::str::contains("--max-depth"))
         .stdout(predicate::str::contains("--include"))
-        .stdout(predicate::str::contains("--exclude"));
+        .stdout(predicate::str::contains("--exclude"))
+        .stdout(predicate::str::contains("--output-dir"));
+}
+
+#[test]
+fn fetch_help_shows_output_dir() {
+    servo_fetch()
+        .args(["--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--output-dir"));
 }
 
 #[test]

--- a/skills/servo-fetch/SKILL.md
+++ b/skills/servo-fetch/SKILL.md
@@ -121,20 +121,22 @@ execute_js(url: "https://example.com", expression: "[...document.querySelectorAl
 ## CLI
 
 ```bash
-servo-fetch https://example.com                    # Markdown (default)
-servo-fetch https://example.com --format json             # Structured JSON
-servo-fetch URL1 URL2 URL3                         # Parallel batch (Markdown with separators)
-servo-fetch URL1 URL2 --format json                       # Parallel batch (NDJSON)
-servo-fetch https://example.com --screenshot out.png
-servo-fetch https://example.com --js "document.title"
-servo-fetch https://example.com --selector article
-servo-fetch https://example.com --schema schema.json  # Schema-driven JSON
-servo-fetch https://example.com --format html         # Raw HTML
-servo-fetch https://example.com --format text         # Plain text
-servo-fetch https://example.com -t 60              # Custom timeout
-servo-fetch https://example.com --settle 500       # Extra wait for SPAs
-servo-fetch crawl https://docs.example.com --limit 20  # Crawl a site (BFS)
+servo-fetch https://example.com                                  # Markdown (default)
+servo-fetch https://example.com --format json                    # Structured JSON
+servo-fetch URL1 URL2 URL3                                       # Parallel batch (Markdown with separators)
+servo-fetch URL1 URL2 --format json                              # Parallel batch (NDJSON)
+servo-fetch https://example.com --screenshot out.png             # Save PNG screenshot
+servo-fetch https://example.com --js "document.title"            # Run JavaScript and print result
+servo-fetch https://example.com --selector article               # Extract a section by CSS selector
+servo-fetch https://example.com --schema schema.json             # Schema-driven JSON
+servo-fetch https://example.com --format html                    # Raw HTML
+servo-fetch https://example.com --format text                    # Plain text
+servo-fetch https://example.com -t 60                            # Custom timeout
+servo-fetch https://example.com --settle 500                     # Extra wait for SPAs
+servo-fetch crawl https://docs.example.com --limit 20            # Crawl a site (BFS)
 servo-fetch crawl https://docs.example.com --include "/docs/**"  # Crawl with path filter
+servo-fetch URL --output page.md                                 # Save a single URL to a file
+servo-fetch crawl URL --output-dir ./pages/                      # One file per page
 ```
 
 ## Gotchas

--- a/skills/servo-fetch/references/guide.md
+++ b/skills/servo-fetch/references/guide.md
@@ -27,8 +27,10 @@ Each URL becomes a separate content entry in the response. Failed URLs are repor
 CLI equivalent:
 
 ```bash
-servo-fetch https://a.com https://b.com https://c.com          # Markdown
+servo-fetch https://a.com https://b.com https://c.com                 # Markdown
 servo-fetch https://a.com https://b.com https://c.com --format json   # NDJSON
+servo-fetch https://example.com --output page.md                      # Save single URL to a file
+servo-fetch URL1 URL2 --output-dir ./out/                             # One file per URL
 ```
 
 ## Crawling


### PR DESCRIPTION
## Summary

Add file output to `fetch` and `crawl`:

- **`-o, --output FILE`** — save a single URL's output to an explicit path. Single URL only; auto-creates parent directories.
- **`--output-dir DIR`** — write each URL's output to its own auto-named file (`<host_path>-<fnv1a64>.<ext>`). Works for batch fetch and crawl. Auto-creates the directory.

## Related issues

N/A

## Test Plan

- 14-phase manual e2e on the release binary covering: each format with `--output FILE`, batch `--output-dir`, parent-dir auto-create, error exit codes, idempotency, slug collision (different URLs sharing a slug stem are disambiguated by hash), Unicode URLs, 500-char URL truncation
- Path-traversal hardening verified against 7 attack vectors (`../`, percent-encoded `..`, `\..\`, NULL byte, query/fragment traversal, empty host, credential leak) — all neutralized

New tests:
- 4 CLI conflict tests (`--output` vs `--screenshot` / `--output-dir` / multi URL)
- 2 slug unit tests (`slug_strips_credentials_and_fragment`, `slug_includes_non_default_port`)
- 1 e2e (`output_writes_single_file`)

## Checklist

- [x] Ran `cargo fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
- [x] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed
- [x] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it