### PR TITLE
fix(cli): align package.metadata.binstall with release archive layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ sudo apt install -y libegl1 libfontconfig1 libfreetype6
 xvfb-run --auto-servernum servo-fetch "https://example.com"
 ```
 
-**Windows** — keep `servo-fetch.exe`, `libEGL.dll`, and `libGLESv2.dll` in the same directory.
+**Windows** — `cargo binstall` does not copy sidecar files ([cargo-binstall#353](https://github.com/cargo-bins/cargo-binstall/issues/353)), so the installed `servo-fetch.exe` fails at startup with a missing `libEGL.dll`. Download the `.zip` from [Releases](https://github.com/konippi/servo-fetch/releases) instead — it bundles `libEGL.dll` and `libGLESv2.dll`.
 
 **macOS** — no extra setup needed.
 

--- a/crates/servo-fetch-cli/Cargo.toml
+++ b/crates/servo-fetch-cli/Cargo.toml
@@ -61,6 +61,9 @@ wiremock = { workspace = true }
 workspace = true
 
 [package.metadata.binstall]
-pkg-url = "{ repo }/releases/download/v{ version }/servo-fetch-v{ version }-{ target }.tar.gz"
-pkg-fmt = "tgz"
-bin-dir = "servo-fetch"
+pkg-url = "{ repo }/releases/download/v{ version }/servo-fetch-v{ version }-{ target }{ archive-suffix }"
+bin-dir = "servo-fetch-v{ version }-{ target }/{ bin }{ binary-ext }"
+disabled-strategies = ["quick-install", "compile"]
+
+[package.metadata.binstall.overrides.x86_64-pc-windows-msvc]
+pkg-fmt = "zip"


### PR DESCRIPTION
## Summary

Fix `[package.metadata.binstall]` config in `servo-fetch-cli` so `cargo binstall servo-fetch-cli` actually works on Linux/macOS. Also added `disabled-strategies = ["quick-install", "compile"]` to prevent silent fallback to third-party mirrors or 30-minute source builds (servo dependency requires libclang + significant build time).

### Windows caveat

`cargo binstall` cannot copy sidecar files ([cargo-binstall#353](https://github.com/cargo-bins/cargo-binstall/issues/353)), so on Windows the binary installs but fails at startup with a missing `libEGL.dll`. The README install section now documents this and points Windows users to the bundled `.zip` from GitHub Releases.

## Test Plan

Local manifest dry-run, verified before commit against published v0.11.1 (host: aarch64-apple-darwin):

```bash
cargo binstall \
  --manifest-path crates/servo-fetch-cli \
  --no-confirm --dry-run \
  --strategies crate-meta-data \
  servo-fetch-cli
```

## Checklist

- [x] Ran `cargo +nightly fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
- [x] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed
- [x] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it