### PR TITLE
chore: enforce canonical imports via pinned nightly rustfmt

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -22,7 +22,7 @@ Thanks for contributing to servo-fetch!
 
 ## Checklist
 
-- [ ] Ran `cargo fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
+- [ ] Ran `cargo +nightly fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
 - [ ] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed
 - [ ] Tests added or updated, or explained why not in the Test Plan
 - [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
-          toolchain: "1.95.0"
+          toolchain: nightly-2026-05-08
           components: rustfmt
       - run: cargo fmt --all --check
 

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,8 +1,9 @@
 edition = "2024"
 style_edition = "2024"
-
 max_width = 120
-
+unstable_features = true
+group_imports = "StdExternalCrate"
+imports_granularity = "Module"
 use_field_init_shorthand = true
 use_try_shorthand = true
 newline_style = "Unix"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,8 +20,8 @@ Run these from the workspace root unless noted. Copy-paste ready:
 ```sh
 cargo build                                             # Debug build
 cargo build --release                                   # Release build (slow)
-cargo fmt --all                                         # Format
-cargo fmt --all -- --check                              # CI fmt check
+cargo +nightly fmt --all                                # Format
+cargo +nightly fmt --all -- --check                     # CI fmt check
 cargo clippy --workspace --all-targets -- -D warnings   # Lint (pedantic, warnings are errors)
 cargo test --workspace                                  # Unit + integration tests (fast)
 cargo test -- --ignored                                 # Include Servo-backed e2e tests (slow)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,11 +26,13 @@ cargo run -- "https://example.com" --js "document.title"    # JS execution
 cargo test                                                  # Run tests
 cargo test -- --ignored                                     # Run Servo+network tests (slow)
 cargo clippy                                                # Lint (pedantic)
-cargo fmt                                                   # Format
+cargo +nightly fmt                                          # Format
 cargo deny check                                            # License & advisory check
 taplo fmt                                                   # Format TOML files (install: cargo install taplo-cli --locked)
 typos                                                       # Spell check
 ```
+
+> Build/test run on stable. Format requires nightly rustfmt for unstable `imports_granularity` / `group_imports`; one-time: `rustup toolchain install nightly --component rustfmt --profile minimal`.
 
 ### Profiling
 
@@ -70,7 +72,7 @@ refactor: simplify bridge error handling
 ## Pull request guidelines
 
 - Keep PRs focused on a single change
-- Ensure `cargo clippy`, `cargo fmt --check`, and `cargo test` pass with zero warnings
+- Ensure `cargo clippy`, `cargo +nightly fmt --check`, and `cargo test` pass with zero warnings
 - Run `cargo test -- --ignored` if your change affects Servo integration or network behavior
 - Update documentation if behavior changes
 

--- a/crates/servo-fetch-cli/src/cli.rs
+++ b/crates/servo-fetch-cli/src/cli.rs
@@ -1,5 +1,7 @@
 //! CLI argument parsing.
 
+use std::path::PathBuf;
+
 use clap::builder::NonEmptyStringValueParser;
 use clap::{ArgAction, Args, Parser, Subcommand, ValueEnum, value_parser};
 
@@ -70,15 +72,15 @@ pub(crate) struct FetchArgs {
 
     /// Path to a CSS-selector schema file for structured JSON extraction
     #[arg(long, value_name = "FILE", conflicts_with_all = ["screenshot", "js", "selector", "format"])]
-    pub schema: Option<std::path::PathBuf>,
+    pub schema: Option<PathBuf>,
 
     /// Save the rendered output to a single file (single URL only).
     #[arg(short = 'o', long, value_name = "FILE", conflicts_with_all = ["screenshot", "output_dir"])]
-    pub output: Option<std::path::PathBuf>,
+    pub output: Option<PathBuf>,
 
     /// Write each URL's output to a file in this directory (auto-created).
     #[arg(long, value_name = "DIR", conflicts_with = "screenshot")]
-    pub output_dir: Option<std::path::PathBuf>,
+    pub output_dir: Option<PathBuf>,
 
     /// Visibility-aware filtering policy.
     #[arg(long, value_name = "POLICY", value_enum, default_value_t = VisibilityArg::Moderate)]
@@ -210,7 +212,7 @@ pub(crate) struct CrawlArgs {
 
     /// Write each crawled page's output to a file in this directory.
     #[arg(long, value_name = "DIR")]
-    pub output_dir: Option<std::path::PathBuf>,
+    pub output_dir: Option<PathBuf>,
 }
 
 #[derive(Args, Debug)]

--- a/crates/servo-fetch-cli/src/commands/crawl.rs
+++ b/crates/servo-fetch-cli/src/commands/crawl.rs
@@ -1,7 +1,8 @@
 //! Crawl subcommand — BFS website crawler.
 
+use std::fs;
 use std::io::{self, Write as _};
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use serde::Serialize;
 
@@ -21,7 +22,7 @@ struct StatsRecord {
 /// Crawl a site starting from `args.url` and stream results to stdout or a directory.
 pub(crate) fn run(args: &CrawlArgs) -> anyhow::Result<()> {
     if let Some(dir) = args.output_dir.as_deref() {
-        std::fs::create_dir_all(dir)?;
+        fs::create_dir_all(dir)?;
     }
     let json = matches!(args.format, CrawlFormat::Json);
     let sink = Sink::from_dir(args.output_dir.as_deref());
@@ -76,13 +77,13 @@ fn build_crawl_options(args: &CrawlArgs, json: bool) -> servo_fetch::CrawlOption
     let mut opts = servo_fetch::CrawlOptions::new(&args.url)
         .limit(args.limit)
         .max_depth(args.max_depth)
-        .timeout(std::time::Duration::from_secs(args.timeout))
-        .settle(std::time::Duration::from_millis(args.settle))
+        .timeout(Duration::from_secs(args.timeout))
+        .settle(Duration::from_millis(args.settle))
         .concurrency(usize::try_from(args.concurrency).unwrap_or(usize::MAX))
         .delay(if args.delay_ms == 0 {
             None
         } else {
-            Some(std::time::Duration::from_millis(args.delay_ms))
+            Some(Duration::from_millis(args.delay_ms))
         })
         .json(json);
     if !args.include.is_empty() {
@@ -105,7 +106,7 @@ fn emit_json(result: &servo_fetch::CrawlResult, sink: Sink<'_>) -> anyhow::Resul
     sink.writeln(&result.url, Ext::Json, &line)
 }
 
-fn emit_stats(out: &mut impl io::Write, crawled: u64, errors: u64, elapsed: std::time::Duration) -> io::Result<()> {
+fn emit_stats(out: &mut impl io::Write, crawled: u64, errors: u64, elapsed: Duration) -> io::Result<()> {
     let stats = StatsRecord {
         kind: "stats",
         crawled,

--- a/crates/servo-fetch-cli/src/commands/fetch.rs
+++ b/crates/servo-fetch-cli/src/commands/fetch.rs
@@ -1,10 +1,11 @@
 //! Default fetch command — single URL, batch, and PDF probe.
 
+use std::fs;
+use std::io::{self, Write as _};
 use std::path::Path;
 use std::time::Duration;
 
-use anyhow::{Result, bail};
-
+use anyhow::{Error, Result, bail};
 use servo_fetch::{FetchOptions, Page};
 
 use crate::cli::{FetchArgs, Format};
@@ -15,11 +16,11 @@ use crate::progress::Progress;
 pub(crate) fn run(args: &FetchArgs) -> Result<()> {
     validate_args(args)?;
     if let Some(dir) = args.output_dir.as_deref() {
-        std::fs::create_dir_all(dir)?;
+        fs::create_dir_all(dir)?;
     }
     if let Some(file) = args.output.as_deref() {
         if let Some(parent) = file.parent().filter(|p| !p.as_os_str().is_empty()) {
-            std::fs::create_dir_all(parent)?;
+            fs::create_dir_all(parent)?;
         }
     }
     match args.urls.as_slice() {
@@ -57,7 +58,7 @@ fn run_single(args: &FetchArgs, url_str: &str) -> Result<()> {
     progress.ticker(&format!("Fetching {url_str}..."));
 
     let opts = build_fetch_options(args, url_str)?;
-    let page = servo_fetch::fetch(opts).map_err(anyhow::Error::from);
+    let page = servo_fetch::fetch(opts).map_err(Error::from);
     progress.clear();
     let page = page?;
     dispatch_output(args, &page, url_str, sink(args))
@@ -132,10 +133,9 @@ fn batch_emit(args: &FetchArgs, page: &Page, url: &str, sink: Sink<'_>) -> Resul
         Format::Json => output::Json { page, url, selector }.execute_compact(sink),
         Format::Markdown => {
             if sink.is_stdout() {
-                use std::io::Write as _;
-                writeln!(std::io::stdout(), "--- {url} ---")?;
+                writeln!(io::stdout(), "--- {url} ---")?;
                 output::Markdown { page, url, selector }.execute(sink)?;
-                writeln!(std::io::stdout())?;
+                writeln!(io::stdout())?;
                 Ok(())
             } else {
                 output::Markdown { page, url, selector }.execute(sink)

--- a/crates/servo-fetch-cli/src/exit.rs
+++ b/crates/servo-fetch-cli/src/exit.rs
@@ -1,8 +1,10 @@
 //! Process exit lifecycle.
 
-use std::io::Write as _;
+use std::io::{self, Write as _};
 
-pub(crate) fn exit_code(result: anyhow::Result<()>) -> i32 {
+use anyhow::{Error, Result};
+
+pub(crate) fn exit_code(result: Result<()>) -> i32 {
     match result {
         Ok(()) => 0,
         Err(err) if is_broken_pipe(&err) => 0,
@@ -13,19 +15,19 @@ pub(crate) fn exit_code(result: anyhow::Result<()>) -> i32 {
     }
 }
 
-fn is_broken_pipe(err: &anyhow::Error) -> bool {
+fn is_broken_pipe(err: &Error) -> bool {
     err.chain().any(|cause| {
         cause
-            .downcast_ref::<std::io::Error>()
-            .is_some_and(|e| e.kind() == std::io::ErrorKind::BrokenPipe)
+            .downcast_ref::<io::Error>()
+            .is_some_and(|e| e.kind() == io::ErrorKind::BrokenPipe)
     })
 }
 
 /// Flush stdio and terminate via `libc::_exit`, skipping SpiderMonkey's
 /// static destructors that race on `pthread_mutex_destroy`.
 pub(crate) fn flush_and_exit(code: i32) -> ! {
-    let _ = std::io::stdout().flush();
-    let _ = std::io::stderr().flush();
+    let _ = io::stdout().flush();
+    let _ = io::stderr().flush();
     #[allow(unsafe_code)]
     unsafe {
         libc::_exit(code);
@@ -43,8 +45,8 @@ mod tests {
 
     #[test]
     fn broken_pipe_is_zero() {
-        let err = std::io::Error::new(std::io::ErrorKind::BrokenPipe, "pipe");
-        assert_eq!(exit_code(Err(anyhow::Error::new(err))), 0);
+        let err = io::Error::new(io::ErrorKind::BrokenPipe, "pipe");
+        assert_eq!(exit_code(Err(Error::new(err))), 0);
     }
 
     #[test]
@@ -54,8 +56,8 @@ mod tests {
 
     #[test]
     fn broken_pipe_detected_through_chain() {
-        let io = std::io::Error::new(std::io::ErrorKind::BrokenPipe, "pipe");
-        let err = anyhow::Error::new(io).context("while writing");
+        let io = io::Error::new(io::ErrorKind::BrokenPipe, "pipe");
+        let err = Error::new(io).context("while writing");
         assert!(is_broken_pipe(&err));
     }
 

--- a/crates/servo-fetch-cli/src/logging.rs
+++ b/crates/servo-fetch-cli/src/logging.rs
@@ -1,6 +1,6 @@
 //! Logging initialization.
 
-use std::io::IsTerminal as _;
+use std::io::{self, IsTerminal as _};
 
 use tracing_subscriber::EnvFilter;
 use tracing_subscriber::fmt::time::Uptime;
@@ -53,10 +53,10 @@ pub(crate) fn init(verbosity: Verbosity) {
         )
         .from_env_lossy();
 
-    let ansi = std::io::stderr().is_terminal() && std::env::var_os("NO_COLOR").is_none_or(|v| v.is_empty());
+    let ansi = io::stderr().is_terminal() && std::env::var_os("NO_COLOR").is_none_or(|v| v.is_empty());
     let builder = tracing_subscriber::fmt()
         .with_env_filter(filter)
-        .with_writer(std::io::stderr)
+        .with_writer(io::stderr)
         .with_ansi(ansi)
         .with_target(verbosity.detailed());
 

--- a/crates/servo-fetch-cli/src/mcp.rs
+++ b/crates/servo-fetch-cli/src/mcp.rs
@@ -4,10 +4,11 @@ mod params;
 mod server;
 mod tools;
 
+use std::net::SocketAddr;
+
 use rmcp::ServiceExt as _;
-use rmcp::transport::streamable_http_server::{
-    StreamableHttpServerConfig, StreamableHttpService, session::local::LocalSessionManager,
-};
+use rmcp::transport::streamable_http_server::session::local::LocalSessionManager;
+use rmcp::transport::streamable_http_server::{StreamableHttpServerConfig, StreamableHttpService};
 
 /// Start the MCP server on stdio or Streamable HTTP transport.
 pub(crate) async fn run(port: Option<u16>) -> anyhow::Result<()> {
@@ -38,7 +39,7 @@ async fn run_http(port: u16) -> anyhow::Result<()> {
     );
 
     let router = axum::Router::new().nest_service("/mcp", service);
-    let addr = std::net::SocketAddr::from(([127, 0, 0, 1], port));
+    let addr = SocketAddr::from(([127, 0, 0, 1], port));
     let listener = tokio::net::TcpListener::bind(addr).await?;
     tracing::info!(%addr, "MCP server listening");
 

--- a/crates/servo-fetch-cli/src/mcp/server.rs
+++ b/crates/servo-fetch-cli/src/mcp/server.rs
@@ -1,5 +1,7 @@
 //! MCP server handler — tool routing and server info.
 
+use std::fmt::Write as _;
+
 use rmcp::handler::server::router::tool::ToolRouter;
 use rmcp::handler::server::wrapper::Parameters;
 use rmcp::model::{CallToolResult, Content, ProtocolVersion, ServerCapabilities, ServerInfo};
@@ -130,7 +132,6 @@ impl ServoFetchMcp {
         if !page.console_messages.is_empty() {
             result.push_str("\n\n--- console output ---\n");
             for msg in &page.console_messages {
-                use std::fmt::Write as _;
                 let _ = writeln!(result, "[{:?}] {}", msg.level, msg.message);
             }
         }
@@ -273,8 +274,9 @@ impl ServerHandler for ServoFetchMcp {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use rmcp::ServerHandler;
+
+    use super::*;
 
     #[test]
     fn server_info_has_name_and_version() {

--- a/crates/servo-fetch-cli/src/mcp/tools.rs
+++ b/crates/servo-fetch-cli/src/mcp/tools.rs
@@ -4,11 +4,10 @@ use base64::Engine as _;
 use rmcp::ErrorData;
 use rmcp::model::{CallToolResult, Content};
 
-use crate::tools::{ToolError, ToolResult};
-
 pub(super) use crate::tools::{
     CrawlOptions as CrawlToolOptions, batch_fetch_pages, extract, fetch_js, fetch_page, paginate,
 };
+use crate::tools::{ToolError, ToolResult};
 
 pub(super) fn validated_url(url: &str) -> Result<String, ErrorData> {
     crate::tools::validated_url(url).map_err(ErrorData::from)

--- a/crates/servo-fetch-cli/src/output.rs
+++ b/crates/servo-fetch-cli/src/output.rs
@@ -1,11 +1,12 @@
 //! Output sinks.
 
+use std::fmt::{self, Write as _};
 use std::fs;
-use std::io::Write as _;
+use std::io::{self, Write as _};
 use std::path::Path;
 
 use anyhow::{Result, bail};
-
+use serde_json::Value;
 use servo_fetch::Page;
 
 /// File extension for sink-emitted content.
@@ -28,8 +29,8 @@ impl Ext {
     }
 }
 
-impl std::fmt::Display for Ext {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for Ext {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self.as_str())
     }
 }
@@ -72,7 +73,7 @@ impl<'a> Sink<'a> {
         let needs_nl = ensure_newline && !sanitized.ends_with('\n');
         match self {
             Self::Stdout => {
-                let mut out = std::io::stdout().lock();
+                let mut out = io::stdout().lock();
                 out.write_all(sanitized.as_bytes())?;
                 if needs_nl {
                     out.write_all(b"\n")?;
@@ -140,7 +141,7 @@ impl Json<'_> {
     /// Emit a single-line NDJSON record for batch output.
     pub(crate) fn execute_compact(&self, sink: Sink<'_>) -> Result<()> {
         let pretty = self.render()?;
-        let line = serde_json::from_str::<serde_json::Value>(&pretty)
+        let line = serde_json::from_str::<Value>(&pretty)
             .ok()
             .and_then(|v| serde_json::to_string(&v).ok())
             .unwrap_or(pretty);
@@ -197,10 +198,10 @@ impl Extracted<'_> {
         sink.writeln(self.url, Ext::Json, &serde_json::to_string(&self.payload())?)
     }
 
-    fn payload(&self) -> serde_json::Value {
+    fn payload(&self) -> Value {
         serde_json::json!({
             "url": self.url,
-            "extracted": self.page.extracted.as_ref().unwrap_or(&serde_json::Value::Null),
+            "extracted": self.page.extracted.as_ref().unwrap_or(&Value::Null),
         })
     }
 }
@@ -217,7 +218,6 @@ fn slug_from_url(url: &str, ext: Ext) -> String {
     let stripped = url::Url::parse(url).ok().map_or_else(
         || url.to_owned(),
         |u| {
-            use std::fmt::Write as _;
             let mut s = u.host_str().unwrap_or("").to_owned();
             if let Some(p) = u.port() {
                 let _ = write!(s, ":{p}");

--- a/crates/servo-fetch-cli/src/progress.rs
+++ b/crates/servo-fetch-cli/src/progress.rs
@@ -1,6 +1,6 @@
 //! Terminal progress UI written directly to stderr.
 
-use std::io::{IsTerminal as _, Write as _};
+use std::io::{self, IsTerminal as _, Write as _};
 
 /// TTY-aware reporter for long-running commands.
 pub(crate) struct Progress {
@@ -10,19 +10,19 @@ pub(crate) struct Progress {
 impl Progress {
     pub(crate) fn new() -> Self {
         Self {
-            is_tty: std::io::stderr().is_terminal(),
+            is_tty: io::stderr().is_terminal(),
         }
     }
 
     pub(crate) fn header(&self, msg: &str) {
         if self.is_tty {
-            let _ = writeln!(std::io::stderr(), "{msg}");
+            let _ = writeln!(io::stderr(), "{msg}");
         }
     }
 
     pub(crate) fn ticker(&self, msg: &str) {
         if self.is_tty {
-            let mut out = std::io::stderr();
+            let mut out = io::stderr();
             let _ = write!(out, "{msg}");
             let _ = out.flush();
         }
@@ -30,7 +30,7 @@ impl Progress {
 
     pub(crate) fn clear(&self) {
         if self.is_tty {
-            let mut err = std::io::stderr();
+            let mut err = io::stderr();
             let _ = write!(err, "\r\x1b[2K");
             let _ = err.flush();
         }
@@ -42,8 +42,8 @@ impl Progress {
         }
         let mark = if ok { "✓" } else { "✗" };
         let _ = match total {
-            Some(total) => writeln!(std::io::stderr(), "[{index}/{total}] {url} {mark}"),
-            None => writeln!(std::io::stderr(), "[{index}] {url} {mark}"),
+            Some(total) => writeln!(io::stderr(), "[{index}/{total}] {url} {mark}"),
+            None => writeln!(io::stderr(), "[{index}] {url} {mark}"),
         };
     }
 }

--- a/crates/servo-fetch-cli/src/serve.rs
+++ b/crates/servo-fetch-cli/src/serve.rs
@@ -71,11 +71,11 @@ async fn shutdown_signal() {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
     use axum::body::{Body, to_bytes};
     use axum::http::{Request, StatusCode};
     use tower::ServiceExt as _;
+
+    use super::*;
 
     async fn send(req: Request<Body>) -> (StatusCode, String, String) {
         let res = router().oneshot(req).await.unwrap();

--- a/crates/servo-fetch-cli/src/serve/handlers.rs
+++ b/crates/servo-fetch-cli/src/serve/handlers.rs
@@ -5,8 +5,6 @@ use axum::Json as AxumJson;
 use axum::http::{HeaderValue, StatusCode, header};
 use axum::response::IntoResponse;
 
-use crate::tools;
-
 use super::error::ApiError;
 use super::extract::Json;
 use super::params::{
@@ -14,6 +12,7 @@ use super::params::{
     ExecuteJsResponse, FetchRequest, FetchResponse, Format, HealthResponse, MapRequest, MapResponse, ScreenshotRequest,
     VersionResponse,
 };
+use crate::tools;
 
 const MAX_TIMEOUT_SECS: u64 = 300;
 const MAX_SETTLE_MS: u64 = 10_000;

--- a/crates/servo-fetch-cli/src/tools/common.rs
+++ b/crates/servo-fetch-cli/src/tools/common.rs
@@ -2,10 +2,9 @@
 
 use std::sync::OnceLock;
 
-use tokio::sync::Semaphore;
-
 use servo_fetch::Page;
 use servo_fetch::extract::{self, ExtractInput};
+use tokio::sync::Semaphore;
 
 use super::error::{ToolError, ToolResult};
 

--- a/crates/servo-fetch-cli/src/tools/fetch.rs
+++ b/crates/servo-fetch-cli/src/tools/fetch.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 
 use servo_fetch::extract::{self, ExtractInput};
 use servo_fetch::{FetchOptions, Page};
+use tokio::task::spawn_blocking;
 
 use super::common::{fetch_semaphore, paginate};
 use super::error::{ToolError, ToolResult};
@@ -14,7 +15,7 @@ pub(crate) async fn fetch_page(url: &str, timeout: u64, settle_ms: u64) -> ToolR
         .await
         .map_err(|e| ToolError::internal(format!("fetch semaphore closed: {e}")))?;
     let url = url.to_string();
-    tokio::task::spawn_blocking(move || {
+    spawn_blocking(move || {
         servo_fetch::fetch(
             FetchOptions::new(&url)
                 .timeout(Duration::from_secs(timeout))
@@ -33,7 +34,7 @@ pub(crate) async fn fetch_js(url: &str, expression: &str, timeout: u64, settle_m
         .map_err(|e| ToolError::internal(format!("fetch semaphore closed: {e}")))?;
     let url = url.to_string();
     let expression = expression.to_string();
-    tokio::task::spawn_blocking(move || {
+    spawn_blocking(move || {
         servo_fetch::fetch(
             FetchOptions::javascript(&url, &expression)
                 .timeout(Duration::from_secs(timeout))
@@ -51,7 +52,7 @@ pub(crate) async fn fetch_screenshot(url: &str, full_page: bool, timeout: u64, s
         .await
         .map_err(|e| ToolError::internal(format!("fetch semaphore closed: {e}")))?;
     let url = url.to_string();
-    tokio::task::spawn_blocking(move || {
+    spawn_blocking(move || {
         servo_fetch::fetch(
             FetchOptions::screenshot(&url, full_page)
                 .timeout(Duration::from_secs(timeout))
@@ -78,7 +79,7 @@ pub(crate) async fn batch_fetch_pages(
         let tx = tx.clone();
         let url = url.clone();
         let selector = selector.map(String::from);
-        tokio::task::spawn_blocking(move || {
+        spawn_blocking(move || {
             let text = fetch_and_render(&url, timeout, settle_ms, json, selector.as_deref(), max_len);
             let _ = tx.blocking_send((url, text));
             drop(permit);

--- a/crates/servo-fetch-cli/tests/cli.rs
+++ b/crates/servo-fetch-cli/tests/cli.rs
@@ -1,9 +1,12 @@
 //! CLI integration tests.
 
+use std::fs;
 use std::future::Future;
+use std::str::from_utf8;
 
 use assert_cmd::Command;
 use predicates::prelude::*;
+use serde_json::Value;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -116,7 +119,7 @@ fn json_produces_valid_json() {
             .get_output()
             .stdout
             .clone();
-        let parsed: serde_json::Value = serde_json::from_slice(&output).expect("valid JSON");
+        let parsed: Value = serde_json::from_slice(&output).expect("valid JSON");
         assert!(parsed.get("title").is_some());
     });
 }
@@ -151,7 +154,7 @@ fn screenshot_creates_file() {
             .mount(&s)
             .await;
         let dir = std::env::temp_dir().join("servo-fetch-e2e");
-        std::fs::create_dir_all(&dir).ok();
+        fs::create_dir_all(&dir).ok();
         let file = dir.join("test.png");
         servo_fetch()
             .args([
@@ -165,7 +168,7 @@ fn screenshot_creates_file() {
             .success();
         assert!(file.exists());
         assert!(file.metadata().unwrap().len() > 0);
-        std::fs::remove_file(&file).ok();
+        fs::remove_file(&file).ok();
     });
 }
 
@@ -203,12 +206,12 @@ fn crawl_produces_ndjson() {
             .get_output()
             .stdout
             .clone();
-        let lines: Vec<&str> = std::str::from_utf8(&output).unwrap().lines().collect();
+        let lines: Vec<&str> = from_utf8(&output).unwrap().lines().collect();
         assert!(lines.len() >= 2, "expected page + stats record, got: {lines:?}");
-        let page: serde_json::Value = serde_json::from_str(lines[0]).expect("valid NDJSON");
+        let page: Value = serde_json::from_str(lines[0]).expect("valid NDJSON");
         assert_eq!(page["type"], "page");
         assert!(page["fetched_at"].is_string(), "fetched_at must be present");
-        let stats: serde_json::Value = serde_json::from_str(lines.last().unwrap()).expect("valid stats NDJSON");
+        let stats: Value = serde_json::from_str(lines.last().unwrap()).expect("valid stats NDJSON");
         assert_eq!(stats["type"], "stats");
         assert!(stats["crawled"].as_u64().is_some_and(|n| n >= 1));
     });
@@ -250,7 +253,7 @@ fn crawl_selector_scopes_content() {
             .get_output()
             .stdout
             .clone();
-        let text = std::str::from_utf8(&output).unwrap();
+        let text = from_utf8(&output).unwrap();
         assert!(text.contains("Kept"), "selector should keep h1 text, got: {text}");
         assert!(
             !text.contains("Dropped paragraph"),
@@ -295,15 +298,14 @@ fn crawl_json_embeds_structured_content() {
             .get_output()
             .stdout
             .clone();
-        let line = std::str::from_utf8(&output)
+        let line = from_utf8(&output)
             .unwrap()
             .lines()
             .next()
             .expect("expected NDJSON line");
-        let outer: serde_json::Value = serde_json::from_str(line).expect("outer NDJSON must parse");
+        let outer: Value = serde_json::from_str(line).expect("outer NDJSON must parse");
         let content_str = outer["content"].as_str().expect("content must be a string");
-        let inner: serde_json::Value =
-            serde_json::from_str(content_str).expect("content must be structured JSON, not markdown");
+        let inner: Value = serde_json::from_str(content_str).expect("content must be structured JSON, not markdown");
         assert!(
             inner.get("title").is_some(),
             "inner JSON should have a 'title' field, got: {content_str}"
@@ -362,7 +364,7 @@ fn output_writes_single_file() {
             ])
             .assert()
             .success();
-        let body = std::fs::read_to_string(&file).expect("file written");
+        let body = fs::read_to_string(&file).expect("file written");
         assert!(body.contains("Direct"), "got: {body}");
     });
 }
@@ -390,13 +392,13 @@ fn output_dir_writes_single_file() {
             ])
             .assert()
             .success();
-        let entries: Vec<_> = std::fs::read_dir(dir.path())
+        let entries: Vec<_> = fs::read_dir(dir.path())
             .expect("dir exists")
             .filter_map(Result::ok)
             .filter(|e| e.path().extension().is_some_and(|ext| ext == "md"))
             .collect();
         assert_eq!(entries.len(), 1, "expected exactly 1 .md file");
-        let body = std::fs::read_to_string(entries[0].path()).unwrap();
+        let body = fs::read_to_string(entries[0].path()).unwrap();
         assert!(body.contains("Saved"), "got: {body}");
     });
 }
@@ -441,14 +443,14 @@ fn crawl_output_dir_writes_per_page_files() {
             .stdout
             .clone();
         assert!(output.is_empty(), "stdout should be silent in --output-dir mode");
-        let entries: Vec<_> = std::fs::read_dir(dir.path())
+        let entries: Vec<_> = fs::read_dir(dir.path())
             .expect("dir exists")
             .filter_map(Result::ok)
             .filter(|e| e.path().extension().is_some_and(|ext| ext == "json"))
             .collect();
         assert_eq!(entries.len(), 1, "expected exactly 1 .json file");
-        let line = std::fs::read_to_string(entries[0].path()).unwrap();
-        let record: serde_json::Value = serde_json::from_str(line.trim()).expect("valid JSON");
+        let line = fs::read_to_string(entries[0].path()).unwrap();
+        let record: Value = serde_json::from_str(line.trim()).expect("valid JSON");
         assert_eq!(record["type"], "page");
     });
 }

--- a/crates/servo-fetch-cli/tests/mcp.rs
+++ b/crates/servo-fetch-cli/tests/mcp.rs
@@ -2,6 +2,7 @@
 
 use rmcp::ServiceExt;
 use rmcp::transport::TokioChildProcess;
+use tokio::process::Command;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -9,7 +10,7 @@ mod common;
 use common::mock_page;
 
 async fn connect() -> rmcp::service::RunningService<rmcp::RoleClient, impl rmcp::service::Service<rmcp::RoleClient>> {
-    let mut cmd = tokio::process::Command::new(env!("CARGO_BIN_EXE_servo-fetch"));
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_servo-fetch"));
     cmd.arg("mcp");
     let transport = TokioChildProcess::new(cmd).unwrap();
     ().serve(transport).await.expect("MCP handshake failed")
@@ -17,7 +18,7 @@ async fn connect() -> rmcp::service::RunningService<rmcp::RoleClient, impl rmcp:
 
 async fn connect_loopback()
 -> rmcp::service::RunningService<rmcp::RoleClient, impl rmcp::service::Service<rmcp::RoleClient>> {
-    let mut cmd = tokio::process::Command::new(env!("CARGO_BIN_EXE_servo-fetch"));
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_servo-fetch"));
     cmd.args(["mcp", "--allow-private-addresses"]);
     let transport = TokioChildProcess::new(cmd).unwrap();
     ().serve(transport).await.expect("MCP handshake failed")

--- a/crates/servo-fetch/src/bridge.rs
+++ b/crates/servo-fetch/src/bridge.rs
@@ -3,19 +3,21 @@
 use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
 use std::rc::Rc;
-use std::sync::{Arc, Condvar, Mutex, OnceLock, mpsc};
+use std::sync::{Arc, Condvar, Mutex, OnceLock, PoisonError, mpsc};
 use std::time::{Duration, Instant};
+use std::{fmt, thread};
 
 use anyhow::{Result, anyhow};
 use dpi::PhysicalSize;
 use image::RgbaImage;
+use serde_json::Value;
 use servo::{
     ConsoleLogLevel, EventLoopWaker, JSValue, LoadStatus, NavigationRequest, Preferences, RenderingContext,
     ServoBuilder, SoftwareRenderingContext, UserContentManager, WebView, WebViewBuilder, WebViewDelegate, WebViewId,
 };
+use url::Url;
 
-use crate::layout;
-use crate::visibility;
+use crate::{layout, visibility};
 
 const JS_EVAL_TIMEOUT: Duration = Duration::from_secs(10);
 
@@ -49,19 +51,19 @@ pub(crate) struct WakeFlag {
 impl WakeFlag {
     /// Block up to `timeout` for a signal, then clear the flag atomically.
     fn wait_and_take(&self, timeout: Duration) -> bool {
-        let mut guard = self.flag.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        let mut guard = self.flag.lock().unwrap_or_else(PoisonError::into_inner);
         if !*guard {
             let (next, _) = self
                 .cv
                 .wait_timeout(guard, timeout)
-                .unwrap_or_else(std::sync::PoisonError::into_inner);
+                .unwrap_or_else(PoisonError::into_inner);
             guard = next;
         }
         std::mem::replace(&mut *guard, false)
     }
 
     fn signal(&self) {
-        *self.flag.lock().unwrap_or_else(std::sync::PoisonError::into_inner) = true;
+        *self.flag.lock().unwrap_or_else(PoisonError::into_inner) = true;
         self.cv.notify_all();
     }
 }
@@ -90,7 +92,7 @@ pub(crate) fn wait_for_wake(timeout: Duration) {
         if let Some(flag) = slot.borrow().as_ref() {
             flag.wait_and_take(timeout);
         } else {
-            std::thread::sleep(timeout);
+            thread::sleep(timeout);
         }
     });
 }
@@ -144,8 +146,8 @@ pub(crate) enum ConsoleLevel {
     Trace,
 }
 
-impl std::fmt::Display for ConsoleLevel {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for ConsoleLevel {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Log => f.write_str("log"),
             Self::Debug => f.write_str("debug"),
@@ -332,7 +334,7 @@ pub(crate) fn fetch_page(opts: FetchOptions<'_>) -> Result<ServoPage> {
         let wake = Arc::new(WakeFlag::default());
         let wake_for_thread = wake.clone();
         let policy = pending_policy();
-        std::thread::Builder::new()
+        thread::Builder::new()
             .name("servo-engine".into())
             .spawn(move || servo_thread(rx, wake_for_thread, policy))
             .expect("failed to spawn servo thread");
@@ -484,7 +486,7 @@ fn start_fetch(
     ucm: &Rc<UserContentManager>,
     req: FetchRequest,
 ) -> std::result::Result<PendingFetch, (FetchRequest, anyhow::Error)> {
-    let parsed_url = match url::Url::parse(&req.url) {
+    let parsed_url = match Url::parse(&req.url) {
         Ok(u) => u,
         Err(e) => return Err((req, anyhow!("bad url: {e}"))),
     };
@@ -629,7 +631,7 @@ fn build_servo(waker: FlagWaker) -> Result<(Rc<SoftwareRenderingContext>, servo:
 }
 
 fn create_noise_removal_stylesheet() -> servo::user_contents::UserStyleSheet {
-    let url = url::Url::parse("servo-fetch://user-stylesheet/noise-removal").expect("static URL is well-formed");
+    let url = Url::parse("servo-fetch://user-stylesheet/noise-removal").expect("static URL is well-formed");
     servo::user_contents::UserStyleSheet::new(NOISE_REMOVAL_CSS.to_string(), url)
 }
 
@@ -678,31 +680,31 @@ pub(crate) fn eval_js(servo: &servo::Servo, webview: &WebView, script: &str) -> 
     }
 }
 
-fn jsvalue_to_json(val: &JSValue) -> Result<serde_json::Value> {
+fn jsvalue_to_json(val: &JSValue) -> Result<Value> {
     const MAX_DEPTH: u8 = 64;
-    fn convert(val: &JSValue, depth: u8) -> Result<serde_json::Value> {
+    fn convert(val: &JSValue, depth: u8) -> Result<Value> {
         if depth >= MAX_DEPTH {
             return Err(anyhow!("JS value nested too deeply (>{MAX_DEPTH} levels)"));
         }
         Ok(match val {
-            JSValue::Undefined | JSValue::Null => serde_json::Value::Null,
-            JSValue::Boolean(b) => serde_json::Value::Bool(*b),
+            JSValue::Undefined | JSValue::Null => Value::Null,
+            JSValue::Boolean(b) => Value::Bool(*b),
             JSValue::Number(n) => serde_json::json!(n),
             JSValue::String(s)
             | JSValue::Element(s)
             | JSValue::ShadowRoot(s)
             | JSValue::Frame(s)
-            | JSValue::Window(s) => serde_json::Value::String(s.clone()),
+            | JSValue::Window(s) => Value::String(s.clone()),
             JSValue::Array(arr) => {
                 let items: Result<Vec<_>> = arr.iter().map(|v| convert(v, depth + 1)).collect();
-                serde_json::Value::Array(items?)
+                Value::Array(items?)
             }
             JSValue::Object(map) => {
                 let entries: Result<serde_json::Map<_, _>> = map
                     .iter()
                     .map(|(k, v)| Ok((k.clone(), convert(v, depth + 1)?)))
                     .collect();
-                serde_json::Value::Object(entries?)
+                Value::Object(entries?)
             }
         })
     }
@@ -756,8 +758,8 @@ mod tests {
 
     #[test]
     fn jsvalue_to_json_primitives() {
-        assert_eq!(jsvalue_to_json(&JSValue::Null).unwrap(), serde_json::Value::Null);
-        assert_eq!(jsvalue_to_json(&JSValue::Undefined).unwrap(), serde_json::Value::Null);
+        assert_eq!(jsvalue_to_json(&JSValue::Null).unwrap(), Value::Null);
+        assert_eq!(jsvalue_to_json(&JSValue::Undefined).unwrap(), Value::Null);
         assert_eq!(
             jsvalue_to_json(&JSValue::Boolean(true)).unwrap(),
             serde_json::json!(true)
@@ -792,8 +794,8 @@ mod tests {
     fn wake_flag_signal_releases_waiter() {
         let wake = Arc::new(WakeFlag::default());
         let w = wake.clone();
-        let handle = std::thread::spawn(move || w.wait_and_take(Duration::from_secs(5)));
-        std::thread::sleep(Duration::from_millis(10));
+        let handle = thread::spawn(move || w.wait_and_take(Duration::from_secs(5)));
+        thread::sleep(Duration::from_millis(10));
         wake.signal();
         assert!(handle.join().unwrap(), "waiter should observe the signal");
     }

--- a/crates/servo-fetch/src/crawl.rs
+++ b/crates/servo-fetch/src/crawl.rs
@@ -1,10 +1,11 @@
 //! Site crawling — BFS link traversal with scope, robots.txt, and rate limiting.
 
 use std::collections::{HashSet, VecDeque};
-use std::hash::{Hash, Hasher};
+use std::fmt;
+use std::hash::{DefaultHasher, Hash, Hasher};
 use std::time::{Duration, SystemTime};
 
-use tokio::task::JoinSet;
+use tokio::task::{JoinSet, spawn_blocking};
 use tokio::time::{MissedTickBehavior, interval};
 use url::Url;
 
@@ -152,8 +153,8 @@ pub struct CrawlError {
     pub message: String,
 }
 
-impl std::fmt::Display for CrawlError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for CrawlError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(&self.message)
     }
 }
@@ -218,7 +219,7 @@ pub fn crawl_each(opts: CrawlOptions, mut on_page: impl FnMut(&CrawlResult)) -> 
     net::ensure_crypto_provider();
     let plan = build_crawl_plan(&opts)?;
     crate::runtime::block_on(async {
-        let robots = tokio::task::spawn_blocking({
+        let robots = spawn_blocking({
             let seed = plan.seed.clone();
             let user_agent = plan.user_agent.clone();
             let timeout = Duration::from_secs(plan.timeout_secs);
@@ -336,7 +337,7 @@ impl Frontier {
     }
 
     fn is_duplicate_content(&mut self, content: &str) -> bool {
-        let mut h = std::hash::DefaultHasher::new();
+        let mut h = DefaultHasher::new();
         content.hash(&mut h);
         !self.content_hashes.insert(h.finish())
     }
@@ -564,9 +565,10 @@ fn error_result(url: &Url, depth: usize, error: String, fetched_at: SystemTime) 
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::collections::HashMap;
     use std::sync::Arc;
+
+    use super::*;
 
     #[test]
     fn crawl_options_defaults() {
@@ -641,7 +643,7 @@ mod tests {
     }
 
     fn page(links: &[&str]) -> String {
-        use std::fmt::Write;
+        use std::fmt::Write as _;
         let mut anchors = String::new();
         for l in links {
             write!(anchors, r#"<a href="{l}">link</a>"#).unwrap();

--- a/crates/servo-fetch/src/error.rs
+++ b/crates/servo-fetch/src/error.rs
@@ -1,5 +1,6 @@
 //! Error types.
 
+use std::fmt;
 use std::time::Duration;
 
 /// A specialized `Result` type for servo-fetch.
@@ -100,8 +101,8 @@ pub(crate) enum UrlError {
     PrivateAddress(String),
 }
 
-impl std::fmt::Display for UrlError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for UrlError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Invalid(reason) => f.write_str(reason),
             Self::PrivateAddress(host) => {

--- a/crates/servo-fetch/src/extract.rs
+++ b/crates/servo-fetch/src/extract.rs
@@ -2,7 +2,7 @@
 
 use std::borrow::Cow;
 use std::collections::HashMap;
-use std::fmt::Write;
+use std::fmt::{self, Write as _};
 
 use dom_query::Document;
 use dom_smoothie::Readability;
@@ -19,7 +19,7 @@ use crate::visibility::{self, A11yIndex, VisibilityPolicy};
 pub enum ExtractError {
     /// Failed to format Markdown output.
     #[error("markdown formatting failed")]
-    Fmt(#[from] std::fmt::Error),
+    Fmt(#[from] fmt::Error),
     /// Failed to serialize JSON output.
     #[error("JSON serialization failed")]
     Json(#[from] serde_json::Error),

--- a/crates/servo-fetch/src/fetch.rs
+++ b/crates/servo-fetch/src/fetch.rs
@@ -1,9 +1,11 @@
 //! Single-page fetching and rendered content extraction.
 
 use std::collections::HashMap;
+use std::fmt;
 use std::sync::Arc;
 use std::time::Duration;
 
+use serde_json::Value;
 use servo::accesskit::{Node, NodeId};
 
 use crate::error::Error;
@@ -35,7 +37,7 @@ pub struct Page {
     pub accessibility_tree: Option<String>,
     /// Structured data extracted via [`FetchOptions::schema`].
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub extracted: Option<serde_json::Value>,
+    pub extracted: Option<Value>,
     /// PNG-encoded screenshot bytes — read via [`Page::screenshot_png`].
     #[serde(skip)]
     screenshot_png: Option<Vec<u8>>,
@@ -180,8 +182,8 @@ impl ConsoleLevel {
     }
 }
 
-impl std::fmt::Display for ConsoleLevel {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for ConsoleLevel {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.pad(self.as_str())
     }
 }
@@ -420,7 +422,7 @@ mod tests {
             ..Page::default()
         };
         let json = page.extract_json().unwrap();
-        let _: serde_json::Value = serde_json::from_str(&json).expect("valid JSON");
+        let _: Value = serde_json::from_str(&json).expect("valid JSON");
     }
 
     #[test]
@@ -449,7 +451,7 @@ mod tests {
         let json = page
             .extract_json_with_selector("https://example.com/page", "article")
             .unwrap();
-        let parsed: serde_json::Value = serde_json::from_str(&json).expect("valid JSON");
+        let parsed: Value = serde_json::from_str(&json).expect("valid JSON");
         assert_eq!(parsed["url"].as_str(), Some("https://example.com/page"));
         assert!(parsed["text_content"].as_str().unwrap().contains("scoped"));
     }

--- a/crates/servo-fetch/src/map.rs
+++ b/crates/servo-fetch/src/map.rs
@@ -4,12 +4,12 @@ use std::collections::{HashSet, VecDeque};
 use std::io::Read as _;
 use std::time::{Duration, Instant};
 
+use tokio::task::spawn_blocking;
 use url::Url;
 
-use crate::bridge;
-use crate::net;
 use crate::robots::{RobotsPolicy, RobotsRules};
 use crate::scope::{is_same_site, matches_scope, normalize_url};
+use crate::{bridge, net};
 
 const MAP_SITEMAP_MAX_BYTES: u64 = 50 * 1024 * 1024;
 const MAP_SITEMAP_MAX_DECOMPRESSED: u64 = 10 * 1024 * 1024;
@@ -165,7 +165,7 @@ pub(crate) async fn run(opts: &MapConfig, mut on_url: impl FnMut(&MapEntry)) {
         let seed = opts.seed.clone();
         let user_agent = opts.user_agent.clone();
         let timeout = opts.timeout;
-        tokio::task::spawn_blocking(move || RobotsRules::fetch(&seed, user_agent.as_deref(), timeout))
+        spawn_blocking(move || RobotsRules::fetch(&seed, user_agent.as_deref(), timeout))
             .await
             .unwrap_or(RobotsPolicy::Unreachable)
     };
@@ -194,7 +194,7 @@ pub(crate) async fn run(opts: &MapConfig, mut on_url: impl FnMut(&MapEntry)) {
 
         let body = {
             let agent = agent.clone();
-            tokio::task::spawn_blocking({
+            spawn_blocking({
                 let seed = opts.seed.clone();
                 move || fetch_sitemap(&agent, &sitemap_url, &seed)
             })
@@ -229,10 +229,7 @@ pub(crate) async fn run(opts: &MapConfig, mut on_url: impl FnMut(&MapEntry)) {
         let html = {
             let agent = agent.clone();
             let seed = opts.seed.clone();
-            tokio::task::spawn_blocking(move || fetch_html(&agent, &seed))
-                .await
-                .ok()
-                .flatten()
+            spawn_blocking(move || fetch_html(&agent, &seed)).await.ok().flatten()
         };
         if let Some(html) = html {
             for link in extract_links(&html, &opts.seed) {
@@ -760,13 +757,16 @@ mod tests {
     }
 
     mod integration {
-        use crate::map::{
-            MapConfig, MapEntry, build_agent, extract_links, fetch_html, fetch_sitemap, parse_sitemap, run,
-        };
         use std::time::Duration;
+
+        use tokio::task::spawn_blocking;
         use url::Url;
         use wiremock::matchers::{method, path};
         use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        use crate::map::{
+            MapConfig, MapEntry, build_agent, extract_links, fetch_html, fetch_sitemap, parse_sitemap, run,
+        };
 
         #[tokio::test]
         async fn fetch_sitemap_parses_urlset() {
@@ -780,9 +780,7 @@ mod tests {
 
             let agent = build_agent("test/1.0", Duration::from_secs(5));
             let url = Url::parse(&format!("{}/sitemap.xml", server.uri())).unwrap();
-            let body = tokio::task::spawn_blocking(move || fetch_sitemap(&agent, &url, &url))
-                .await
-                .unwrap();
+            let body = spawn_blocking(move || fetch_sitemap(&agent, &url, &url)).await.unwrap();
 
             let entries = parse_sitemap(&body.unwrap());
             assert_eq!(entries.len(), 1);
@@ -802,9 +800,7 @@ mod tests {
 
             let agent = build_agent("test/1.0", Duration::from_secs(5));
             let url = Url::parse(&format!("{}/sitemap.xml", server.uri())).unwrap();
-            let body = tokio::task::spawn_blocking(move || fetch_sitemap(&agent, &url, &url))
-                .await
-                .unwrap();
+            let body = spawn_blocking(move || fetch_sitemap(&agent, &url, &url)).await.unwrap();
 
             assert!(body.is_none());
         }
@@ -820,18 +816,17 @@ mod tests {
 
             let agent = build_agent("test/1.0", Duration::from_secs(5));
             let url = Url::parse(&format!("{}/sitemap.xml", server.uri())).unwrap();
-            let body = tokio::task::spawn_blocking(move || fetch_sitemap(&agent, &url, &url))
-                .await
-                .unwrap();
+            let body = spawn_blocking(move || fetch_sitemap(&agent, &url, &url)).await.unwrap();
 
             assert!(body.is_none());
         }
 
         #[tokio::test]
         async fn fetch_sitemap_handles_gzip() {
+            use std::io::Write as _;
+
             use flate2::Compression;
             use flate2::write::GzEncoder;
-            use std::io::Write;
 
             let server = MockServer::start().await;
             let xml = r#"<?xml version="1.0"?><urlset><url><loc>https://example.com/gz</loc></url></urlset>"#;
@@ -847,9 +842,7 @@ mod tests {
 
             let agent = build_agent("test/1.0", Duration::from_secs(5));
             let url = Url::parse(&format!("{}/sitemap.xml.gz", server.uri())).unwrap();
-            let body = tokio::task::spawn_blocking(move || fetch_sitemap(&agent, &url, &url))
-                .await
-                .unwrap();
+            let body = spawn_blocking(move || fetch_sitemap(&agent, &url, &url)).await.unwrap();
 
             let entries = parse_sitemap(&body.unwrap());
             assert_eq!(entries.len(), 1);
@@ -869,7 +862,7 @@ mod tests {
 
             let agent = build_agent("test/1.0", Duration::from_secs(5));
             let seed = Url::parse(&server.uri()).unwrap();
-            let html = tokio::task::spawn_blocking({
+            let html = spawn_blocking({
                 let seed = seed.clone();
                 move || fetch_html(&agent, &seed)
             })

--- a/crates/servo-fetch/src/net.rs
+++ b/crates/servo-fetch/src/net.rs
@@ -1,6 +1,9 @@
 //! Network address validation — blocks private, reserved, and special-purpose IPs.
 
+use std::net::{Ipv4Addr, Ipv6Addr};
 use std::sync::Once;
+
+use url::Url;
 
 use crate::error::{UrlError, map_url_error};
 
@@ -25,13 +28,13 @@ impl NetworkPolicy {
 
 /// Validate a URL for fetching. Rejects disallowed schemes and private addresses
 /// based on the policy set via [`crate::init`].
-pub fn validate_url(url: &str) -> crate::error::Result<url::Url> {
+pub fn validate_url(url: &str) -> crate::error::Result<Url> {
     validate_url_with_policy(url, crate::bridge::engine_policy()).map_err(|e| map_url_error(url, e))
 }
 
 /// Validate a URL against the given [`NetworkPolicy`].
-pub(crate) fn validate_url_with_policy(input: &str, policy: NetworkPolicy) -> Result<url::Url, UrlError> {
-    let mut parsed = url::Url::parse(input).map_err(|e| UrlError::Invalid(format!("invalid URL: {input}: {e}")))?;
+pub(crate) fn validate_url_with_policy(input: &str, policy: NetworkPolicy) -> Result<Url, UrlError> {
+    let mut parsed = Url::parse(input).map_err(|e| UrlError::Invalid(format!("invalid URL: {input}: {e}")))?;
     match parsed.scheme() {
         "http" | "https" => {}
         s => {
@@ -84,20 +87,17 @@ fn is_private_host(host: &str) -> bool {
     if BLOCKED_HOSTS.iter().any(|&b| host.eq_ignore_ascii_case(b)) {
         return true;
     }
-    if let Ok(ip) = host.parse::<std::net::Ipv4Addr>() {
+    if let Ok(ip) = host.parse::<Ipv4Addr>() {
         return is_private_ipv4(ip);
     }
-    if let Ok(ip) = host
-        .trim_matches(|c| c == '[' || c == ']')
-        .parse::<std::net::Ipv6Addr>()
-    {
+    if let Ok(ip) = host.trim_matches(|c| c == '[' || c == ']').parse::<Ipv6Addr>() {
         return is_private_ipv6(&ip);
     }
     false
 }
 
 /// IANA IPv4 Special-Purpose Address Registry (RFC 6890) + cloud metadata.
-fn is_private_ipv4(ip: std::net::Ipv4Addr) -> bool {
+fn is_private_ipv4(ip: Ipv4Addr) -> bool {
     const BLOCKED: &[(u32, u32)] = &[
         (0x0000_0000, 0xff00_0000), // 0.0.0.0/8        — RFC 1122 current network
         (0x0a00_0000, 0xff00_0000), // 10.0.0.0/8       — RFC 1918 private
@@ -121,7 +121,7 @@ fn is_private_ipv4(ip: std::net::Ipv4Addr) -> bool {
 }
 
 /// IANA IPv6 Special-Purpose Address Registry + IPv4-mapped/compatible.
-fn is_private_ipv6(ip: &std::net::Ipv6Addr) -> bool {
+fn is_private_ipv6(ip: &Ipv6Addr) -> bool {
     if let Some(v4) = ip.to_ipv4_mapped().or_else(|| ip.to_ipv4()) {
         return is_private_ipv4(v4);
     }

--- a/crates/servo-fetch/src/pdf.rs
+++ b/crates/servo-fetch/src/pdf.rs
@@ -89,9 +89,10 @@ mod tests {
     }
 
     mod integration {
-        use crate::pdf::probe;
         use wiremock::matchers::{method, path};
         use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        use crate::pdf::probe;
 
         async fn run_probe(url: String, timeout: u64) -> Option<Vec<u8>> {
             tokio::task::spawn_blocking(move || probe(&url, timeout)).await.unwrap()

--- a/crates/servo-fetch/src/robots.rs
+++ b/crates/servo-fetch/src/robots.rs
@@ -165,9 +165,10 @@ fn pattern_match_len(pattern: &str, path: &str) -> usize {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use wiremock::matchers::{header, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use super::*;
 
     #[test]
     fn robots_parse_allow_disallow() {

--- a/crates/servo-fetch/src/sanitize.rs
+++ b/crates/servo-fetch/src/sanitize.rs
@@ -1,6 +1,7 @@
 //! Strips terminal escape sequences and control characters from output.
 
 use std::borrow::Cow;
+use std::str::Chars;
 
 const CSI_MAX_LEN: u16 = 256;
 const STRING_SEQ_MAX_LEN: u16 = 4096;
@@ -46,7 +47,7 @@ fn is_bidi_control(c: char) -> bool {
     matches!(c, '\u{202A}'..='\u{202E}' | '\u{2066}'..='\u{2069}' | '\u{200F}' | '\u{200E}')
 }
 
-fn consume_csi(chars: &mut std::str::Chars<'_>) {
+fn consume_csi(chars: &mut Chars<'_>) {
     let mut n = 0u16;
     for c in chars.by_ref() {
         n += 1;
@@ -56,7 +57,7 @@ fn consume_csi(chars: &mut std::str::Chars<'_>) {
     }
 }
 
-fn consume_escape_sequence(chars: &mut std::str::Chars<'_>, c1_csi: bool) {
+fn consume_escape_sequence(chars: &mut Chars<'_>, c1_csi: bool) {
     if c1_csi {
         consume_csi(chars);
         return;

--- a/crates/servo-fetch/src/schema.rs
+++ b/crates/servo-fetch/src/schema.rs
@@ -287,8 +287,9 @@ fn extract_field(container: &Selection<'_>, field: &ExtractField) -> Value {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use serde_json::json;
+
+    use super::*;
 
     const PRODUCTS: &str = r#"
         <html><body>

--- a/crates/servo-fetch/src/sys/macos.rs
+++ b/crates/servo-fetch/src/sys/macos.rs
@@ -3,7 +3,8 @@
 use std::fs::File;
 use std::io::{self, BufRead, BufReader, Read, Write};
 use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
-use std::panic::AssertUnwindSafe;
+use std::panic::{AssertUnwindSafe, catch_unwind};
+use std::str::from_utf8;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread::{self, JoinHandle};
 
@@ -103,12 +104,12 @@ where
             Ok(_) => {}
             Err(_) => continue,
         }
-        let Ok(line) = std::str::from_utf8(&buf) else {
+        let Ok(line) = from_utf8(&buf) else {
             let _ = out.write_all(&buf);
             continue;
         };
         let trimmed = line.strip_suffix('\n').unwrap_or(line);
-        let suppress = std::panic::catch_unwind(AssertUnwindSafe(|| predicate(trimmed))).unwrap_or(false);
+        let suppress = catch_unwind(AssertUnwindSafe(|| predicate(trimmed))).unwrap_or(false);
         if !suppress {
             let _ = out.write_all(line.as_bytes());
         }
@@ -175,13 +176,13 @@ mod tests {
     #[test]
     fn drops_matching_lines() {
         let out = run(b"keep one\nDROP me\nkeep two\n", |line| line.contains("DROP"));
-        assert_eq!(std::str::from_utf8(&out).unwrap(), "keep one\nkeep two\n");
+        assert_eq!(from_utf8(&out).unwrap(), "keep one\nkeep two\n");
     }
 
     #[test]
     fn tolerates_predicate_panic() {
         let out = run(b"a\nb\nc\n", |_| panic!("boom"));
-        assert_eq!(std::str::from_utf8(&out).unwrap(), "a\nb\nc\n");
+        assert_eq!(from_utf8(&out).unwrap(), "a\nb\nc\n");
     }
 
     #[test]

--- a/crates/servo-fetch/src/visibility.rs
+++ b/crates/servo-fetch/src/visibility.rs
@@ -4,10 +4,10 @@ mod a11y;
 mod js;
 mod selectors;
 
+use bitflags::bitflags;
+
 pub(crate) use self::a11y::A11yIndex;
 pub(crate) use self::selectors::selectors_to_strip;
-
-use bitflags::bitflags;
 
 /// User stylesheet applied before render to enforce ARIA, HTML, and modal
 /// semantics so matched nodes never produce boxes.

--- a/crates/servo-fetch/src/visibility/a11y.rs
+++ b/crates/servo-fetch/src/visibility/a11y.rs
@@ -4,7 +4,8 @@ use std::collections::{BTreeSet, HashMap};
 
 use servo::accesskit::{Node, NodeId, Rect, Role};
 
-use super::{VisibilityFlags, VisibilityPolicy, selectors::make_selector};
+use super::selectors::make_selector;
+use super::{VisibilityFlags, VisibilityPolicy};
 
 /// Threshold matching common off-screen hide patterns.
 const OFFSCREEN_THRESHOLD_PX: f64 = 99_999.0;


### PR DESCRIPTION
## Summary

Enforce canonical Rust import organization across the workspace via nightly rustfmt.

## Related issues

N/A

## Test Plan

```bash
cargo +nightly fmt --all --check
cargo clippy --workspace --all-targets --no-deps -- -D warnings
cargo test --workspace -- --include-ignored
```

## Checklist

- [x] Ran `cargo +nightly fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
- [x] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed
- [x] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it