### PR TITLE
ci(release): drop obsolete untagged-* draft release workaround

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -70,36 +70,6 @@ jobs:
           command: release
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-      - name: Fetch new tags
-        if: steps.release-plz.outputs.releases_created == 'true'
-        run: git fetch --tags
-      - name: Fix untagged-* draft release
-        if: steps.release-plz.outputs.releases_created == 'true'
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          REPO: ${{ github.repository }}
-          STEPS_RELEASE_PLZ_OUTPUTS_RELEASES: ${{ steps.release-plz.outputs.releases }}
-        run: |
-          tag=$(echo "${STEPS_RELEASE_PLZ_OUTPUTS_RELEASES}" | jq -r '.[] | select(.package_name == "servo-fetch-cli") | .tag')
-          echo "Looking for untagged draft release to fix for tag: $tag"
-          release_id=""
-          for attempt in $(seq 1 10); do
-            release_id=$(gh api "repos/${REPO}/releases" \
-              | jq -r --arg tag "$tag" '.[] | select(.draft and (.tag_name | startswith("untagged-")) and (.name | contains($tag))) | .id' \
-              | head -1) || true
-            if [ -n "$release_id" ]; then
-              break
-            fi
-            echo "  Attempt $attempt/10: not found yet, retrying in 5s..."
-            sleep 5
-          done
-          if [ -n "$release_id" ]; then
-            echo "Fixing draft release $release_id: setting tag_name to $tag"
-            gh api "repos/${REPO}/releases/${release_id}" --method PATCH --field tag_name="$tag"
-          else
-            echo "::error::No untagged draft release found for $tag after 10 attempts"
-            exit 1
-          fi
       - id: tag
         if: steps.release-plz.outputs.releases_created == 'true'
         env:


### PR DESCRIPTION
## Summary

The `release-plz-release` job has a `Fix untagged-* draft release` step that is now actively breaking releases. It was added as a workaround for an older `release-plz/action` behavior that pushed the tag *after* creating the draft, leaving the draft with a placeholder `untagged-XXXX` `tag_name`. The step looped for 50s looking for such drafts and PATCHed their `tag_name` into shape.

## Related issues

Refs https://github.com/konippi/servo-fetch/actions/runs/26426470173.

## Test Plan

- `actionlint .github/workflows/*.yml` — exit 0 across all workflows
- `zizmor --persona=auditor .github/workflows/release-plz.yml`

End-to-end verification is the next push to `main`: it should produce a v0.11.2 GitHub release (assets + Docker image + crates.io + PyPI), all with `--draft=false` at the end.

## Checklist

- [x] Ran `cargo +nightly fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
- [x] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed
- [x] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it