### PR TITLE
fix(cliff): apply taplo formatting

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -26,27 +26,27 @@ body = """
 sort_commits = "newest"
 tag_pattern = "v[0-9]+\\.[0-9]+\\.[0-9]+"
 commit_preprocessors = [
-    { pattern = '(?m)[ \t]+\(#\d+\)$', replace = "" },
+  { pattern = '(?m)[ \t]+\(#\d+\)$', replace = "" },
 ]
 commit_parsers = [
-    { message = "^chore: bump version", skip = true },
-    { message = "^chore: trigger", skip = true },
-    { message = "^chore\\(release\\)", skip = true },
-    { message = "^Merge pull request", skip = true },
-    { message = "^Merge branch", skip = true },
-    { message = "^feat", group = "<!-- 00 -->Features" },
-    { message = "^fix", group = "<!-- 01 -->Bug Fixes" },
-    { message = "^perf", group = "<!-- 02 -->Performance" },
-    { message = "^refactor", group = "<!-- 03 -->Refactor" },
-    { message = "^doc", group = "<!-- 04 -->Documentation" },
-    { message = "^test", group = "<!-- 05 -->Testing" },
-    { message = "^build", group = "<!-- 06 -->Build" },
-    { message = "^chore\\(ci\\)", group = "<!-- 07 -->CI" },
-    { message = "^ci", group = "<!-- 07 -->CI" },
-    { message = "^style", group = "<!-- 08 -->Styling" },
-    { message = "^chore\\(deps\\)", group = "<!-- 09 -->Dependencies" },
-    { message = "^chore", group = "<!-- 10 -->Miscellaneous" },
-    { message = "^revert", group = "<!-- 11 -->Revert" },
+  { message = "^chore: bump version", skip = true },
+  { message = "^chore: trigger", skip = true },
+  { message = "^chore\\(release\\)", skip = true },
+  { message = "^Merge pull request", skip = true },
+  { message = "^Merge branch", skip = true },
+  { message = "^feat", group = "<!-- 00 -->Features" },
+  { message = "^fix", group = "<!-- 01 -->Bug Fixes" },
+  { message = "^perf", group = "<!-- 02 -->Performance" },
+  { message = "^refactor", group = "<!-- 03 -->Refactor" },
+  { message = "^doc", group = "<!-- 04 -->Documentation" },
+  { message = "^test", group = "<!-- 05 -->Testing" },
+  { message = "^build", group = "<!-- 06 -->Build" },
+  { message = "^chore\\(ci\\)", group = "<!-- 07 -->CI" },
+  { message = "^ci", group = "<!-- 07 -->CI" },
+  { message = "^style", group = "<!-- 08 -->Styling" },
+  { message = "^chore\\(deps\\)", group = "<!-- 09 -->Dependencies" },
+  { message = "^chore", group = "<!-- 10 -->Miscellaneous" },
+  { message = "^revert", group = "<!-- 11 -->Revert" },
 ]
 
 [remote.github]


### PR DESCRIPTION
## Summary

Apply `taplo fmt` to `cliff.toml` so the file matches the formatter's expected indentation (4 spaces → 2 spaces inside `commit_preprocessors` and `commit_parsers` arrays).

## Related issues

Unblocks #218.

## Test Plan

- `taplo fmt --check` on the working tree before this commit: fails on `cliff.toml`
- `taplo fmt --check` after this commit: clean

## Checklist

- [x] Ran `cargo +nightly fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
- [x] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed
- [x] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it