### PR TITLE
chore: add cargo aliases mirroring CI commands

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -7,3 +7,9 @@ rustflags = ["-C", "link-arg=/Brepro"]
 
 [env]
 MACOSX_DEPLOYMENT_TARGET = "13.0"
+
+[alias]
+lint = "clippy --workspace --locked --all-targets -- -D warnings"
+test-ci = "nextest run --workspace --locked --cargo-profile ci --profile ci"
+test-doc = "test --workspace --locked --profile ci --doc"
+test-e2e = "nextest run -p servo-fetch-cli --run-ignored only --locked --cargo-profile ci --profile ci-e2e"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,15 @@ cargo nextest run --workspace --profile ci                                   # U
 cargo nextest run -p servo-fetch-cli --run-ignored only --profile ci-e2e     # E2E, retries on flake
 ```
 
+Cargo aliases for exact CI parity (defined in `.cargo/config.toml`):
+
+```sh
+cargo lint        # cargo-clippy job
+cargo test-ci     # cargo-test job (unit/integration via nextest)
+cargo test-doc    # cargo-test job (doc tests)
+cargo test-e2e    # e2e job (Servo-backed, retries on flake)
+```
+
 Ignored tests require a working Servo environment. Servo uses `SoftwareRenderingContext` internally, so no X server is needed in CI (the apt install list in `release.yml` includes X11 libs for linking, not for runtime). If an `ignored` test fails locally, first retry; if it still fails, check whether the test hits the network or a site that requires `--settle`.
 
 ## Code conventions

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,15 @@ taplo fmt                                                   # Format TOML files 
 typos                                                       # Spell check
 ```
 
+For exact CI parity (with `--locked`, CI profile, etc.), use these cargo aliases:
+
+```sh
+cargo lint        # CI cargo-clippy
+cargo test-ci     # CI cargo-test (unit/integration)
+cargo test-doc    # CI cargo-test (doc)
+cargo test-e2e    # CI e2e (Servo-backed)
+```
+
 > Build/test run on stable. Format requires nightly rustfmt for unstable `imports_granularity` / `group_imports`; one-time: `rustup toolchain install nightly --component rustfmt --profile minimal`.
 
 ### Profiling


### PR DESCRIPTION
## Summary

Add cargo aliases mirroring the CI lint/test commands so contributors can reproduce them locally with one short command.

## Test Plan

- `cargo --list` recognises all four aliases.

## Checklist

- [x] Ran `cargo +nightly fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
- [x] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed
- [x] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it