### PR TITLE
chore: introduce release-plz for automated release PRs

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,0 +1,32 @@
+name: Release-plz
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  release-plz-pr:
+    name: Release-plz PR
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    if: ${{ github.repository_owner == 'konippi' }}
+    permissions:
+      contents: write
+      pull-requests: write
+    concurrency:
+      group: release-plz-${{ github.ref }}
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: release-plz/action@4a08fbe6cb1bb0e4d066058e6efcf50f352db236 # v0.5.129
+        with:
+          command: release-pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: release-plz/action@4a08fbe6cb1bb0e4d066058e6efcf50f352db236 # v0.5.129
+      - uses: release-plz/action@064f4d1e36c843611ddf013be726beaa4ad804db # v0.5.129
         with:
           command: release-pr
         env:

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,14 @@
+[workspace]
+changelog_config = "cliff.toml"
+changelog_update = false
+publish = false
+git_tag_enable = false
+semver_check = false
+release_commits = "^(feat|fix|perf)[!(:]"
+pr_labels = ["release"]
+
+[[package]]
+name = "servo-fetch-cli"
+changelog_update = true
+changelog_path = "CHANGELOG.md"
+changelog_include = ["servo-fetch", "servo-fetch-python"]


### PR DESCRIPTION
## Summary

Introduces [release-plz](https://release-plz.dev/) to automate Release PR creation. When `feat:` / `fix:` / `perf:` commits land on `main`, release-plz opens (or refreshes) a single Release PR that bumps the workspace version and updates `CHANGELOG.md`. After merging, a manual `git tag vX.Y.Z` push triggers the existing `release.yml` / `release-python.yml` for the actual publishes.

## Test Plan

- `taplo check`: all clean

## Checklist

- [x] Ran `cargo +nightly fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
- [x] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed
- [x] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it