### PR TITLE
feat(cli): replace --screenshot with --format png

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ cargo build
 ```sh
 cargo run -- "https://example.com"                          # Markdown output
 cargo run -- "https://example.com" --format json            # JSON output
-cargo run -- "https://example.com" --screenshot page.png    # Screenshot
+cargo run -- "https://example.com" --format png -o page.png # Screenshot
 cargo run -- "https://example.com" --js "document.title"    # JS execution
 cargo test                                                  # Run tests
 cargo test -- --ignored                                     # Run Servo+network tests (slow)

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ and a Python SDK.
 
 ```bash
 # CLI
-servo-fetch "https://example.com"                        # clean Markdown
-servo-fetch "https://example.com" --screenshot page.png  # PNG screenshot
+servo-fetch "https://example.com"                          # clean Markdown
+servo-fetch "https://example.com" --format png -o page.png # PNG screenshot
 ```
 
 ```rust
@@ -65,7 +65,7 @@ Methodology, three-axis breakdown, per-fixture F1, and raw JSON:
 ## Install
 
 | Interface | Install | Docs |
-|-----------|---------|------|
+| --------- | ------- | ---- |
 | **CLI** | `curl -fsSL https://raw.githubusercontent.com/konippi/servo-fetch/main/install.sh \| sh` | [CLI docs](crates/servo-fetch-cli/README.md) |
 | **Rust** | `cargo add servo-fetch` | [Library docs](crates/servo-fetch/README.md) |
 | **Python** | `pip install servo-fetch` | [Python docs](bindings/python/README.md) |
@@ -98,19 +98,19 @@ xvfb-run --auto-servernum servo-fetch "https://example.com"
 ### CLI
 
 ```bash
-servo-fetch "https://example.com"                        # Markdown (default)
-servo-fetch "https://example.com" --format json          # Structured JSON
-servo-fetch "https://example.com" --screenshot page.png  # PNG screenshot
-servo-fetch "https://example.com" --js "document.title"  # Run JavaScript
-servo-fetch "https://example.com" --schema schema.json   # Schema-driven JSON
-servo-fetch URL1 URL2 URL3                               # Parallel batch
-servo-fetch "https://example.com" --output page.md       # Save to a single file
-servo-fetch URL1 URL2 --output-dir ./out/                # Save each URL to its own file
-servo-fetch crawl "https://docs.example.com" --limit 20  # Crawl a site
-servo-fetch crawl URL --output-dir ./pages/              # Save each crawled page to its own file
-servo-fetch map "https://example.com"                    # Discover URLs via sitemap
-servo-fetch mcp                                          # MCP server (stdio)
-servo-fetch serve                                        # HTTP API server
+servo-fetch "https://example.com"                          # Markdown (default)
+servo-fetch "https://example.com" --format json            # Structured JSON
+servo-fetch "https://example.com" --format png -o page.png # PNG screenshot
+servo-fetch "https://example.com" --js "document.title"    # Run JavaScript
+servo-fetch "https://example.com" --schema schema.json     # Schema-driven JSON
+servo-fetch URL1 URL2 URL3                                 # Parallel batch
+servo-fetch "https://example.com" --output page.md         # Save to a single file
+servo-fetch URL1 URL2 --output-dir ./out/                  # Save each URL to its own file
+servo-fetch crawl "https://docs.example.com" --limit 20    # Crawl a site
+servo-fetch crawl URL --output-dir ./pages/                # Save each crawled page to its own file
+servo-fetch map "https://example.com"                      # Discover URLs via sitemap
+servo-fetch mcp                                            # MCP server (stdio)
+servo-fetch serve                                          # HTTP API server
 ```
 
 Full CLI reference → [`servo-fetch-cli`](crates/servo-fetch-cli/README.md)

--- a/crates/servo-fetch-cli/README.md
+++ b/crates/servo-fetch-cli/README.md
@@ -49,8 +49,10 @@ servo-fetch URL1 URL2 --output-dir ./out/      # One file per URL (auto-created)
 ### Screenshots
 
 ```bash
-servo-fetch "https://example.com" --screenshot page.png
-servo-fetch "https://example.com" --screenshot full.png --full-page
+servo-fetch "https://example.com" --format png -o page.png
+servo-fetch "https://example.com" --format png --full-page -o full.png
+servo-fetch "https://example.com" --format png | chafa            # pipe to terminal renderer
+servo-fetch "https://example.com" --format png -o -               # stdout (explicit)
 ```
 
 ### JavaScript execution
@@ -153,8 +155,8 @@ Self-contained `/health` probe for any orchestrator that runs a command and insp
 | Flag | Description |
 | ---- | ----------- |
 | `--format json` | Structured JSON output (NDJSON for multiple URLs) |
-| `--screenshot <FILE>` | Save PNG screenshot |
-| `--full-page` | Capture full scrollable page (requires `--screenshot`) |
+| `--format png` | PNG screenshot of the rendered page (single URL only) |
+| `--full-page` | Capture full scrollable page (requires `--format png`) |
 | `--js <EXPR>` | Execute JavaScript and print result |
 | `--selector <CSS>` | Extract specific section by CSS selector |
 | `--format html\|text` | Raw HTML or plain text output |

--- a/crates/servo-fetch-cli/src/cli.rs
+++ b/crates/servo-fetch-cli/src/cli.rs
@@ -39,19 +39,15 @@ pub(crate) struct FetchArgs {
 
     /// Output format
     #[arg(long, value_enum, value_name = "FORMAT", default_value_t = Format::Markdown,
-          conflicts_with_all = ["screenshot", "js"])]
+          conflicts_with_all = ["js"])]
     pub format: Format,
 
-    /// Save screenshot as PNG (single URL only)
-    #[arg(long, value_name = "FILE", conflicts_with_all = ["js"])]
-    pub screenshot: Option<String>,
-
-    /// Capture the full scrollable page instead of just the viewport.
-    #[arg(long, requires = "screenshot")]
+    /// Capture the full scrollable page instead of just the viewport (requires `--format png`).
+    #[arg(long)]
     pub full_page: bool,
 
     /// Execute JavaScript and print the result (single URL only)
-    #[arg(long, value_name = "EXPR", conflicts_with_all = ["screenshot"])]
+    #[arg(long, value_name = "EXPR")]
     pub js: Option<String>,
 
     /// Timeout in seconds for page load
@@ -71,15 +67,15 @@ pub(crate) struct FetchArgs {
     pub user_agent: Option<String>,
 
     /// Path to a CSS-selector schema file for structured JSON extraction
-    #[arg(long, value_name = "FILE", conflicts_with_all = ["screenshot", "js", "selector", "format"])]
+    #[arg(long, value_name = "FILE", conflicts_with_all = ["js", "selector", "format"])]
     pub schema: Option<PathBuf>,
 
-    /// Save the rendered output to a single file (single URL only).
-    #[arg(short = 'o', long, value_name = "FILE", conflicts_with_all = ["screenshot", "output_dir"])]
+    /// Save the rendered output to a single file. Use `-` for stdout, `./-` for a literal `-` file.
+    #[arg(short = 'o', long, value_name = "FILE", conflicts_with_all = ["output_dir"])]
     pub output: Option<PathBuf>,
 
     /// Write each URL's output to a file in this directory (auto-created).
-    #[arg(long, value_name = "DIR", conflicts_with = "screenshot")]
+    #[arg(long, value_name = "DIR")]
     pub output_dir: Option<PathBuf>,
 
     /// Visibility-aware filtering policy.
@@ -119,6 +115,8 @@ pub(crate) enum Format {
     Html,
     /// Plain text (`document.body.innerText`)
     Text,
+    /// PNG screenshot of the rendered page (single URL only)
+    Png,
 }
 
 /// Crawl output format.
@@ -293,6 +291,7 @@ mod tests {
         assert!(Format::from_str("json", true).is_ok());
         assert!(Format::from_str("html", true).is_ok());
         assert!(Format::from_str("text", true).is_ok());
+        assert!(Format::from_str("png", true).is_ok());
         assert!(Format::from_str("xml", true).is_err());
     }
 
@@ -302,14 +301,6 @@ mod tests {
         assert!(CrawlFormat::from_str("markdown", true).is_ok());
         assert!(CrawlFormat::from_str("json", true).is_ok());
         assert!(CrawlFormat::from_str("html", true).is_err());
-    }
-
-    #[test]
-    fn conflicting_format_and_screenshot() {
-        assert_eq!(
-            error_kind(&["--format", "json", "--screenshot", "out.png", "https://example.com"]),
-            ErrorKind::ArgumentConflict,
-        );
     }
 
     #[test]
@@ -329,11 +320,17 @@ mod tests {
     }
 
     #[test]
-    fn full_page_requires_screenshot() {
-        assert_eq!(
-            error_kind(&["--full-page", "https://example.com"]),
-            ErrorKind::MissingRequiredArgument,
+    fn full_page_requires_format_png() {
+        assert_validation_err(
+            &["--full-page", "https://example.com"],
+            "--full-page requires --format png",
         );
+    }
+
+    #[test]
+    fn full_page_with_format_png_is_allowed() {
+        let cli = parse(&["--full-page", "--format", "png", "-o", "out.png", "https://example.com"]).unwrap();
+        validate_args(&cli.fetch).unwrap();
     }
 
     #[test]
@@ -353,19 +350,55 @@ mod tests {
     }
 
     #[test]
-    fn output_dir_conflicts_with_screenshot() {
+    fn format_png_conflicts_with_js() {
         assert_eq!(
-            error_kind(&["--output-dir", "out", "--screenshot", "out.png", "https://example.com"]),
+            error_kind(&["--format", "png", "--js", "document.title", "https://example.com"]),
             ErrorKind::ArgumentConflict,
         );
     }
 
     #[test]
-    fn output_conflicts_with_screenshot() {
+    fn format_png_conflicts_with_selector() {
+        assert_validation_err(
+            &["--format", "png", "--selector", "article", "https://example.com"],
+            "--selector cannot be used with --format png",
+        );
+    }
+
+    #[test]
+    fn format_png_conflicts_with_schema() {
         assert_eq!(
-            error_kind(&["-o", "out.md", "--screenshot", "out.png", "https://example.com"]),
+            error_kind(&["--format", "png", "--schema", "s.json", "https://example.com"]),
             ErrorKind::ArgumentConflict,
         );
+    }
+
+    #[test]
+    fn format_png_with_multi_urls_errors() {
+        assert_validation_err(
+            &["--format", "png", "https://example.com", "https://example.org"],
+            "--format png only supports a single URL",
+        );
+    }
+
+    #[test]
+    fn format_png_conflicts_with_output_dir() {
+        assert_validation_err(
+            &["--format", "png", "--output-dir", "out", "https://example.com"],
+            "--format png cannot be used with --output-dir",
+        );
+    }
+
+    #[test]
+    fn format_png_with_output_file_is_allowed() {
+        let cli = parse(&["--format", "png", "-o", "out.png", "https://example.com"]).unwrap();
+        validate_args(&cli.fetch).unwrap();
+    }
+
+    #[test]
+    fn format_png_with_dash_output_is_allowed() {
+        let cli = parse(&["--format", "png", "-o", "-", "https://example.com"]).unwrap();
+        validate_args(&cli.fetch).unwrap();
     }
 
     #[test]

--- a/crates/servo-fetch-cli/src/commands/fetch.rs
+++ b/crates/servo-fetch-cli/src/commands/fetch.rs
@@ -38,12 +38,26 @@ pub(crate) fn validate_args(args: &FetchArgs) -> Result<()> {
     if raw_format && args.selector.is_some() {
         bail!("--selector cannot be used with --format html or text");
     }
+    if args.format == Format::Png {
+        if args.selector.is_some() {
+            bail!("--selector cannot be used with --format png");
+        }
+        if args.urls.len() > 1 {
+            bail!("--format png only supports a single URL");
+        }
+        if args.output_dir.is_some() {
+            bail!("--format png cannot be used with --output-dir");
+        }
+    }
+    if args.full_page && args.format != Format::Png {
+        bail!("--full-page requires --format png");
+    }
     if args.urls.len() > 1 {
         if args.output.is_some() {
             bail!("-o/--output is only valid with a single URL; use --output-dir for multiple URLs");
         }
-        if args.screenshot.is_some() || args.js.is_some() || raw_format {
-            bail!("--screenshot, --js, and --format html or text cannot be used with multiple URLs");
+        if args.js.is_some() || raw_format {
+            bail!("--js, and --format html or text cannot be used with multiple URLs");
         }
     }
     Ok(())
@@ -141,20 +155,15 @@ fn batch_emit(args: &FetchArgs, page: &Page, url: &str, sink: Sink<'_>) -> Resul
                 output::Markdown { page, url, selector }.execute(sink)
             }
         }
-        Format::Html | Format::Text => unreachable!("guarded by validate_args before batch dispatch"),
+        Format::Html | Format::Text | Format::Png => {
+            unreachable!("guarded by validate_args before batch dispatch")
+        }
     }
 }
 
 fn dispatch_output(args: &FetchArgs, page: &Page, url: &str, sink: Sink<'_>) -> Result<()> {
     if let Some(result) = page.js_result.as_deref() {
         return output::js_eval(url, result, sink);
-    }
-    if let Some(path) = args.screenshot.as_deref() {
-        return output::Screenshot {
-            page,
-            path: Path::new(path),
-        }
-        .execute();
     }
     if args.schema.is_some() {
         return output::Extracted { page, url }.execute(sink);
@@ -165,11 +174,12 @@ fn dispatch_output(args: &FetchArgs, page: &Page, url: &str, sink: Sink<'_>) -> 
         Format::Json => output::Json { page, url, selector }.execute(sink),
         Format::Html => output::raw(url, output::Ext::Html, &page.html, sink),
         Format::Text => output::raw(url, output::Ext::Text, &page.inner_text, sink),
+        Format::Png => output::Screenshot { page, sink }.execute(),
     }
 }
 
 fn build_fetch_options(args: &FetchArgs, url: &str) -> Result<FetchOptions> {
-    let base = if args.screenshot.is_some() {
+    let base = if args.format == Format::Png {
         FetchOptions::screenshot(url, args.full_page)
     } else if let Some(expr) = args.js.as_deref() {
         FetchOptions::javascript(url, expr)

--- a/crates/servo-fetch-cli/src/output.rs
+++ b/crates/servo-fetch-cli/src/output.rs
@@ -38,26 +38,27 @@ impl fmt::Display for Ext {
 /// Where rendered output goes.
 #[derive(Debug, Copy, Clone)]
 pub(crate) enum Sink<'a> {
-    Stdout,
+    Stdout { explicit: bool },
     File(&'a Path),
     Dir(&'a Path),
 }
 
 impl<'a> Sink<'a> {
     pub(crate) fn from_dir(dir: Option<&'a Path>) -> Self {
-        dir.map_or(Self::Stdout, Self::Dir)
+        dir.map_or(Self::Stdout { explicit: false }, Self::Dir)
     }
 
     pub(crate) fn from_args(file: Option<&'a Path>, dir: Option<&'a Path>) -> Self {
         match (file, dir) {
+            (Some(p), _) if p.as_os_str() == "-" => Self::Stdout { explicit: true },
             (Some(p), _) => Self::File(p),
             (_, Some(d)) => Self::Dir(d),
-            _ => Self::Stdout,
+            _ => Self::Stdout { explicit: false },
         }
     }
 
     pub(crate) fn is_stdout(&self) -> bool {
-        matches!(self, Self::Stdout)
+        matches!(self, Self::Stdout { .. })
     }
 
     pub(crate) fn write(&self, url: &str, ext: Ext, content: &str) -> Result<()> {
@@ -72,7 +73,7 @@ impl<'a> Sink<'a> {
         let sanitized = servo_fetch::sanitize::sanitize(content);
         let needs_nl = ensure_newline && !sanitized.ends_with('\n');
         match self {
-            Self::Stdout => {
+            Self::Stdout { .. } => {
                 let mut out = io::stdout().lock();
                 out.write_all(sanitized.as_bytes())?;
                 if needs_nl {
@@ -87,6 +88,13 @@ impl<'a> Sink<'a> {
             }
         }
     }
+}
+
+fn refuse_binary_to_tty(explicit: bool, is_tty: bool) -> Result<()> {
+    if !explicit && is_tty {
+        bail!("refusing to write PNG to a terminal; use `-o FILE` or pipe to a viewer");
+    }
+    Ok(())
 }
 
 fn write_to_file(url: &str, path: &Path, body: &[u8], with_newline: bool) -> Result<()> {
@@ -163,18 +171,27 @@ impl Json<'_> {
 
 pub(crate) struct Screenshot<'a> {
     pub page: &'a Page,
-    pub path: &'a Path,
+    pub sink: Sink<'a>,
 }
 
 impl Screenshot<'_> {
     pub(crate) fn execute(&self) -> Result<()> {
-        match self.page.screenshot_png() {
-            Some(png) => {
-                fs::write(self.path, png)?;
-                tracing::info!(path = %self.path.display(), "screenshot saved");
+        let png = self.page.screenshot_png().ok_or_else(|| {
+            anyhow::anyhow!("failed to capture screenshot — the page may not have rendered correctly")
+        })?;
+        match self.sink {
+            Sink::Stdout { explicit } => {
+                use std::io::IsTerminal as _;
+                refuse_binary_to_tty(explicit, io::stdout().is_terminal())?;
+                io::stdout().lock().write_all(png)?;
                 Ok(())
             }
-            None => bail!("failed to capture screenshot — the page may not have rendered correctly"),
+            Sink::File(path) => {
+                fs::write(path, png)?;
+                tracing::info!(path = %path.display(), "screenshot saved");
+                Ok(())
+            }
+            Sink::Dir(_) => bail!("--format png cannot be used with --output-dir"),
         }
     }
 }
@@ -353,5 +370,46 @@ mod tests {
     fn slug_includes_non_default_port() {
         let s = slug_from_url("https://example.com:8080/foo", Ext::Markdown);
         assert!(s.contains("8080"), "must include non-default port, got: {s}");
+    }
+
+    #[test]
+    fn refuse_binary_to_tty_default_in_terminal_errors() {
+        let err = refuse_binary_to_tty(false, true).unwrap_err();
+        assert!(err.to_string().contains("refusing"));
+    }
+
+    #[test]
+    fn refuse_binary_to_tty_default_in_pipe_succeeds() {
+        refuse_binary_to_tty(false, false).unwrap();
+    }
+
+    #[test]
+    fn refuse_binary_to_tty_explicit_in_terminal_succeeds() {
+        refuse_binary_to_tty(true, true).unwrap();
+    }
+
+    #[test]
+    fn refuse_binary_to_tty_explicit_in_pipe_succeeds() {
+        refuse_binary_to_tty(true, false).unwrap();
+    }
+
+    #[test]
+    fn sink_from_args_dash_is_explicit_stdout() {
+        let dash = Path::new("-");
+        let sink = Sink::from_args(Some(dash), None);
+        assert!(matches!(sink, Sink::Stdout { explicit: true }));
+    }
+
+    #[test]
+    fn sink_from_args_dot_dash_is_file() {
+        let dot_dash = Path::new("./-");
+        let sink = Sink::from_args(Some(dot_dash), None);
+        assert!(matches!(sink, Sink::File(p) if p == dot_dash));
+    }
+
+    #[test]
+    fn sink_from_args_no_output_is_default_stdout() {
+        let sink = Sink::from_args(None, None);
+        assert!(matches!(sink, Sink::Stdout { explicit: false }));
     }
 }

--- a/crates/servo-fetch-cli/tests/cli.rs
+++ b/crates/servo-fetch-cli/tests/cli.rs
@@ -145,7 +145,7 @@ fn js_eval_returns_result() {
 
 #[test]
 #[ignore = "e2e: requires Servo engine"]
-fn screenshot_creates_file() {
+fn format_png_creates_file() {
     block_on(async {
         let s = MockServer::start().await;
         Mock::given(method("GET"))
@@ -158,7 +158,9 @@ fn screenshot_creates_file() {
         let file = dir.join("test.png");
         servo_fetch()
             .args([
-                "--screenshot",
+                "--format",
+                "png",
+                "-o",
                 file.to_str().unwrap(),
                 "--allow-private-addresses",
                 TIMEOUT,

--- a/skills/servo-fetch/SKILL.md
+++ b/skills/servo-fetch/SKILL.md
@@ -125,7 +125,7 @@ servo-fetch https://example.com                                  # Markdown (def
 servo-fetch https://example.com --format json                    # Structured JSON
 servo-fetch URL1 URL2 URL3                                       # Parallel batch (Markdown with separators)
 servo-fetch URL1 URL2 --format json                              # Parallel batch (NDJSON)
-servo-fetch https://example.com --screenshot out.png             # Save PNG screenshot
+servo-fetch https://example.com --format png -o out.png          # Save PNG screenshot
 servo-fetch https://example.com --js "document.title"            # Run JavaScript and print result
 servo-fetch https://example.com --selector article               # Extract a section by CSS selector
 servo-fetch https://example.com --schema schema.json             # Schema-driven JSON


### PR DESCRIPTION
## Summary

Drop `--screenshot FILE` in favor of `--format png` (consistency with other format axes). Adds `-o -` for explicit stdout, `./-` for a literal `-` file.

Migration: `--screenshot file.png` → `--format png -o file.png`.

## Related issues

Closes #245

## Test Plan

- `cargo test --workspace --locked`: all passed
- Added: 4 TTY-safeguard tests, 7 `--format png` conflict tests

## Checklist

- [x] Ran `cargo +nightly fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
- [x] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed
- [x] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it