### PR TITLE
refactor(bridge): closure-capture reply with engine-owned timeout

### DIFF
--- a/crates/servo-fetch/src/bridge.rs
+++ b/crates/servo-fetch/src/bridge.rs
@@ -3,7 +3,7 @@
 use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
 use std::rc::Rc;
-use std::sync::{Arc, Condvar, Mutex, OnceLock, PoisonError, mpsc};
+use std::sync::{Arc, Condvar, Mutex, OnceLock, PoisonError};
 use std::time::{Duration, Instant};
 use std::{fmt, thread};
 
@@ -15,6 +15,7 @@ use servo::{
     ConsoleLogLevel, EventLoopWaker, JSValue, LoadStatus, NavigationRequest, Preferences, RenderingContext,
     ServoBuilder, SoftwareRenderingContext, UserContentManager, WebView, WebViewBuilder, WebViewDelegate, WebViewId,
 };
+use tokio::sync::{mpsc, oneshot};
 use url::Url;
 
 use crate::{layout, visibility};
@@ -31,8 +32,6 @@ pub(crate) fn default_user_agent() -> &'static str {
         crate::net::sanitize_user_agent(raw)
     })
 }
-/// Max wait before we re-check time-based conditions.
-pub(crate) const FALLBACK_WAIT: Duration = Duration::from_millis(5);
 const LAYOUT_JS: &str = include_str!("js/layout.js");
 const VISIBILITY_JS: &str = include_str!("js/visibility.js");
 const MAX_CONSOLE_MESSAGES: usize = 100;
@@ -270,7 +269,7 @@ struct FetchRequest {
     settle_ms: u64,
     mode: FetchMode,
     user_agent: Option<String>,
-    reply: mpsc::Sender<Result<ServoPage>>,
+    reply: oneshot::Sender<Result<ServoPage>>,
 }
 
 struct PendingFetch {
@@ -282,7 +281,7 @@ struct PendingFetch {
 }
 
 struct Engine {
-    requests: mpsc::SyncSender<FetchRequest>,
+    requests: mpsc::Sender<FetchRequest>,
     wake: Arc<WakeFlag>,
     policy: crate::net::NetworkPolicy,
 }
@@ -326,11 +325,14 @@ impl PageFetcher for ServoFetcher {
 }
 
 pub(crate) fn fetch_page(opts: FetchOptions<'_>) -> Result<ServoPage> {
-    /// Max outstanding requests queued toward the engine.
+    crate::runtime::block_on(fetch_page_async(opts))?
+}
+
+pub(crate) async fn fetch_page_async(opts: FetchOptions<'_>) -> Result<ServoPage> {
     const PENDING_CAPACITY: usize = 64;
 
     let engine = ENGINE.get_or_init(|| {
-        let (tx, rx) = mpsc::sync_channel::<FetchRequest>(PENDING_CAPACITY);
+        let (tx, rx) = mpsc::channel::<FetchRequest>(PENDING_CAPACITY);
         let wake = Arc::new(WakeFlag::default());
         let wake_for_thread = wake.clone();
         let policy = pending_policy();
@@ -345,30 +347,43 @@ pub(crate) fn fetch_page(opts: FetchOptions<'_>) -> Result<ServoPage> {
         }
     });
 
-    let (reply_tx, reply_rx) = mpsc::channel();
+    let (reply_tx, reply_rx) = oneshot::channel();
     let deadline =
         Duration::from_secs(opts.timeout_secs) + Duration::from_millis(opts.settle_ms) + Duration::from_secs(2);
-    engine
-        .requests
-        .send(FetchRequest {
-            url: opts.url.to_string(),
-            timeout_secs: opts.timeout_secs,
-            settle_ms: opts.settle_ms,
-            mode: opts.mode,
-            user_agent: opts.user_agent.map(String::from),
-            reply: reply_tx,
-        })
-        .map_err(|_| anyhow!("Servo engine is not running (it may have crashed on a previous request)"))?;
-    // Nudge the engine so it checks the request queue even if it was idle.
-    engine.wake.signal();
+    let request = FetchRequest {
+        url: opts.url.to_string(),
+        timeout_secs: opts.timeout_secs,
+        settle_ms: opts.settle_ms,
+        mode: opts.mode,
+        user_agent: opts.user_agent.map(String::from),
+        reply: reply_tx,
+    };
 
-    match reply_rx.recv_timeout(deadline) {
+    match tokio::time::timeout(
+        deadline,
+        dispatch_request(&engine.requests, &engine.wake, request, reply_rx),
+    )
+    .await
+    {
         Ok(result) => result,
-        Err(mpsc::RecvTimeoutError::Timeout) => {
-            Err(anyhow!("Servo engine did not respond within {}s", deadline.as_secs()))
-        }
-        Err(mpsc::RecvTimeoutError::Disconnected) => Err(anyhow!("Servo engine crashed while processing this page")),
+        Err(_) => Err(anyhow!("Servo engine did not respond within {}s", deadline.as_secs())),
     }
+}
+
+async fn dispatch_request(
+    sender: &mpsc::Sender<FetchRequest>,
+    wake: &WakeFlag,
+    request: FetchRequest,
+    reply_rx: oneshot::Receiver<Result<ServoPage>>,
+) -> Result<ServoPage> {
+    sender
+        .send(request)
+        .await
+        .map_err(|_| anyhow!("Servo engine is not running (it may have crashed on a previous request)"))?;
+    wake.signal();
+    reply_rx
+        .await
+        .map_err(|_| anyhow!("Servo engine crashed while processing this page"))?
 }
 
 fn is_apple_gl_driver_noise(line: &str) -> bool {
@@ -379,13 +394,13 @@ fn is_apple_gl_driver_noise(line: &str) -> bool {
     clippy::needless_pass_by_value,
     reason = "the thread owns its receiver for its lifetime"
 )]
-fn servo_thread(request_rx: mpsc::Receiver<FetchRequest>, wake: Arc<WakeFlag>, policy: crate::net::NetworkPolicy) {
+fn servo_thread(mut request_rx: mpsc::Receiver<FetchRequest>, wake: Arc<WakeFlag>, policy: crate::net::NetworkPolicy) {
     let _filter = crate::sys::StderrFilter::install(is_apple_gl_driver_noise).ok();
 
     let (rc_ctx, servo) = match build_servo(FlagWaker(wake.clone())) {
         Ok(pair) => pair,
         Err(e) => {
-            if let Ok(req) = request_rx.recv() {
+            if let Some(req) = request_rx.blocking_recv() {
                 let _ = req.reply.send(Err(e.context("Servo initialization failed")));
             }
             return;
@@ -410,9 +425,9 @@ fn servo_thread(request_rx: mpsc::Receiver<FetchRequest>, wake: Arc<WakeFlag>, p
 
         if pending.is_empty() {
             // Idle: block until a new request nudges us or the channel hangs up.
-            match request_rx.recv() {
-                Ok(req) => accept_request(&servo, &rc_ctx, &delegate, &ucm, req, &mut pending),
-                Err(_) => return,
+            match request_rx.blocking_recv() {
+                Some(req) => accept_request(&servo, &rc_ctx, &delegate, &ucm, req, &mut pending),
+                None => return,
             }
             continue;
         }
@@ -423,7 +438,7 @@ fn servo_thread(request_rx: mpsc::Receiver<FetchRequest>, wake: Arc<WakeFlag>, p
         if !pending.is_empty() {
             // Wait for Servo to wake us or the next pending deadline, whichever is sooner.
             let now = Instant::now();
-            let next = pending
+            let next_deadline = pending
                 .values()
                 .map(|p| {
                     p.state
@@ -432,8 +447,8 @@ fn servo_thread(request_rx: mpsc::Receiver<FetchRequest>, wake: Arc<WakeFlag>, p
                         .map_or(p.deadline, |t| t + Duration::from_millis(p.request.settle_ms))
                 })
                 .min()
-                .map_or(FALLBACK_WAIT, |t| t.saturating_duration_since(now).min(FALLBACK_WAIT));
-            wake.wait_and_take(next);
+                .expect("pending is non-empty");
+            wake.wait_and_take(next_deadline.saturating_duration_since(now));
         }
     }
 }
@@ -641,14 +656,18 @@ fn create_noise_removal_stylesheet() -> servo::user_contents::UserStyleSheet {
 /// fully parsed on pages with heavy inline scripts (e.g. amazon.co.jp); see
 /// servo/servo#41972.
 fn wait_for_ready_state(servo: &servo::Servo, webview: &WebView, deadline: Instant) {
-    while Instant::now() < deadline {
+    loop {
         servo.spin_event_loop();
         if matches!(eval_js(servo, webview, "document.readyState"), Ok(s) if s == "complete") {
             return;
         }
-        wait_for_wake(FALLBACK_WAIT);
+        let now = Instant::now();
+        if now >= deadline {
+            tracing::warn!("document did not finish loading; content may be incomplete");
+            return;
+        }
+        wait_for_wake(deadline.saturating_duration_since(now));
     }
-    tracing::warn!("document did not finish loading; content may be incomplete");
 }
 
 pub(crate) fn eval_js(servo: &servo::Servo, webview: &WebView, script: &str) -> Result<String> {
@@ -673,10 +692,11 @@ pub(crate) fn eval_js(servo: &servo::Servo, webview: &WebView, script: &str) -> 
         if let Some(val) = result.borrow_mut().take() {
             return val;
         }
-        if Instant::now() > deadline {
+        let now = Instant::now();
+        if now >= deadline {
             return Err(anyhow!("timeout waiting for JS evaluation"));
         }
-        wait_for_wake(FALLBACK_WAIT);
+        wait_for_wake(deadline.saturating_duration_since(now));
     }
 }
 
@@ -875,5 +895,102 @@ mod tests {
             state.console_messages.borrow().is_empty(),
             "console_messages should be empty"
         );
+    }
+
+    fn test_request(reply_tx: oneshot::Sender<Result<ServoPage>>) -> FetchRequest {
+        FetchRequest {
+            url: "test://".into(),
+            timeout_secs: 1,
+            settle_ms: 0,
+            mode: FetchMode::Content { include_a11y: false },
+            user_agent: None,
+            reply: reply_tx,
+        }
+    }
+
+    #[tokio::test]
+    async fn dispatch_request_returns_ok_when_engine_replies() {
+        let (req_tx, mut req_rx) = mpsc::channel::<FetchRequest>(1);
+        let wake = WakeFlag::default();
+        let (reply_tx, reply_rx) = oneshot::channel();
+
+        tokio::spawn(async move {
+            if let Some(req) = req_rx.recv().await {
+                let _ = req.reply.send(Ok(ServoPage::default()));
+            }
+        });
+
+        let Ok(page) = dispatch_request(&req_tx, &wake, test_request(reply_tx), reply_rx).await else {
+            panic!("expected Ok");
+        };
+        assert!(page.html.is_empty(), "default ServoPage has empty html");
+    }
+
+    #[tokio::test]
+    async fn dispatch_request_propagates_engine_error() {
+        let (req_tx, mut req_rx) = mpsc::channel::<FetchRequest>(1);
+        let wake = WakeFlag::default();
+        let (reply_tx, reply_rx) = oneshot::channel();
+
+        tokio::spawn(async move {
+            if let Some(req) = req_rx.recv().await {
+                let _ = req.reply.send(Err(anyhow!("custom failure: page exploded")));
+            }
+        });
+
+        let Err(err) = dispatch_request(&req_tx, &wake, test_request(reply_tx), reply_rx).await else {
+            panic!("expected error");
+        };
+        assert!(
+            err.to_string().contains("page exploded"),
+            "original error preserved, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn dispatch_request_yields_crashed_when_reply_dropped() {
+        let (req_tx, mut req_rx) = mpsc::channel::<FetchRequest>(1);
+        let wake = WakeFlag::default();
+        let (reply_tx, reply_rx) = oneshot::channel();
+
+        tokio::spawn(async move {
+            if let Some(req) = req_rx.recv().await {
+                drop(req.reply);
+            }
+        });
+
+        let Err(err) = dispatch_request(&req_tx, &wake, test_request(reply_tx), reply_rx).await else {
+            panic!("expected crash error");
+        };
+        assert!(err.to_string().contains("crashed"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn dispatch_request_yields_not_running_when_channel_closed() {
+        let (req_tx, req_rx) = mpsc::channel::<FetchRequest>(1);
+        let wake = WakeFlag::default();
+        let (reply_tx, reply_rx) = oneshot::channel();
+        drop(req_rx);
+
+        let Err(err) = dispatch_request(&req_tx, &wake, test_request(reply_tx), reply_rx).await else {
+            panic!("expected not running error");
+        };
+        assert!(err.to_string().contains("not running"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn outer_timeout_yields_did_not_respond_error() {
+        let (req_tx, _req_rx) = mpsc::channel::<FetchRequest>(1);
+        let wake = WakeFlag::default();
+        let (reply_tx, reply_rx) = oneshot::channel();
+        let request_fut = dispatch_request(&req_tx, &wake, test_request(reply_tx), reply_rx);
+        let deadline = Duration::from_millis(50);
+
+        let result: Result<ServoPage> = match tokio::time::timeout(deadline, request_fut).await {
+            Ok(r) => r,
+            Err(_) => Err(anyhow!("Servo engine did not respond within {}s", deadline.as_secs())),
+        };
+        let Err(err) = result else { panic!("expected timeout") };
+        assert!(err.to_string().contains("did not respond"), "got: {err}");
     }
 }

--- a/crates/servo-fetch/src/bridge.rs
+++ b/crates/servo-fetch/src/bridge.rs
@@ -20,7 +20,7 @@ use url::Url;
 
 use crate::{layout, visibility};
 
-const JS_EVAL_TIMEOUT: Duration = Duration::from_secs(10);
+const EXTRACTION_BUDGET: Duration = Duration::from_secs(10);
 
 pub(crate) fn default_user_agent() -> &'static str {
     static UA: OnceLock<String> = OnceLock::new();
@@ -263,7 +263,7 @@ pub(crate) enum FetchMode {
     ExecuteJs { expression: String },
 }
 
-type ReplyFn = Box<dyn FnOnce(Result<ServoPage>) + Send>;
+type ReplyFn = Box<dyn FnOnce(Result<ServoPage>) + Send + 'static>;
 
 struct FetchRequest {
     url: String,
@@ -357,14 +357,13 @@ fn build_request(opts: FetchOptions<'_>, reply: ReplyFn) -> FetchRequest {
     }
 }
 
-fn request_deadline(opts: &FetchOptions<'_>) -> Duration {
-    Duration::from_secs(opts.timeout_secs) + Duration::from_millis(opts.settle_ms) + Duration::from_secs(2)
+fn extraction_deadline_for(page_deadline: Instant) -> Instant {
+    page_deadline.max(Instant::now() + EXTRACTION_BUDGET)
 }
 
 pub(crate) fn fetch_page(opts: FetchOptions<'_>) -> Result<ServoPage> {
     let engine = ensure_engine();
     let (reply_tx, reply_rx) = std::sync::mpsc::sync_channel::<Result<ServoPage>>(1);
-    let deadline = request_deadline(&opts);
     let request = build_request(
         opts,
         Box::new(move |r| {
@@ -380,15 +379,9 @@ pub(crate) fn fetch_page(opts: FetchOptions<'_>) -> Result<ServoPage> {
         }
     })?;
     engine.wake.signal();
-    match reply_rx.recv_timeout(deadline) {
-        Ok(result) => result,
-        Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
-            Err(anyhow!("Servo engine did not respond within {}s", deadline.as_secs()))
-        }
-        Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
-            Err(anyhow!("Servo engine crashed while processing this page"))
-        }
-    }
+    reply_rx
+        .recv()
+        .unwrap_or_else(|_| Err(anyhow!("Servo engine crashed while processing this page")))
 }
 
 fn is_apple_gl_driver_noise(line: &str) -> bool {
@@ -570,23 +563,32 @@ fn finish_fetch(servo: &servo::Servo, p: &PendingFetch) -> Result<ServoPage> {
         let _ = ctx.make_current();
     }
 
-    wait_for_ready_state(servo, &p.webview, p.deadline);
+    let extraction_deadline = extraction_deadline_for(p.deadline);
 
-    let inner_text = eval_js(servo, &p.webview, "document.body.innerText").ok();
-    let layout_json = eval_js(servo, &p.webview, LAYOUT_JS).ok();
-    let visibility_json = eval_js(servo, &p.webview, VISIBILITY_JS).ok();
+    wait_for_ready_state(servo, &p.webview, extraction_deadline);
 
-    let html = match eval_js(servo, &p.webview, "document.documentElement.outerHTML") {
+    let inner_text = eval_js(servo, &p.webview, "document.body.innerText", extraction_deadline).ok();
+    let layout_json = eval_js(servo, &p.webview, LAYOUT_JS, extraction_deadline).ok();
+    let visibility_json = eval_js(servo, &p.webview, VISIBILITY_JS, extraction_deadline).ok();
+
+    let html = match eval_js(
+        servo,
+        &p.webview,
+        "document.documentElement.outerHTML",
+        extraction_deadline,
+    ) {
         Ok(h) if !h.is_empty() => h,
         other => other?,
     };
 
     let (screenshot, js_result) = match &p.request.mode {
         FetchMode::Screenshot { full_page } => (
-            crate::screenshot::capture(servo, &p.webview, *full_page, p.request.timeout_secs),
+            crate::screenshot::capture(servo, &p.webview, *full_page, extraction_deadline),
             None,
         ),
-        FetchMode::ExecuteJs { expression } => (None, Some(eval_js(servo, &p.webview, expression)?)),
+        FetchMode::ExecuteJs { expression } => {
+            (None, Some(eval_js(servo, &p.webview, expression, extraction_deadline)?))
+        }
         FetchMode::Content { .. } => (None, None),
     };
 
@@ -663,7 +665,7 @@ fn create_noise_removal_stylesheet() -> servo::user_contents::UserStyleSheet {
 fn wait_for_ready_state(servo: &servo::Servo, webview: &WebView, deadline: Instant) {
     loop {
         servo.spin_event_loop();
-        if matches!(eval_js(servo, webview, "document.readyState"), Ok(s) if s == "complete") {
+        if matches!(eval_js(servo, webview, "document.readyState", deadline), Ok(s) if s == "complete") {
             return;
         }
         let now = Instant::now();
@@ -675,7 +677,10 @@ fn wait_for_ready_state(servo: &servo::Servo, webview: &WebView, deadline: Insta
     }
 }
 
-pub(crate) fn eval_js(servo: &servo::Servo, webview: &WebView, script: &str) -> Result<String> {
+pub(crate) fn eval_js(servo: &servo::Servo, webview: &WebView, script: &str, deadline: Instant) -> Result<String> {
+    if Instant::now() >= deadline {
+        return Err(anyhow!("timeout waiting for JS evaluation"));
+    }
     let result: Rc<RefCell<Option<Result<String>>>> = Rc::new(RefCell::new(None));
     let cb_result = result.clone();
 
@@ -691,7 +696,6 @@ pub(crate) fn eval_js(servo: &servo::Servo, webview: &WebView, script: &str) -> 
         *cb_result.borrow_mut() = Some(val);
     });
 
-    let deadline = Instant::now() + JS_EVAL_TIMEOUT;
     loop {
         servo.spin_event_loop();
         if let Some(val) = result.borrow_mut().take() {
@@ -929,19 +933,24 @@ mod tests {
         assert_eq!(req.timeout_secs, 5);
         assert_eq!(req.settle_ms, 100);
         assert_eq!(req.user_agent.as_deref(), Some("test-ua"));
+        assert!(matches!(req.mode, FetchMode::Content { include_a11y: false }));
     }
 
     #[test]
-    fn request_deadline_sums_timeout_settle_and_buffer() {
-        let opts = FetchOptions {
-            url: "x",
-            timeout_secs: 30,
-            settle_ms: 500,
-            mode: FetchMode::Content { include_a11y: false },
-            user_agent: None,
-        };
-        // 30s + 500ms + 2s = 32.5s
-        assert_eq!(request_deadline(&opts), Duration::from_millis(32_500));
+    fn extraction_deadline_floors_at_budget_when_page_deadline_passed() {
+        let result = extraction_deadline_for(Instant::now());
+        let remaining = result.saturating_duration_since(Instant::now());
+        assert!(
+            remaining >= Duration::from_millis(9_500) && remaining <= EXTRACTION_BUDGET,
+            "remaining outside expected window: {remaining:?}"
+        );
+    }
+
+    #[test]
+    fn extraction_deadline_uses_page_deadline_when_far_future() {
+        let future = Instant::now() + Duration::from_secs(60);
+        let result = extraction_deadline_for(future);
+        assert_eq!(result, future);
     }
 
     #[test]

--- a/crates/servo-fetch/src/bridge.rs
+++ b/crates/servo-fetch/src/bridge.rs
@@ -15,7 +15,7 @@ use servo::{
     ConsoleLogLevel, EventLoopWaker, JSValue, LoadStatus, NavigationRequest, Preferences, RenderingContext,
     ServoBuilder, SoftwareRenderingContext, UserContentManager, WebView, WebViewBuilder, WebViewDelegate, WebViewId,
 };
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::mpsc;
 use url::Url;
 
 use crate::{layout, visibility};
@@ -263,13 +263,15 @@ pub(crate) enum FetchMode {
     ExecuteJs { expression: String },
 }
 
+type ReplyFn = Box<dyn FnOnce(Result<ServoPage>) + Send>;
+
 struct FetchRequest {
     url: String,
     timeout_secs: u64,
     settle_ms: u64,
     mode: FetchMode,
     user_agent: Option<String>,
-    reply: oneshot::Sender<Result<ServoPage>>,
+    reply: ReplyFn,
 }
 
 struct PendingFetch {
@@ -324,14 +326,10 @@ impl PageFetcher for ServoFetcher {
     }
 }
 
-pub(crate) fn fetch_page(opts: FetchOptions<'_>) -> Result<ServoPage> {
-    crate::runtime::block_on(fetch_page_async(opts))?
-}
+const PENDING_CAPACITY: usize = 64;
 
-pub(crate) async fn fetch_page_async(opts: FetchOptions<'_>) -> Result<ServoPage> {
-    const PENDING_CAPACITY: usize = 64;
-
-    let engine = ENGINE.get_or_init(|| {
+fn ensure_engine() -> &'static Engine {
+    ENGINE.get_or_init(|| {
         let (tx, rx) = mpsc::channel::<FetchRequest>(PENDING_CAPACITY);
         let wake = Arc::new(WakeFlag::default());
         let wake_for_thread = wake.clone();
@@ -345,45 +343,52 @@ pub(crate) async fn fetch_page_async(opts: FetchOptions<'_>) -> Result<ServoPage
             wake,
             policy,
         }
-    });
+    })
+}
 
-    let (reply_tx, reply_rx) = oneshot::channel();
-    let deadline =
-        Duration::from_secs(opts.timeout_secs) + Duration::from_millis(opts.settle_ms) + Duration::from_secs(2);
-    let request = FetchRequest {
+fn build_request(opts: FetchOptions<'_>, reply: ReplyFn) -> FetchRequest {
+    FetchRequest {
         url: opts.url.to_string(),
         timeout_secs: opts.timeout_secs,
         settle_ms: opts.settle_ms,
         mode: opts.mode,
         user_agent: opts.user_agent.map(String::from),
-        reply: reply_tx,
-    };
-
-    match tokio::time::timeout(
-        deadline,
-        dispatch_request(&engine.requests, &engine.wake, request, reply_rx),
-    )
-    .await
-    {
-        Ok(result) => result,
-        Err(_) => Err(anyhow!("Servo engine did not respond within {}s", deadline.as_secs())),
+        reply,
     }
 }
 
-async fn dispatch_request(
-    sender: &mpsc::Sender<FetchRequest>,
-    wake: &WakeFlag,
-    request: FetchRequest,
-    reply_rx: oneshot::Receiver<Result<ServoPage>>,
-) -> Result<ServoPage> {
-    sender
-        .send(request)
-        .await
-        .map_err(|_| anyhow!("Servo engine is not running (it may have crashed on a previous request)"))?;
-    wake.signal();
-    reply_rx
-        .await
-        .map_err(|_| anyhow!("Servo engine crashed while processing this page"))?
+fn request_deadline(opts: &FetchOptions<'_>) -> Duration {
+    Duration::from_secs(opts.timeout_secs) + Duration::from_millis(opts.settle_ms) + Duration::from_secs(2)
+}
+
+pub(crate) fn fetch_page(opts: FetchOptions<'_>) -> Result<ServoPage> {
+    let engine = ensure_engine();
+    let (reply_tx, reply_rx) = std::sync::mpsc::sync_channel::<Result<ServoPage>>(1);
+    let deadline = request_deadline(&opts);
+    let request = build_request(
+        opts,
+        Box::new(move |r| {
+            let _ = reply_tx.send(r);
+        }),
+    );
+    engine.requests.try_send(request).map_err(|e| match e {
+        mpsc::error::TrySendError::Full(_) => {
+            anyhow!("Servo engine queue is full ({PENDING_CAPACITY} pending); back off and retry")
+        }
+        mpsc::error::TrySendError::Closed(_) => {
+            anyhow!("Servo engine is not running (it may have crashed on a previous request)")
+        }
+    })?;
+    engine.wake.signal();
+    match reply_rx.recv_timeout(deadline) {
+        Ok(result) => result,
+        Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+            Err(anyhow!("Servo engine did not respond within {}s", deadline.as_secs()))
+        }
+        Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+            Err(anyhow!("Servo engine crashed while processing this page"))
+        }
+    }
 }
 
 fn is_apple_gl_driver_noise(line: &str) -> bool {
@@ -401,7 +406,7 @@ fn servo_thread(mut request_rx: mpsc::Receiver<FetchRequest>, wake: Arc<WakeFlag
         Ok(pair) => pair,
         Err(e) => {
             if let Some(req) = request_rx.blocking_recv() {
-                let _ = req.reply.send(Err(e.context("Servo initialization failed")));
+                (req.reply)(Err(e.context("Servo initialization failed")));
             }
             return;
         }
@@ -466,7 +471,7 @@ fn accept_request(
             pending.insert(p.webview.id(), p);
         }
         Err((req, err)) => {
-            let _ = req.reply.send(Err(err));
+            (req.reply)(Err(err));
         }
     }
 }
@@ -490,7 +495,7 @@ fn harvest(servo: &servo::Servo, delegate: &Rc<SharedDelegate>, pending: &mut Ha
         let result = finish_fetch(servo, &p);
         delegate.remove(id);
         drop(p.webview);
-        let _ = p.request.reply.send(result);
+        (p.request.reply)(result);
     }
 }
 
@@ -733,6 +738,8 @@ fn jsvalue_to_json(val: &JSValue) -> Result<Value> {
 
 #[cfg(test)]
 mod tests {
+    use tokio::sync::oneshot;
+
     use super::*;
 
     #[test]
@@ -897,100 +904,93 @@ mod tests {
         );
     }
 
-    fn test_request(reply_tx: oneshot::Sender<Result<ServoPage>>) -> FetchRequest {
+    fn closure_test_request(reply: ReplyFn) -> FetchRequest {
         FetchRequest {
             url: "test://".into(),
             timeout_secs: 1,
             settle_ms: 0,
             mode: FetchMode::Content { include_a11y: false },
             user_agent: None,
-            reply: reply_tx,
+            reply,
+        }
+    }
+
+    #[test]
+    fn build_request_preserves_fields() {
+        let opts = FetchOptions {
+            url: "test://example",
+            timeout_secs: 5,
+            settle_ms: 100,
+            mode: FetchMode::Content { include_a11y: false },
+            user_agent: Some("test-ua"),
+        };
+        let req = build_request(opts, Box::new(|_| {}));
+        assert_eq!(req.url, "test://example");
+        assert_eq!(req.timeout_secs, 5);
+        assert_eq!(req.settle_ms, 100);
+        assert_eq!(req.user_agent.as_deref(), Some("test-ua"));
+    }
+
+    #[test]
+    fn request_deadline_sums_timeout_settle_and_buffer() {
+        let opts = FetchOptions {
+            url: "x",
+            timeout_secs: 30,
+            settle_ms: 500,
+            mode: FetchMode::Content { include_a11y: false },
+            user_agent: None,
+        };
+        // 30s + 500ms + 2s = 32.5s
+        assert_eq!(request_deadline(&opts), Duration::from_millis(32_500));
+    }
+
+    #[test]
+    fn closure_reply_delivers_via_std_mpsc() {
+        let (tx, rx) = std::sync::mpsc::sync_channel::<Result<ServoPage>>(1);
+        let req = closure_test_request(Box::new(move |r| {
+            let _ = tx.send(r);
+        }));
+        (req.reply)(Ok(ServoPage::default()));
+        let Ok(Ok(page)) = rx.recv_timeout(Duration::from_millis(50)) else {
+            panic!("expected Ok delivery");
+        };
+        assert!(page.html.is_empty());
+    }
+
+    #[tokio::test]
+    async fn closure_reply_delivers_via_oneshot() {
+        let (tx, rx) = oneshot::channel::<Result<ServoPage>>();
+        let req = closure_test_request(Box::new(move |r| {
+            let _ = tx.send(r);
+        }));
+        (req.reply)(Err(anyhow!("test failure")));
+        let Ok(Err(err)) = rx.await else {
+            panic!("expected Err delivery");
+        };
+        assert!(err.to_string().contains("test failure"));
+    }
+
+    #[test]
+    fn closure_drop_disconnects_std_mpsc_receiver() {
+        let (tx, rx) = std::sync::mpsc::sync_channel::<Result<ServoPage>>(1);
+        let req = closure_test_request(Box::new(move |r| {
+            let _ = tx.send(r);
+        }));
+        drop(req); // simulate engine dropping the request before invoking reply
+        match rx.recv_timeout(Duration::from_millis(50)) {
+            Ok(_) => panic!("expected disconnect"),
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {}
+            Err(other) => panic!("expected Disconnected, got: {other:?}"),
         }
     }
 
     #[tokio::test]
-    async fn dispatch_request_returns_ok_when_engine_replies() {
-        let (req_tx, mut req_rx) = mpsc::channel::<FetchRequest>(1);
-        let wake = WakeFlag::default();
-        let (reply_tx, reply_rx) = oneshot::channel();
-
-        tokio::spawn(async move {
-            if let Some(req) = req_rx.recv().await {
-                let _ = req.reply.send(Ok(ServoPage::default()));
-            }
-        });
-
-        let Ok(page) = dispatch_request(&req_tx, &wake, test_request(reply_tx), reply_rx).await else {
-            panic!("expected Ok");
-        };
-        assert!(page.html.is_empty(), "default ServoPage has empty html");
-    }
-
-    #[tokio::test]
-    async fn dispatch_request_propagates_engine_error() {
-        let (req_tx, mut req_rx) = mpsc::channel::<FetchRequest>(1);
-        let wake = WakeFlag::default();
-        let (reply_tx, reply_rx) = oneshot::channel();
-
-        tokio::spawn(async move {
-            if let Some(req) = req_rx.recv().await {
-                let _ = req.reply.send(Err(anyhow!("custom failure: page exploded")));
-            }
-        });
-
-        let Err(err) = dispatch_request(&req_tx, &wake, test_request(reply_tx), reply_rx).await else {
-            panic!("expected error");
-        };
-        assert!(
-            err.to_string().contains("page exploded"),
-            "original error preserved, got: {err}"
-        );
-    }
-
-    #[tokio::test]
-    async fn dispatch_request_yields_crashed_when_reply_dropped() {
-        let (req_tx, mut req_rx) = mpsc::channel::<FetchRequest>(1);
-        let wake = WakeFlag::default();
-        let (reply_tx, reply_rx) = oneshot::channel();
-
-        tokio::spawn(async move {
-            if let Some(req) = req_rx.recv().await {
-                drop(req.reply);
-            }
-        });
-
-        let Err(err) = dispatch_request(&req_tx, &wake, test_request(reply_tx), reply_rx).await else {
-            panic!("expected crash error");
-        };
-        assert!(err.to_string().contains("crashed"), "got: {err}");
-    }
-
-    #[tokio::test]
-    async fn dispatch_request_yields_not_running_when_channel_closed() {
-        let (req_tx, req_rx) = mpsc::channel::<FetchRequest>(1);
-        let wake = WakeFlag::default();
-        let (reply_tx, reply_rx) = oneshot::channel();
-        drop(req_rx);
-
-        let Err(err) = dispatch_request(&req_tx, &wake, test_request(reply_tx), reply_rx).await else {
-            panic!("expected not running error");
-        };
-        assert!(err.to_string().contains("not running"), "got: {err}");
-    }
-
-    #[tokio::test]
-    async fn outer_timeout_yields_did_not_respond_error() {
-        let (req_tx, _req_rx) = mpsc::channel::<FetchRequest>(1);
-        let wake = WakeFlag::default();
-        let (reply_tx, reply_rx) = oneshot::channel();
-        let request_fut = dispatch_request(&req_tx, &wake, test_request(reply_tx), reply_rx);
-        let deadline = Duration::from_millis(50);
-
-        let result: Result<ServoPage> = match tokio::time::timeout(deadline, request_fut).await {
-            Ok(r) => r,
-            Err(_) => Err(anyhow!("Servo engine did not respond within {}s", deadline.as_secs())),
-        };
-        let Err(err) = result else { panic!("expected timeout") };
-        assert!(err.to_string().contains("did not respond"), "got: {err}");
+    async fn closure_drop_disconnects_oneshot_receiver() {
+        let (tx, rx) = oneshot::channel::<Result<ServoPage>>();
+        let req = closure_test_request(Box::new(move |r| {
+            let _ = tx.send(r);
+        }));
+        drop(req);
+        assert!(rx.await.is_err());
     }
 }

--- a/crates/servo-fetch/src/screenshot.rs
+++ b/crates/servo-fetch/src/screenshot.rs
@@ -2,7 +2,7 @@
 
 use std::cell::RefCell;
 use std::rc::Rc;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 use dpi::PhysicalSize;
 use euclid::{Box2D, Point2D};
@@ -18,7 +18,7 @@ pub(crate) fn capture(
     servo: &servo::Servo,
     webview: &WebView,
     full_page: bool,
-    timeout_secs: u64,
+    deadline: Instant,
 ) -> Option<RgbaImage> {
     /// 16,384 matches the GPU texture limit on most modern hardware and caps
     /// the RGBA framebuffer at ~1 GB.
@@ -27,17 +27,17 @@ pub(crate) fn capture(
     let viewport = PhysicalSize::new(layout::VIEWPORT_WIDTH, layout::VIEWPORT_HEIGHT);
 
     if !full_page {
-        return take_screenshot(servo, webview, None, timeout_secs);
+        return take_screenshot(servo, webview, None, deadline);
     }
 
-    let Some(measured) = measure_full_page(servo, webview) else {
+    let Some(measured) = measure_full_page(servo, webview, deadline) else {
         tracing::warn!("failed to measure full page size; falling back to viewport screenshot");
-        return take_screenshot(servo, webview, None, timeout_secs);
+        return take_screenshot(servo, webview, None, deadline);
     };
 
     let Some(resized) = resolve_full_page_size(measured, viewport, MAX_PIXELS) else {
         // Content already fits in the viewport; skip the resize round-trip.
-        return take_screenshot(servo, webview, None, timeout_secs);
+        return take_screenshot(servo, webview, None, deadline);
     };
 
     if resized != measured {
@@ -57,7 +57,7 @@ pub(crate) fn capture(
         size: viewport,
     };
     webview.resize(resized);
-    take_screenshot(servo, webview, Some(device_rect(resized)), timeout_secs)
+    take_screenshot(servo, webview, Some(device_rect(resized)), deadline)
 }
 
 /// RAII guard that restores the `WebView`'s viewport size on drop.
@@ -78,7 +78,7 @@ fn take_screenshot(
     servo: &servo::Servo,
     webview: &WebView,
     rect: Option<WebViewRect>,
-    timeout_secs: u64,
+    deadline: Instant,
 ) -> Option<RgbaImage> {
     let result: Rc<RefCell<Option<Result<RgbaImage, servo::ScreenshotCaptureError>>>> = Rc::new(RefCell::new(None));
     let cb_result = result.clone();
@@ -86,7 +86,6 @@ fn take_screenshot(
         *cb_result.borrow_mut() = Some(r);
     });
 
-    let deadline = Instant::now() + Duration::from_secs(timeout_secs);
     loop {
         servo.spin_event_loop();
         if let Some(outcome) = result.borrow_mut().take() {
@@ -94,11 +93,12 @@ fn take_screenshot(
                 .inspect_err(|e| tracing::warn!(error = ?e, "screenshot capture failed"))
                 .ok();
         }
-        if Instant::now() > deadline {
-            tracing::warn!(timeout_secs, "screenshot capture timed out");
+        let now = Instant::now();
+        if now >= deadline {
+            tracing::warn!("screenshot capture timed out");
             return None;
         }
-        wait_for_wake(Duration::from_millis(10));
+        wait_for_wake(deadline.saturating_duration_since(now));
     }
 }
 
@@ -128,7 +128,7 @@ fn resolve_full_page_size(
 }
 
 /// Read the full scrollable content size via JS, saturating at [`u32::MAX`].
-fn measure_full_page(servo: &servo::Servo, webview: &WebView) -> Option<PhysicalSize<u32>> {
+fn measure_full_page(servo: &servo::Servo, webview: &WebView, deadline: Instant) -> Option<PhysicalSize<u32>> {
     const SIZE_JS: &str = r"
         JSON.stringify({
             w: Math.max(document.body.scrollWidth, document.documentElement.scrollWidth),
@@ -140,7 +140,7 @@ fn measure_full_page(servo: &servo::Servo, webview: &WebView) -> Option<Physical
         w: f64,
         h: f64,
     }
-    let raw = eval_js(servo, webview, SIZE_JS).ok()?;
+    let raw = eval_js(servo, webview, SIZE_JS, deadline).ok()?;
     let size: Size = serde_json::from_str(&raw).ok()?;
 
     #[expect(


### PR DESCRIPTION
## Summary

Migrate the Servo engine bridge to a closure-capture reply pattern with engine-owned timeout (single source of truth).

## Test Plan

```
cargo test -p servo-fetch --lib  # all passed
RUSTDOCFLAGS="-D warnings" cargo doc --workspace --lib --no-deps --locked
```

## Checklist

- [x] Ran `cargo +nightly fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
- [x] Documentation updated (no user-facing behavior change; pure internal refactor)
- [x] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it
