### PR TITLE
fix(changelog): use preprocessor for PR links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,20 +6,20 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
-- *(cli)* Add -o/--output and --output-dir for file output
-- *(cli)* Unify output flags under --format
+- *(cli)* Add -o/--output and --output-dir for file output ([#207](https://github.com/konippi/servo-fetch/pull/207))
+- *(cli)* Unify output flags under --format ([#206](https://github.com/konippi/servo-fetch/pull/206))
 
 ### Bug Fixes
 
-- *(bridge)* Bail out on timeout to avoid Servo parser race
+- *(bridge)* Bail out on timeout to avoid Servo parser race ([#208](https://github.com/konippi/servo-fetch/pull/208))
 
 ### Refactor
 
-- *(test)* Run CLI tests in-process instead of spawning binary
+- *(test)* Run CLI tests in-process instead of spawning binary ([#211](https://github.com/konippi/servo-fetch/pull/211))
 
 ### Miscellaneous
 
-- Enforce canonical imports via pinned nightly rustfmt
+- Enforce canonical imports via pinned nightly rustfmt ([#210](https://github.com/konippi/servo-fetch/pull/210))
 
 ## [0.11.0](https://github.com/konippi/servo-fetch/compare/v0.10.1..v0.11.0) - 2026-05-21
 

--- a/cliff.toml
+++ b/cliff.toml
@@ -16,7 +16,7 @@ body = """
 ### {{ group | striptags | trim }}
 
 {% for commit in commits %}\
-- {% if commit.scope %}*({{ commit.scope }})* {% endif %}{% if commit.breaking %}[**breaking**] {% endif %}{{ commit.message | upper_first }}{% if commit.remote.pr_number %} ([#{{ commit.remote.pr_number }}]({{ self::remote_url() }}/pull/{{ commit.remote.pr_number }})){% endif %}
+- {% if commit.scope %}*({{ commit.scope }})* {% endif %}{% if commit.breaking %}[**breaking**] {% endif %}{{ commit.message | upper_first }}
 {% endfor %}\
 {% endfor %}
 {%- endif %}
@@ -26,11 +26,12 @@ body = """
 sort_commits = "newest"
 tag_pattern = "v[0-9]+\\.[0-9]+\\.[0-9]+"
 commit_preprocessors = [
-  { pattern = '(?m)[ \t]+\(#\d+\)$', replace = "" },
+  { pattern = '(?m)\(#([0-9]+)\)$', replace = '([#${1}](https://github.com/konippi/servo-fetch/pull/${1}))' },
 ]
 commit_parsers = [
   { message = "^chore: bump version", skip = true },
   { message = "^chore: trigger", skip = true },
+  { message = "^chore: release", skip = true },
   { message = "^chore\\(release\\)", skip = true },
   { message = "^Merge pull request", skip = true },
   { message = "^Merge branch", skip = true },


### PR DESCRIPTION
## Summary

release-plz embedded git-cliff does not populate `commit.remote.pr_number`, so the previous template-based PR link approach yielded empty links in the `[0.11.1]` CHANGELOG section. Switch to the release-plz canonical pattern (per [official docs](https://release-plz.dev/docs/config#the-commit_preprocessors-field)) of substituting `(#N)` to a markdown link directly in `commit_preprocessor`.

## Test Plan

Locally simulated.

## Checklist

- [ ] Ran `cargo +nightly fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
- [ ] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed
- [ ] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it