### PR TITLE
ci(release): add workflow_dispatch trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 permissions: {}
 


### PR DESCRIPTION
## Summary

Add `workflow_dispatch:` to `release.yml` so the release pipeline can be re-fired manually without pushing a new commit to `main`. Useful whenever the orchestrator needs to be re-run on the current `main` HEAD — for example, after a release was aborted partway through and the relevant tag/draft were torn down.

## Related issues

Refs https://github.com/konippi/servo-fetch/actions/runs/26428890028 (failed v0.11.2 run that left the release half-baked)

## Test Plan

- `actionlint .github/workflows/release.yml` — exit 0.
-  `zizmor .github/workflows/release.yml` — 0 findings.

## Checklist

- [ ] Ran `cargo +nightly fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
- [ ] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed
- [ ] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it
