### PR TITLE
fix(bridge): bail out on timeout to avoid Servo parser race

### DIFF
--- a/crates/servo-fetch/src/bridge.rs
+++ b/crates/servo-fetch/src/bridge.rs
@@ -537,13 +537,18 @@ fn start_fetch(
 fn finish_fetch(servo: &servo::Servo, p: &PendingFetch) -> Result<ServoPage> {
     let timed_out = p.state.loaded_at.get().is_none() && Instant::now() > p.deadline;
 
+    if timed_out {
+        return Err(anyhow!(
+            "page load timed out after {timeout}s (try increasing --timeout)",
+            timeout = p.request.timeout_secs,
+        ));
+    }
+
     if let Some(ref ctx) = p.dedicated_ctx {
         let _ = ctx.make_current();
     }
 
-    if !timed_out {
-        wait_for_ready_state(servo, &p.webview, p.deadline);
-    }
+    wait_for_ready_state(servo, &p.webview, p.deadline);
 
     let inner_text = eval_js(servo, &p.webview, "document.body.innerText").ok();
     let layout_json = eval_js(servo, &p.webview, LAYOUT_JS).ok();
@@ -551,18 +556,8 @@ fn finish_fetch(servo: &servo::Servo, p: &PendingFetch) -> Result<ServoPage> {
 
     let html = match eval_js(servo, &p.webview, "document.documentElement.outerHTML") {
         Ok(h) if !h.is_empty() => h,
-        _ if timed_out => {
-            return Err(anyhow!(
-                "page load timed out after {timeout}s (try increasing --timeout)",
-                timeout = p.request.timeout_secs,
-            ));
-        }
         other => other?,
     };
-
-    if timed_out {
-        tracing::warn!("page load did not complete; returning best-effort content");
-    }
 
     let (screenshot, js_result) = match &p.request.mode {
         FetchMode::Screenshot { full_page } => (


### PR DESCRIPTION
## Summary

`finish_fetch` previously kept driving the Servo engine via `eval_js` even after the fetch deadline had elapsed. While the engine pumped the event loop, a still-suspended `<script src=…>` could resume and trigger a SIGSEGV inside upstream `document.rs:2710` (Servo issue [#40744](https://github.com/servo/servo/issues/40744)). The crash surfaced most often in `serve` mode, where many concurrent fetches multiplied the chance of hitting the race.

## Related issues

Closes #199

## Test Plan

- `cargo test --workspace`: all passed

## Checklist

- [x] Ran `cargo fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
- [x] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed
- [x] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it