### PR TITLE
fix(changelog): support both release-plz and git-cliff CLI render contexts

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -5,7 +5,13 @@ header = """
 All notable changes to this project will be documented in this file.
 """
 body = """
-{%- macro remote_url() -%}https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}{%- endmacro -%}
+{%- macro remote_url() -%}
+{%- if remote.owner -%} {# release-plz specific variable #}
+https://github.com/{{ remote.owner }}/{{ remote.repo }}\
+{%- else -%}
+https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}\
+{%- endif -%}
+{% endmacro %}
 {% if version %}
 {% if previous.version %}\
 ## [{{ version | trim_start_matches(pat="v") }}]({{ self::remote_url() }}/compare/{{ previous.version }}..{{ version }}) - {{ timestamp | date(format="%Y-%m-%d") }}


### PR DESCRIPTION
## Summary

`cliff.toml`'s `remote_url()` macro uses `remote.github.owner`, which `git-cliff` CLI populates from `[remote.github]` but release-plz's embedded git-cliff does not.

## Related issues

Follow-up to #213.

## Test Plan

N/A

## Checklist

- [x] Ran `cargo +nightly fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
- [x] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed
- [x] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it