### PR TITLE
fix(docker): set XDG_RUNTIME_DIR to suppress EGL warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,12 +32,14 @@ RUN groupadd --gid 1001 servo \
 COPY --chown=servo:servo --chmod=0755 \
      dist/${TARGETARCH}/servo-fetch /usr/local/bin/servo-fetch
 
+RUN mkdir -p -m 0700 /tmp/runtime-servo && chown servo:servo /tmp/runtime-servo
+
 USER servo
 WORKDIR /home/servo
 
 EXPOSE 3000
-# fontconfig cache on /tmp for --read-only compatibility
 ENV XDG_CACHE_HOME=/tmp
+ENV XDG_RUNTIME_DIR=/tmp/runtime-servo
 
 HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
     CMD curl -fsS --max-time 2 http://127.0.0.1:3000/health || exit 1


### PR DESCRIPTION
## Summary

Running the published image emits an EGL/Mesa diagnostic on every fetch:

```
$ docker run --rm ghcr.io/konippi/servo-fetch:latest https://example.com
error: XDG_RUNTIME_DIR is invalid or not set in the environment.
# Example Domain
...
```

`XDG_RUNTIME_DIR` was simply unset in the image, so libEGL / Mesa fell through to its complaint path on first GL initialization. The message is harmless but it pollutes stderr (breaks shell pipelines that grep for `error:` and is noisy in `serve` mode logs).

## Related issues

Part of #199  

## Test Plan

Verified locally on macOS arm64 with Docker 28.4.0. Binary extracted from the published image so the comparison only varies the Dockerfile under test:

```bash
# Baseline (current published image)
docker run --rm ghcr.io/konippi/servo-fetch:latest https://example.com 2>&1 | grep -iE "xdg|runtime"
# → error: XDG_RUNTIME_DIR is invalid or not set in the environment.

# Fixed (this branch)
docker buildx build --platform linux/arm64 --build-arg TARGETARCH=arm64 -t sf-fixed:test --load .
docker run --rm sf-fixed:test https://example.com 2>&1 | grep -iE "xdg|runtime"
# → (no output — warning gone)
```

## Checklist

- [x] Ran `cargo fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
- [x] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed
- [x] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it