### PR TITLE
feat(schema): expose MAX_NESTING_DEPTH and add cargo-doc CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,38 @@ jobs:
           components: rustfmt
       - run: cargo fmt --all --check
 
+  cargo-doc:
+    name: Doc
+    needs: [changes]
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    env:
+      CARGO_INCREMENTAL: 0
+      RUSTDOCFLAGS: -D warnings
+      SCCACHE_GHA_ENABLED: true
+      RUSTC_WRAPPER: sccache
+      CCACHE: sccache
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: "1.95.0"
+      - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+      - name: Install servo build deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake clang pkg-config libfontconfig-dev libfreetype-dev \
+            libssl-dev libglib2.0-dev libegl1-mesa-dev
+      - run: cargo doc --workspace --lib --no-deps --locked
+      - name: sccache stats
+        if: always()
+        run: sccache --show-stats
+
   taplo:
     name: TOML Lint
     needs: [changes]
@@ -310,7 +342,7 @@ jobs:
   ci-passed:
     name: CI Passed
     if: '!cancelled()'
-    needs: [changes, cargo-clippy, cargo-test, e2e, cargo-fmt, taplo, cargo-deny, cargo-shear, typos, python-lint, python-test]
+    needs: [changes, cargo-clippy, cargo-test, cargo-doc, e2e, cargo-fmt, taplo, cargo-deny, cargo-shear, typos, python-lint, python-test]
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:

--- a/crates/servo-fetch/src/schema.rs
+++ b/crates/servo-fetch/src/schema.rs
@@ -4,8 +4,8 @@ use dom_query::{Document, Matcher, Selection};
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 
-/// Maximum `NestedList` nesting depth allowed in a schema.
-const MAX_NESTING_DEPTH: usize = 64;
+/// Maximum nesting depth allowed for `NestedList` schemas.
+pub const MAX_NESTING_DEPTH: usize = 64;
 
 /// Schema parse or validation error.
 #[derive(Debug, thiserror::Error)]


### PR DESCRIPTION
## Summary

`SchemaError::TooDeep` doc linked to private `MAX_NESTING_DEPTH`, triggering `rustdoc::private_intra_doc_links` warnings. Make the const `pub` and add a `cargo doc -D warnings` CI job.

## Test Plan

```
RUSTDOCFLAGS="-D warnings" cargo doc --workspace --lib --no-deps --locked   # 0 warnings
cargo test -p servo-fetch --lib  # all passed
```

## Checklist

- [x] Ran `cargo +nightly fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
- [x] Documentation updated (`MAX_NESTING_DEPTH` is now pub, surfaced on docs.rs)
- [x] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it