### PR TITLE
fix(ci): update smoke test to use --format png

### DIFF
--- a/.github/workflows/test-smoke.yml
+++ b/.github/workflows/test-smoke.yml
@@ -146,7 +146,7 @@ jobs:
             | python3 -c 'import json,sys; json.load(sys.stdin)'
           sleep 2
 
-          "$BIN" --screenshot "$SHOT" 'https://example.com'
+          "$BIN" --format png -o "$SHOT" 'https://example.com'
           head -c 8 "$SHOT" | cmp -s - <(printf '\x89PNG\r\n\x1a\n')
           sleep 2
 


### PR DESCRIPTION
## Summary

The L3 smoke test step still referenced `--screenshot FILE` after #246 removed the flag, causing CI to fail on the v0.11.3 release tag push. Updates to `--format png -o FILE`.

## Related issues

Refs #246

## Test Plan

N/A

## Checklist

- [x] Ran `cargo +nightly fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
- [x] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed
- [x] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it