### PR TITLE
feat: preserve source chain and restructure variants

### DIFF
--- a/bindings/python/src/client.rs
+++ b/bindings/python/src/client.rs
@@ -142,6 +142,7 @@ impl Client {
                 if stop.load(Ordering::Acquire) {
                     return;
                 }
+                let mut r_opt = Some(r);
                 Python::attach(|py| {
                     if let Some(ref ab) = abort {
                         if matches!(
@@ -152,7 +153,7 @@ impl Client {
                             return;
                         }
                     }
-                    let item = match Py::new(py, CrawlResult::from_core(r.clone())) {
+                    let item = match Py::new(py, CrawlResult::from_core(r_opt.take().expect("once"))) {
                         Ok(i) => i,
                         Err(e) => {
                             *cb_err.lock().expect("poisoned") = Some(e);

--- a/bindings/python/src/crawl.rs
+++ b/bindings/python/src/crawl.rs
@@ -42,8 +42,8 @@ impl CrawlResult {
     }
 
     #[getter]
-    fn error(&self) -> Option<&str> {
-        self.inner.outcome.as_ref().err().map(|e| e.message.as_str())
+    fn error(&self) -> Option<String> {
+        self.inner.outcome.as_ref().err().map(ToString::to_string)
     }
 
     /// `True` if the crawl succeeded for this URL.
@@ -71,7 +71,9 @@ impl CrawlResult {
             ),
             Err(e) => format!(
                 "{name}(url={:?}, depth={}, error={:?})",
-                this.inner.url, this.inner.depth, e.message
+                this.inner.url,
+                this.inner.depth,
+                e.to_string()
             ),
         })
     }

--- a/bindings/python/src/errors.rs
+++ b/bindings/python/src/errors.rs
@@ -51,8 +51,8 @@ pub(crate) fn map_error(err: servo_fetch::Error) -> PyErr {
         servo_fetch::Error::InvalidUrl { url, reason } => {
             InvalidUrlError::new_err(format!("invalid URL '{}': {reason}", redact_url(url)))
         }
-        servo_fetch::Error::AddressNotAllowed(host) => NetworkError::new_err(format!("address not allowed: {host}")),
-        servo_fetch::Error::Engine(msg) => EngineError::new_err(msg.clone()),
+        servo_fetch::Error::AddressNotAllowed { host } => NetworkError::new_err(format!("address not allowed: {host}")),
+        servo_fetch::Error::Engine { source, .. } => EngineError::new_err(source.to_string()),
         servo_fetch::Error::Schema(e) => SchemaError::new_err(e.to_string()),
         _ => ServoFetchError::new_err(err.to_string()),
     }

--- a/crates/servo-fetch-cli/src/commands/crawl.rs
+++ b/crates/servo-fetch-cli/src/commands/crawl.rs
@@ -43,9 +43,9 @@ pub(crate) fn run(args: &CrawlArgs) -> anyhow::Result<()> {
             return;
         }
         let res = if json {
-            emit_json(result, sink)
+            emit_json(&result, sink)
         } else {
-            emit_markdown(result, sink)
+            emit_markdown(&result, sink)
         };
         if let Err(e) = res {
             write_err = Some(e);

--- a/crates/servo-fetch-cli/src/tools/crawl.rs
+++ b/crates/servo-fetch-cli/src/tools/crawl.rs
@@ -50,7 +50,7 @@ pub(crate) async fn crawl_pages(opts: CrawlOptions<'_>) -> ToolResult<Vec<(Strin
                 Ok(page) => paginate(&servo_fetch::sanitize::sanitize(&page.content), 0, max_len),
                 Err(e) => format!("[error] {e}"),
             };
-            results.push((r.url.clone(), text));
+            results.push((r.url, text));
         })
         .map_err(|e| ToolError::fetch(format!("{e:#}")))?;
         Ok(results)

--- a/crates/servo-fetch/README.md
+++ b/crates/servo-fetch/README.md
@@ -112,8 +112,8 @@ use servo_fetch::{fetch, FetchOptions, Error};
 
 match fetch(FetchOptions::new(url)) {
     Ok(page) => { /* ... */ }
-    Err(e) if e.is_timeout() => { /* retry */ }
-    Err(Error::AddressNotAllowed(_)) => { /* skip */ }
+    Err(Error::Timeout { .. }) => { /* retry */ }
+    Err(Error::AddressNotAllowed { .. }) => { /* skip */ }
     Err(e) => return Err(e.into()),
 }
 ```

--- a/crates/servo-fetch/src/crawl.rs
+++ b/crates/servo-fetch/src/crawl.rs
@@ -1,7 +1,6 @@
 //! Site crawling — BFS link traversal with scope, robots.txt, and rate limiting.
 
 use std::collections::{HashSet, VecDeque};
-use std::fmt;
 use std::hash::{DefaultHasher, Hash, Hasher};
 use std::time::{Duration, SystemTime};
 
@@ -122,7 +121,7 @@ impl CrawlOptions {
 }
 
 /// Result for a single crawled page.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 #[non_exhaustive]
 pub struct CrawlResult {
     /// URL of the crawled page.
@@ -132,7 +131,7 @@ pub struct CrawlResult {
     /// Wall-clock time when the fetch completed.
     pub fetched_at: SystemTime,
     /// Page content if successful, or error if failed.
-    pub outcome: Result<CrawlPage, CrawlError>,
+    pub outcome: Result<CrawlPage, crate::error::Error>,
 }
 
 /// Successfully crawled page.
@@ -145,21 +144,6 @@ pub struct CrawlPage {
     /// Number of links discovered on this page.
     pub links_found: usize,
 }
-
-/// Error from a failed crawl attempt.
-#[derive(Debug, Clone)]
-pub struct CrawlError {
-    /// Error message.
-    pub message: String,
-}
-
-impl fmt::Display for CrawlError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&self.message)
-    }
-}
-
-impl std::error::Error for CrawlError {}
 
 impl serde::Serialize for CrawlResult {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -185,7 +169,7 @@ impl serde::Serialize for CrawlResult {
                 map.serialize_entry("url", &self.url)?;
                 map.serialize_entry("depth", &self.depth)?;
                 map.serialize_entry("fetched_at", &fetched_at)?;
-                map.serialize_entry("error", &e.message)?;
+                map.serialize_entry("error", &e.to_string())?;
                 map.end()
             }
         }
@@ -193,19 +177,19 @@ impl serde::Serialize for CrawlResult {
 }
 
 impl CrawlResult {
-    fn from_internal(r: &CrawlPageResult) -> Self {
+    fn from_internal(r: CrawlPageResult) -> Self {
         let outcome = match r.status {
             CrawlStatus::Ok => Ok(CrawlPage {
-                title: r.title.clone(),
-                content: r.content.clone().unwrap_or_default(),
+                title: r.title,
+                content: r.content.unwrap_or_default(),
                 links_found: r.links_found,
             }),
-            CrawlStatus::Error => Err(CrawlError {
-                message: r.error.clone().unwrap_or_default(),
-            }),
+            CrawlStatus::Error => Err(r
+                .error
+                .unwrap_or_else(|| crate::error::Error::engine("unknown crawl error", None))),
         };
         Self {
-            url: r.url.clone(),
+            url: r.url,
             depth: r.depth,
             fetched_at: r.fetched_at,
             outcome,
@@ -215,7 +199,7 @@ impl CrawlResult {
 
 /// Crawl a site, invoking `on_page` for each result as it arrives.
 #[allow(clippy::needless_pass_by_value)]
-pub fn crawl_each(opts: CrawlOptions, mut on_page: impl FnMut(&CrawlResult)) -> crate::error::Result<()> {
+pub fn crawl_each(opts: CrawlOptions, mut on_page: impl FnMut(CrawlResult)) -> crate::error::Result<()> {
     net::ensure_crypto_provider();
     let plan = build_crawl_plan(&opts)?;
     crate::runtime::block_on(async {
@@ -228,19 +212,18 @@ pub fn crawl_each(opts: CrawlOptions, mut on_page: impl FnMut(&CrawlResult)) -> 
         .await
         .unwrap_or(RobotsPolicy::Unreachable);
         run(plan, robots, &bridge::ServoFetcher, |r| {
-            on_page(&CrawlResult::from_internal(r));
+            on_page(CrawlResult::from_internal(r));
         })
-        .await
+        .await;
     })
-    .map_err(|e| crate::error::Error::Engine(e.to_string()))?;
-    Ok(())
+    .map_err(|e| crate::error::Error::engine(e, None))
 }
 
 /// Crawl a site and collect all results.
 #[allow(clippy::needless_pass_by_value)]
 pub fn crawl(opts: CrawlOptions) -> crate::error::Result<Vec<CrawlResult>> {
     let mut results = Vec::new();
-    crawl_each(opts, |r| results.push(r.clone()))?;
+    crawl_each(opts, |r| results.push(r))?;
     Ok(results)
 }
 
@@ -297,7 +280,7 @@ pub(crate) struct CrawlPageResult {
     pub status: CrawlStatus,
     pub title: Option<String>,
     pub content: Option<String>,
-    pub error: Option<String>,
+    pub error: Option<crate::error::Error>,
     pub links_found: usize,
     pub fetched_at: SystemTime,
 }
@@ -367,10 +350,10 @@ pub(crate) async fn run(
     opts: CrawlPlan,
     robots: RobotsPolicy,
     fetcher: &(impl PageFetcher + Clone),
-    mut on_page: impl FnMut(&CrawlPageResult),
-) -> Vec<CrawlPageResult> {
+    mut on_page: impl FnMut(CrawlPageResult),
+) {
     let mut frontier = Frontier::new(&opts.seed);
-    let mut results = Vec::new();
+    let mut completed: usize = 0;
     let mut in_flight: JoinSet<FetchOutcome> = JoinSet::new();
 
     // `Delay` keeps the steady-state rate correct after fetches exceed `delay`.
@@ -383,7 +366,7 @@ pub(crate) async fn run(
     let concurrency = opts.concurrency.max(1);
 
     loop {
-        while in_flight.len() < concurrency && results.len() + in_flight.len() < opts.limit {
+        while in_flight.len() < concurrency && completed + in_flight.len() < opts.limit {
             let Some((url, depth)) = frontier.pop() else {
                 break;
             };
@@ -414,27 +397,24 @@ pub(crate) async fn run(
         } = outcome;
         let page = match result {
             Ok(p) => p,
-            Err(msg) => {
-                let r = error_result(&url, depth, msg, fetched_at);
-                on_page(&r);
-                results.push(r);
+            Err(err) => {
+                on_page(error_result(&url, depth, err, fetched_at));
+                completed += 1;
                 continue;
             }
         };
 
-        let budget_used = results.len() + in_flight.len() + 1;
+        let budget_used = completed + in_flight.len() + 1;
         let mut ctx = CrawlContext {
             frontier: &mut frontier,
             robots: &robots,
             opts: &opts,
         };
         if let Some(r) = process_ok_fetch(&mut ctx, &url, depth, &page, budget_used, fetched_at) {
-            on_page(&r);
-            results.push(r);
+            on_page(r);
+            completed += 1;
         }
     }
-
-    results
 }
 
 fn spawn_fetch(
@@ -458,7 +438,7 @@ fn spawn_fetch(
                 mode: bridge::FetchMode::Content { include_a11y: false },
                 user_agent: user_agent.as_deref(),
             })
-            .map_err(|e| format!("{e:#}"));
+            .map_err(|e| crate::error::Error::engine(e, Some(url_str.clone())));
         FetchOutcome {
             url,
             depth,
@@ -542,15 +522,15 @@ fn process_ok_fetch(
     })
 }
 
-/// Fetch result crossing the `JoinSet` boundary; error is pre-stringified for `Send`.
+/// Fetch result crossing the `JoinSet` boundary.
 struct FetchOutcome {
     url: Url,
     depth: usize,
-    result: Result<bridge::ServoPage, String>,
+    result: Result<bridge::ServoPage, crate::error::Error>,
     fetched_at: SystemTime,
 }
 
-fn error_result(url: &Url, depth: usize, error: String, fetched_at: SystemTime) -> CrawlPageResult {
+fn error_result(url: &Url, depth: usize, error: crate::error::Error, fetched_at: SystemTime) -> CrawlPageResult {
     CrawlPageResult {
         url: url.to_string(),
         depth,
@@ -679,7 +659,8 @@ mod tests {
             delay: None,
         };
         configure(&mut opts);
-        let results = run(opts, RobotsPolicy::Unavailable, &fetcher, |_| {}).await;
+        let mut results = Vec::new();
+        run(opts, RobotsPolicy::Unavailable, &fetcher, |r| results.push(r)).await;
         assert(&results);
     }
 
@@ -966,9 +947,9 @@ mod tests {
     #[test]
     fn error_result_fields() {
         let url = Url::parse("https://example.com/fail").unwrap();
-        let r = error_result(&url, 2, "timeout".into(), SystemTime::now());
+        let r = error_result(&url, 2, crate::error::Error::engine("timeout", None), SystemTime::now());
         assert!(matches!(r.status, CrawlStatus::Error));
-        assert_eq!(r.error.as_deref(), Some("timeout"));
+        assert!(r.error.as_ref().is_some_and(|e| e.to_string().contains("timeout")));
         assert!(r.content.is_none());
     }
 

--- a/crates/servo-fetch/src/error.rs
+++ b/crates/servo-fetch/src/error.rs
@@ -1,17 +1,20 @@
 //! Error types.
 
-use std::fmt;
+use std::error::Error as StdError;
 use std::time::Duration;
 
 /// A specialized `Result` type for servo-fetch.
 pub type Result<T> = std::result::Result<T, Error>;
+
+/// Boxed error type used as the `source` of variants that wrap arbitrary errors.
+pub(crate) type BoxError = Box<dyn StdError + Send + Sync + 'static>;
 
 /// Errors from servo-fetch operations.
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum Error {
     /// The URL is malformed or uses a disallowed scheme.
-    #[error("{reason}")]
+    #[error("invalid URL '{url}': {reason}")]
     InvalidUrl {
         /// The URL that failed validation.
         url: String,
@@ -20,7 +23,7 @@ pub enum Error {
     },
 
     /// The page did not finish loading within the configured timeout.
-    #[error("page load timed out after {}s", timeout.as_secs())]
+    #[error("page load timed out after {}s at {url}", timeout.as_secs())]
     Timeout {
         /// The URL that timed out.
         url: String,
@@ -29,20 +32,41 @@ pub enum Error {
     },
 
     /// The URL resolves to a private or reserved address (SSRF protection).
-    #[error("address not allowed: {0}")]
-    AddressNotAllowed(String),
+    #[error("address not allowed: {host}")]
+    AddressNotAllowed {
+        /// The blocked host.
+        host: String,
+    },
 
     /// The Servo engine is unavailable or crashed.
-    #[error("engine error: {0}")]
-    Engine(String),
+    #[error("engine error: {source}")]
+    Engine {
+        /// URL being processed, if known.
+        url: Option<String>,
+        /// Source error.
+        #[source]
+        source: BoxError,
+    },
 
     /// JavaScript evaluation failed.
-    #[error("JavaScript evaluation failed: {0}")]
-    JavaScript(String),
+    #[error("JavaScript evaluation failed: {source}")]
+    JavaScript {
+        /// URL being processed, if known.
+        url: Option<String>,
+        /// Source error.
+        #[source]
+        source: BoxError,
+    },
 
     /// Screenshot capture failed.
-    #[error("screenshot capture failed: {0}")]
-    Screenshot(String),
+    #[error("screenshot capture failed: {source}")]
+    Screenshot {
+        /// URL being captured, if known.
+        url: Option<String>,
+        /// Source error.
+        #[source]
+        source: BoxError,
+    },
 
     /// Content extraction failed.
     #[error(transparent)]
@@ -57,64 +81,60 @@ pub enum Error {
     Io(#[from] std::io::Error),
 
     /// A glob pattern is invalid.
-    #[error("invalid glob pattern: {0}")]
+    #[error(transparent)]
     InvalidGlob(#[from] globset::Error),
 }
 
 impl Error {
+    /// Construct an [`Error::Engine`] from any error type, preserving source chain.
+    pub(crate) fn engine(source: impl Into<BoxError>, url: Option<String>) -> Self {
+        Self::Engine {
+            url,
+            source: source.into(),
+        }
+    }
+
     /// Returns `true` if this is a timeout error.
     #[must_use]
     pub fn is_timeout(&self) -> bool {
         matches!(self, Self::Timeout { .. })
     }
 
-    /// Returns `true` if this is a network-related error.
+    /// Returns `true` if this is a network-related error (timeout or address-policy rejection).
     #[must_use]
     pub fn is_network(&self) -> bool {
-        matches!(self, Self::Timeout { .. } | Self::AddressNotAllowed(_))
+        matches!(self, Self::Timeout { .. } | Self::AddressNotAllowed { .. })
     }
 
     /// Returns the URL associated with this error, if any.
     #[must_use]
     pub fn url(&self) -> Option<&str> {
         match self {
-            Self::InvalidUrl { url, .. } | Self::Timeout { url, .. } | Self::AddressNotAllowed(url) => Some(url),
+            Self::InvalidUrl { url, .. } | Self::Timeout { url, .. } => Some(url),
+            Self::Engine { url, .. } | Self::JavaScript { url, .. } | Self::Screenshot { url, .. } => url.as_deref(),
+            _ => None,
+        }
+    }
+
+    /// Returns the host that was rejected, if this is [`Error::AddressNotAllowed`].
+    #[must_use]
+    pub fn host(&self) -> Option<&str> {
+        match self {
+            Self::AddressNotAllowed { host } => Some(host),
             _ => None,
         }
     }
 }
 
-#[allow(clippy::used_underscore_items)]
-const _: () = {
-    fn _assert<T: Send + Sync>() {}
-    fn _check() {
-        _assert::<Error>();
-    }
-};
-
-/// Why a URL was rejected by [`validate_url`].
 #[derive(Debug)]
 pub(crate) enum UrlError {
-    /// Malformed URL or disallowed scheme.
     Invalid(String),
-    /// Host resolves to a private or reserved address.
     PrivateAddress(String),
-}
-
-impl fmt::Display for UrlError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Invalid(reason) => f.write_str(reason),
-            Self::PrivateAddress(host) => {
-                write!(f, "access to private/local addresses is not allowed: {host}")
-            }
-        }
-    }
 }
 
 pub(crate) fn map_url_error(url: &str, e: UrlError) -> Error {
     match e {
-        UrlError::PrivateAddress(host) => Error::AddressNotAllowed(host),
+        UrlError::PrivateAddress(host) => Error::AddressNotAllowed { host },
         UrlError::Invalid(reason) => Error::InvalidUrl {
             url: url.into(),
             reason,
@@ -127,7 +147,13 @@ mod tests {
     use super::*;
 
     #[test]
-    fn timeout_is_timeout() {
+    fn assert_send_sync() {
+        fn check<T: Send + Sync>() {}
+        check::<Error>();
+    }
+
+    #[test]
+    fn timeout_predicates() {
         let err = Error::Timeout {
             url: "https://example.com".into(),
             timeout: Duration::from_secs(30),
@@ -135,31 +161,43 @@ mod tests {
         assert!(err.is_timeout());
         assert!(err.is_network());
         assert_eq!(err.url(), Some("https://example.com"));
+        assert_eq!(err.host(), None);
     }
 
     #[test]
-    fn address_not_allowed_is_network() {
-        let err = Error::AddressNotAllowed("127.0.0.1".into());
+    fn address_not_allowed_predicates() {
+        let err = Error::AddressNotAllowed {
+            host: "127.0.0.1".into(),
+        };
         assert!(!err.is_timeout());
         assert!(err.is_network());
-        assert_eq!(err.url(), Some("127.0.0.1"));
+        assert_eq!(err.url(), None);
+        assert_eq!(err.host(), Some("127.0.0.1"));
     }
 
     #[test]
-    fn invalid_url_has_url() {
+    fn invalid_url_carries_url() {
         let err = Error::InvalidUrl {
             url: "bad://url".into(),
             reason: "scheme not allowed".into(),
         };
-        assert!(!err.is_timeout());
         assert!(!err.is_network());
         assert_eq!(err.url(), Some("bad://url"));
+        assert_eq!(err.host(), None);
     }
 
     #[test]
-    fn engine_error_has_no_url() {
-        let err = Error::Engine("crashed".into());
-        assert!(!err.is_timeout());
+    fn engine_helper_preserves_source_chain() {
+        let inner = std::io::Error::other("disk full");
+        let err = Error::engine(inner, Some("https://example.com".into()));
+        assert_eq!(err.url(), Some("https://example.com"));
+        assert!(err.source().is_some());
+        assert_eq!(err.to_string(), "engine error: disk full");
+    }
+
+    #[test]
+    fn engine_without_url_returns_none() {
+        let err = Error::engine(std::io::Error::other("crash"), None);
         assert!(err.url().is_none());
     }
 }

--- a/crates/servo-fetch/src/fetch.rs
+++ b/crates/servo-fetch/src/fetch.rs
@@ -305,14 +305,13 @@ pub fn fetch(opts: FetchOptions) -> crate::error::Result<Page> {
     };
 
     let servo_page = crate::bridge::fetch_page(bridge_opts).map_err(|e| {
-        let msg = format!("{e:#}");
-        if msg.contains("timed out") {
+        if format!("{e:#}").contains("timed out") {
             Error::Timeout {
                 url: opts.url.clone(),
                 timeout: opts.timeout,
             }
         } else {
-            Error::Engine(msg)
+            Error::engine(e, Some(opts.url.clone()))
         }
     })?;
 

--- a/crates/servo-fetch/src/lib.rs
+++ b/crates/servo-fetch/src/lib.rs
@@ -27,7 +27,7 @@ pub(crate) mod scope;
 pub(crate) mod screenshot;
 pub(crate) mod sys;
 
-pub use crawl::{CrawlError, CrawlOptions, CrawlPage, CrawlResult, crawl, crawl_each};
+pub use crawl::{CrawlOptions, CrawlPage, CrawlResult, crawl, crawl_each};
 pub use error::{Error, Result};
 pub use fetch::{ConsoleLevel, ConsoleMessage, FetchOptions, Page, extract_json, fetch, markdown, text};
 pub use map::{MapOptions, MappedUrl, map};

--- a/crates/servo-fetch/src/map.rs
+++ b/crates/servo-fetch/src/map.rs
@@ -130,7 +130,7 @@ pub fn map(opts: MapOptions) -> crate::error::Result<Vec<MappedUrl>> {
             lastmod: entry.lastmod.clone(),
         });
     }))
-    .map_err(|e| crate::error::Error::Engine(e.to_string()))?;
+    .map_err(|e| crate::error::Error::engine(e, None))?;
     Ok(results)
 }
 

--- a/crates/servo-fetch/src/net.rs
+++ b/crates/servo-fetch/src/net.rs
@@ -34,7 +34,7 @@ pub fn validate_url(url: &str) -> crate::error::Result<Url> {
 
 /// Validate a URL against the given [`NetworkPolicy`].
 pub(crate) fn validate_url_with_policy(input: &str, policy: NetworkPolicy) -> Result<Url, UrlError> {
-    let mut parsed = Url::parse(input).map_err(|e| UrlError::Invalid(format!("invalid URL: {input}: {e}")))?;
+    let mut parsed = Url::parse(input).map_err(|e| UrlError::Invalid(e.to_string()))?;
     match parsed.scheme() {
         "http" | "https" => {}
         s => {


### PR DESCRIPTION
## Summary

Restructure `Error` to preserve source chains across thread boundaries (previously stringified via `to_string()`). `Engine` / `JavaScript` / `Screenshot` carry `#[source]` field. Drop `CrawlError` wrapper — `CrawlResult.outcome` is now `Result<CrawlPage, Error>` directly, preserving per-page variant info. Add `Error::engine()` helper and split `url()` / `host()` accessors.

## Test Plan

```
cargo test -p servo-fetch --lib   # all passed
```

## Checklist

- [x] Ran `cargo +nightly fmt`, `cargo clippy`, and `cargo test` locally
- [x] README example updated for new variant syntax
- [x] New tests added (source chain, `host()`, `Error::engine()` helper)
- [x] Commit messages follow Conventional Commits
- [x] I have read the AI usage policy in CONTRIBUTING.md and followed it