### PR TITLE
fix(release): correct git-cliff-action version to v2.13.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
         id: git-cliff
         uses: orhun/git-cliff-action@f50e11560dce63f7c33227798f90b924471a88b5 # v4.8.0
         with:
-          version: "2.13.1"
+          version: "v2.13.1"
           args: --latest --strip header --github-repo ${{ github.repository }}
         env:
           OUTPUT: RELEASE_NOTES.md


### PR DESCRIPTION
## Summary

Add the missing `v` prefix to the `git-cliff-action` `version` input so the installer can resolve the release tag.

## Related issues

Unblocks the v0.11.1 release.

## Test Plan

N/A

## Checklist

- [x] Ran `cargo +nightly fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
- [x] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed
- [x] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it