### PR TITLE
feat(api): split sync and async

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ servo-fetch "https://example.com" --format png -o page.png # PNG screenshot
 
 ```rust
 // Rust
-let md = servo_fetch::markdown("https://example.com")?;
+let md = servo_fetch::blocking::markdown("https://example.com")?;
 ```
 
 ```python
@@ -122,32 +122,32 @@ cargo add servo-fetch
 ```
 
 ```rust
-// URL → Markdown in one line
-let md = servo_fetch::markdown("https://example.com")?;
+// URL → Markdown in one line (async by default; use `blocking::*` for sync)
+let md = servo_fetch::markdown("https://example.com").await?;
 
 // Fetch with options
 use servo_fetch::{fetch, FetchOptions};
 use std::time::Duration;
 
-let page = fetch(FetchOptions::new("https://example.com").timeout(Duration::from_secs(60)))?;
+let page = fetch(&FetchOptions::new("https://example.com").timeout(Duration::from_secs(60))).await?;
 println!("{}", page.html);
 let md = page.markdown()?;
 
 // Crawl a site
 servo_fetch::crawl_each(
-    servo_fetch::CrawlOptions::new("https://docs.example.com")
+    &servo_fetch::CrawlOptions::new("https://docs.example.com")
         .limit(100)
         .user_agent("MyBot/1.0"),
     |result| match &result.outcome {
         Ok(page) => println!("{}: {} chars", result.url, page.content.len()),
         Err(e) => eprintln!("{}: {e}", result.url),
     },
-)?;
+).await?;
 
 // Discover URLs via sitemap (no rendering)
 let urls = servo_fetch::map(
-    servo_fetch::MapOptions::new("https://example.com").limit(1000),
-)?;
+    &servo_fetch::MapOptions::new("https://example.com").limit(1000),
+).await?;
 for u in &urls {
     println!("{}", u.url);
 }

--- a/bindings/python/src/client.rs
+++ b/bindings/python/src/client.rs
@@ -57,7 +57,9 @@ impl Client {
             javascript,
             schema,
         })?;
-        let page = py.detach(|| servo_fetch::fetch(prepared.opts)).map_err(map_error)?;
+        let page = py
+            .detach(|| servo_fetch::blocking::fetch(&prepared.opts))
+            .map_err(map_error)?;
         Ok(Page::new(
             page,
             prepared.url,
@@ -101,7 +103,7 @@ impl Client {
             concurrency,
             delay_ms,
         )?;
-        let results = py.detach(|| servo_fetch::crawl(opts)).map_err(map_error)?;
+        let results = py.detach(|| servo_fetch::blocking::crawl(&opts)).map_err(map_error)?;
         Ok(results.into_iter().map(CrawlResult::from_core).collect())
     }
 
@@ -138,7 +140,7 @@ impl Client {
         let cb_err: Mutex<Option<PyErr>> = Mutex::new(None);
 
         let result = py.detach(|| {
-            servo_fetch::crawl_each(opts, |r| {
+            servo_fetch::blocking::crawl_each(&opts, |r| {
                 if stop.load(Ordering::Acquire) {
                     return;
                 }
@@ -198,7 +200,7 @@ impl Client {
         if let Some(ua) = self.user_agent.as_deref() {
             opts = opts.user_agent(ua);
         }
-        let urls = py.detach(|| servo_fetch::map(opts)).map_err(map_error)?;
+        let urls = py.detach(|| servo_fetch::blocking::map(&opts)).map_err(map_error)?;
         Ok(urls.into_iter().map(MappedUrl::from_core).collect())
     }
 

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -37,7 +37,9 @@ fn fetch(
         javascript,
         schema,
     })?;
-    let servo_page = py.detach(|| servo_fetch::fetch(prepared.opts)).map_err(map_error)?;
+    let servo_page = py
+        .detach(|| servo_fetch::blocking::fetch(&prepared.opts))
+        .map_err(map_error)?;
     Ok(page::Page::new(
         servo_page,
         prepared.url,

--- a/crates/servo-fetch-cli/src/commands/crawl.rs
+++ b/crates/servo-fetch-cli/src/commands/crawl.rs
@@ -34,7 +34,7 @@ pub(crate) fn run(args: &CrawlArgs) -> anyhow::Result<()> {
     let mut write_err: Option<anyhow::Error> = None;
     let started = Instant::now();
 
-    servo_fetch::crawl_each(opts, |result| {
+    servo_fetch::blocking::crawl_each(&opts, |result| {
         completed += 1;
         if result.outcome.is_err() {
             errors += 1;

--- a/crates/servo-fetch-cli/src/commands/fetch.rs
+++ b/crates/servo-fetch-cli/src/commands/fetch.rs
@@ -72,7 +72,7 @@ fn run_single(args: &FetchArgs, url_str: &str) -> Result<()> {
     progress.ticker(&format!("Fetching {url_str}..."));
 
     let opts = build_fetch_options(args, url_str)?;
-    let page = servo_fetch::fetch(opts).map_err(Error::from);
+    let page = servo_fetch::blocking::fetch(&opts).map_err(Error::from);
     progress.clear();
     let page = page?;
     dispatch_output(args, &page, url_str, sink(args))
@@ -108,7 +108,7 @@ async fn run_batch(args: &FetchArgs, urls: &[String]) -> Result<()> {
             if let Some(s) = schema {
                 opts = opts.schema(s);
             }
-            let result = servo_fetch::fetch(opts);
+            let result = servo_fetch::blocking::fetch(&opts);
             let _ = tx.blocking_send((url_str, result));
             drop(permit);
         });

--- a/crates/servo-fetch-cli/src/commands/map.rs
+++ b/crates/servo-fetch-cli/src/commands/map.rs
@@ -20,7 +20,7 @@ pub(crate) fn run(args: &MapArgs) -> anyhow::Result<()> {
         opts = opts.user_agent(ua);
     }
 
-    let results = servo_fetch::map(opts)?;
+    let results = servo_fetch::blocking::map(&opts)?;
 
     let mut out = io::stdout().lock();
     if args.json {

--- a/crates/servo-fetch-cli/src/tools/crawl.rs
+++ b/crates/servo-fetch-cli/src/tools/crawl.rs
@@ -45,7 +45,7 @@ pub(crate) async fn crawl_pages(opts: CrawlOptions<'_>) -> ToolResult<Vec<(Strin
     let max_len = opts.max_len;
     tokio::task::spawn_blocking(move || {
         let mut results = Vec::new();
-        servo_fetch::crawl_each(builder, |r| {
+        servo_fetch::blocking::crawl_each(&builder, |r| {
             let text = match &r.outcome {
                 Ok(page) => paginate(&servo_fetch::sanitize::sanitize(&page.content), 0, max_len),
                 Err(e) => format!("[error] {e}"),

--- a/crates/servo-fetch-cli/src/tools/fetch.rs
+++ b/crates/servo-fetch-cli/src/tools/fetch.rs
@@ -16,8 +16,8 @@ pub(crate) async fn fetch_page(url: &str, timeout: u64, settle_ms: u64) -> ToolR
         .map_err(|e| ToolError::internal(format!("fetch semaphore closed: {e}")))?;
     let url = url.to_string();
     spawn_blocking(move || {
-        servo_fetch::fetch(
-            FetchOptions::new(&url)
+        servo_fetch::blocking::fetch(
+            &FetchOptions::new(&url)
                 .timeout(Duration::from_secs(timeout))
                 .settle(Duration::from_millis(settle_ms)),
         )
@@ -35,8 +35,8 @@ pub(crate) async fn fetch_js(url: &str, expression: &str, timeout: u64, settle_m
     let url = url.to_string();
     let expression = expression.to_string();
     spawn_blocking(move || {
-        servo_fetch::fetch(
-            FetchOptions::javascript(&url, &expression)
+        servo_fetch::blocking::fetch(
+            &FetchOptions::javascript(&url, &expression)
                 .timeout(Duration::from_secs(timeout))
                 .settle(Duration::from_millis(settle_ms)),
         )
@@ -53,8 +53,8 @@ pub(crate) async fn fetch_screenshot(url: &str, full_page: bool, timeout: u64, s
         .map_err(|e| ToolError::internal(format!("fetch semaphore closed: {e}")))?;
     let url = url.to_string();
     spawn_blocking(move || {
-        servo_fetch::fetch(
-            FetchOptions::screenshot(&url, full_page)
+        servo_fetch::blocking::fetch(
+            &FetchOptions::screenshot(&url, full_page)
                 .timeout(Duration::from_secs(timeout))
                 .settle(Duration::from_millis(settle_ms)),
         )
@@ -102,8 +102,8 @@ fn fetch_and_render(
     selector: Option<&str>,
     max_len: usize,
 ) -> String {
-    let page = match servo_fetch::fetch(
-        FetchOptions::new(url)
+    let page = match servo_fetch::blocking::fetch(
+        &FetchOptions::new(url)
             .timeout(Duration::from_secs(timeout))
             .settle(Duration::from_millis(settle_ms)),
     ) {

--- a/crates/servo-fetch-cli/src/tools/map.rs
+++ b/crates/servo-fetch-cli/src/tools/map.rs
@@ -20,7 +20,7 @@ pub(crate) async fn discover_urls(
         opts.exclude(&exclude_glob.iter().map(String::as_str).collect::<Vec<_>>())
     };
 
-    let results = tokio::task::spawn_blocking(move || servo_fetch::map(opts))
+    let results = tokio::task::spawn_blocking(move || servo_fetch::blocking::map(&opts))
         .await
         .map_err(|e| ToolError::internal(e.to_string()))?
         .map_err(|e| ToolError::fetch(e.to_string()))?;

--- a/crates/servo-fetch/README.md
+++ b/crates/servo-fetch/README.md
@@ -13,7 +13,7 @@ Looking for the CLI? See [`servo-fetch-cli`](https://crates.io/crates/servo-fetc
 - **Real JS execution** — SpiderMonkey runs JavaScript, parallel CSS engine computes layout
 - **Layout- and visibility-aware extraction** — strips navbars/footers by rendered position, plus cookie banners, modals, and CSS-hidden content
 - **Schema-driven JSON** — declarative CSS-selector schema pulls structured data, no LLM
-- **Sync API** — no async runtime required; wrap with `spawn_blocking` for async contexts
+- **Async-first API** — top-level functions are `async`; sync mirror in [`blocking`] submodule
 - **PDF auto-detection** — URLs returning PDF are automatically extracted as text
 - **Typed errors** — `Error::Timeout`, `Error::InvalidUrl`, etc. for match-based retry logic
 - **SSRF protection** — blocks private IPs, reserved ranges, and metadata endpoints
@@ -21,7 +21,13 @@ Looking for the CLI? See [`servo-fetch-cli`](https://crates.io/crates/servo-fetc
 ## Quick Start
 
 ```rust
-let md = servo_fetch::markdown("https://example.com")?;
+let md = servo_fetch::markdown("https://example.com").await?;
+```
+
+For synchronous code, use the [`blocking`] submodule:
+
+```rust
+let md = servo_fetch::blocking::markdown("https://example.com")?;
 ```
 
 ## Examples
@@ -33,11 +39,11 @@ use servo_fetch::{fetch, FetchOptions};
 use std::time::Duration;
 
 let page = fetch(
-    FetchOptions::new("https://spa-site.com")
+    &FetchOptions::new("https://spa-site.com")
         .timeout(Duration::from_secs(60))
         .settle(Duration::from_millis(3000))
         .user_agent("MyBot/1.0"),
-)?;
+).await?;
 println!("{}", page.html);
 let md = page.markdown()?;
 ```
@@ -47,7 +53,7 @@ let md = page.markdown()?;
 ```rust
 use servo_fetch::{fetch, FetchOptions};
 
-let page = fetch(FetchOptions::screenshot("https://example.com", true))?;
+let page = fetch(&FetchOptions::screenshot("https://example.com", true)).await?;
 std::fs::write("page.png", page.screenshot_png().unwrap())?;
 ```
 
@@ -56,7 +62,7 @@ std::fs::write("page.png", page.screenshot_png().unwrap())?;
 ```rust
 use servo_fetch::{fetch, FetchOptions};
 
-let page = fetch(FetchOptions::javascript("https://example.com", "document.title"))?;
+let page = fetch(&FetchOptions::javascript("https://example.com", "document.title")).await?;
 println!("{}", page.js_result.unwrap());
 ```
 
@@ -66,14 +72,14 @@ println!("{}", page.js_result.unwrap());
 use servo_fetch::{crawl_each, CrawlOptions};
 
 crawl_each(
-    CrawlOptions::new("https://docs.example.com")
+    &CrawlOptions::new("https://docs.example.com")
         .limit(100)
         .include(&["/docs/**"]),
     |result| match &result.outcome {
         Ok(page) => println!("{}: {} chars", result.url, page.content.len()),
         Err(e) => eprintln!("{}: {e}", result.url),
     },
-)?;
+).await?;
 ```
 
 ### Schema-driven JSON extraction
@@ -94,7 +100,7 @@ let product_schema = ExtractSchema::from_json(r#"{
     ]
 }"#)?;
 
-let page = fetch(FetchOptions::new("https://shop.example.com").schema(product_schema))?;
+let page = fetch(&FetchOptions::new("https://shop.example.com").schema(product_schema)).await?;
 if let Some(value) = &page.extracted {
     println!("{}", serde_json::to_string_pretty(value)?);
 }
@@ -110,7 +116,7 @@ programmatic construction, see [`ExtractSchema::builder()`].
 ```rust
 use servo_fetch::{fetch, FetchOptions, Error};
 
-match fetch(FetchOptions::new(url)) {
+match fetch(&FetchOptions::new(url)).await {
     Ok(page) => { /* ... */ }
     Err(Error::Timeout { .. }) => { /* retry */ }
     Err(Error::AddressNotAllowed { .. }) => { /* skip */ }
@@ -118,12 +124,29 @@ match fetch(FetchOptions::new(url)) {
 }
 ```
 
-### From async contexts
+### Client
 
 ```rust
-let page = tokio::task::spawn_blocking(|| {
-    servo_fetch::fetch(servo_fetch::FetchOptions::new("https://example.com"))
-}).await??;
+use servo_fetch::Client;
+use std::time::Duration;
+
+let client = Client::builder()
+    .timeout(Duration::from_secs(60))
+    .user_agent("MyBot/1.0")
+    .build();
+
+let p1 = client.fetch("https://a.com").await?;
+let p2 = client.fetch("https://b.com").await?;
+```
+
+### Sync mode
+
+```rust
+use servo_fetch::blocking;
+
+let md = blocking::markdown("https://example.com")?;
+let client = blocking::Client::builder().timeout(std::time::Duration::from_secs(60)).build();
+let page = client.fetch("https://example.com")?;
 ```
 
 ## Environment Variables
@@ -134,16 +157,18 @@ let page = tokio::task::spawn_blocking(|| {
 
 ## API Overview
 
-| Function | Description |
-| -------- | ----------- |
-| `markdown(url)` | Fetch → readable Markdown |
-| `extract_json(url)` | Fetch → structured JSON |
-| `text(url)` | Fetch → plain text (`innerText`) |
-| `fetch(opts)` | Fetch with full options → `Page` |
-| `crawl(opts)` | Crawl site → `Vec<CrawlResult>` |
-| `crawl_each(opts, cb)` | Crawl site, streaming results |
-| `map(opts)` | Discover URLs via sitemaps → `Vec<MappedUrl>` |
-| `schema.extract_from(html)` | Apply a CSS-selector schema to HTML → `serde_json::Value` |
+Every function is available in both async (top-level) and sync (`blocking::*`) form.
+
+| Function | Returns |
+| -------- | ------- |
+| `markdown(url)` | Readable Markdown |
+| `text(url)` | Plain text (`innerText`) |
+| `extract_json(url)` | Structured JSON |
+| `fetch(opts)` | `Page` |
+| `crawl(opts)` | `Vec<CrawlResult>` |
+| `crawl_each(opts, cb)` | Streaming results via callback |
+| `map(opts)` | `Vec<MappedUrl>` (URL discovery) |
+| `Client` / `ClientBuilder` | Reusable client with defaults |
 
 See [docs.rs](https://docs.rs/servo-fetch) for the full API reference and [`examples/`](examples/) for complete runnable programs.
 

--- a/crates/servo-fetch/examples/crawl.rs
+++ b/crates/servo-fetch/examples/crawl.rs
@@ -2,9 +2,10 @@
 
 use servo_fetch::{CrawlOptions, crawl_each};
 
-fn main() -> Result<(), servo_fetch::Error> {
+#[tokio::main]
+async fn main() -> Result<(), servo_fetch::Error> {
     crawl_each(
-        CrawlOptions::new("https://example.com").limit(5).max_depth(1),
+        &CrawlOptions::new("https://example.com").limit(5).max_depth(1),
         |result| match &result.outcome {
             Ok(page) => {
                 println!("✓ {} (depth={}, links={})", result.url, result.depth, page.links_found);
@@ -13,7 +14,8 @@ fn main() -> Result<(), servo_fetch::Error> {
                 println!("✗ {} — {e}", result.url);
             }
         },
-    )?;
+    )
+    .await?;
 
     Ok(())
 }

--- a/crates/servo-fetch/examples/error_handling.rs
+++ b/crates/servo-fetch/examples/error_handling.rs
@@ -2,7 +2,8 @@
 
 use servo_fetch::{Error, FetchOptions, fetch};
 
-fn main() {
+#[tokio::main]
+async fn main() {
     let urls = [
         "https://example.com",
         "not a url",
@@ -11,7 +12,7 @@ fn main() {
     ];
 
     for url in urls {
-        match fetch(FetchOptions::new(url)) {
+        match fetch(&FetchOptions::new(url)).await {
             Ok(page) => println!("✓ {url} — {} bytes", page.html.len()),
             Err(e) if e.is_timeout() => println!("⏱ {url} — timeout, retrying..."),
             Err(Error::InvalidUrl { reason, .. }) => println!("✗ {url} — {reason}"),

--- a/crates/servo-fetch/examples/extract_json.rs
+++ b/crates/servo-fetch/examples/extract_json.rs
@@ -1,7 +1,8 @@
 //! Extract structured JSON from a page.
 
-fn main() -> Result<(), servo_fetch::Error> {
-    let json = servo_fetch::extract_json("https://example.com")?;
+#[tokio::main]
+async fn main() -> Result<(), servo_fetch::Error> {
+    let json = servo_fetch::extract_json("https://example.com").await?;
     println!("{json}");
     Ok(())
 }

--- a/crates/servo-fetch/examples/fetch_options.rs
+++ b/crates/servo-fetch/examples/fetch_options.rs
@@ -4,12 +4,14 @@ use std::time::Duration;
 
 use servo_fetch::{FetchOptions, fetch};
 
-fn main() -> Result<(), servo_fetch::Error> {
+#[tokio::main]
+async fn main() -> Result<(), servo_fetch::Error> {
     let page = fetch(
-        FetchOptions::new("https://example.com")
+        &FetchOptions::new("https://example.com")
             .timeout(Duration::from_secs(60))
             .settle(Duration::from_secs(3)),
-    )?;
+    )
+    .await?;
 
     println!("Title: {:?}", page.title);
     println!("HTML length: {}", page.html.len());

--- a/crates/servo-fetch/examples/javascript.rs
+++ b/crates/servo-fetch/examples/javascript.rs
@@ -2,8 +2,9 @@
 
 use servo_fetch::{FetchOptions, fetch};
 
-fn main() -> Result<(), servo_fetch::Error> {
-    let page = fetch(FetchOptions::javascript("https://example.com", "document.title"))?;
+#[tokio::main]
+async fn main() -> Result<(), servo_fetch::Error> {
+    let page = fetch(&FetchOptions::javascript("https://example.com", "document.title")).await?;
 
     println!("JS result: {:?}", page.js_result);
 

--- a/crates/servo-fetch/examples/schema_extract.rs
+++ b/crates/servo-fetch/examples/schema_extract.rs
@@ -3,7 +3,8 @@
 use servo_fetch::schema::ExtractSchema;
 use servo_fetch::{FetchOptions, fetch};
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let product_schema = ExtractSchema::from_json(
         r#"{
         "base_selector": ".product",
@@ -15,7 +16,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }"#,
     )?;
 
-    let page = fetch(FetchOptions::new("https://shop.example.com").schema(product_schema))?;
+    let page = fetch(&FetchOptions::new("https://shop.example.com").schema(product_schema)).await?;
 
     match page.extracted {
         Some(value) => println!("{}", serde_json::to_string_pretty(&value)?),

--- a/crates/servo-fetch/examples/screenshot.rs
+++ b/crates/servo-fetch/examples/screenshot.rs
@@ -2,8 +2,9 @@
 
 use servo_fetch::{FetchOptions, fetch};
 
-fn main() -> Result<(), servo_fetch::Error> {
-    let page = fetch(FetchOptions::screenshot("https://example.com", true))?;
+#[tokio::main]
+async fn main() -> Result<(), servo_fetch::Error> {
+    let page = fetch(&FetchOptions::screenshot("https://example.com", true)).await?;
 
     match page.screenshot_png() {
         Some(png) => {

--- a/crates/servo-fetch/examples/simple.rs
+++ b/crates/servo-fetch/examples/simple.rs
@@ -1,7 +1,8 @@
 //! Fetch a page and extract Markdown.
 
-fn main() -> Result<(), servo_fetch::Error> {
-    let md = servo_fetch::markdown("https://example.com")?;
+#[tokio::main]
+async fn main() -> Result<(), servo_fetch::Error> {
+    let md = servo_fetch::markdown("https://example.com").await?;
     println!("{md}");
     Ok(())
 }

--- a/crates/servo-fetch/src/blocking.rs
+++ b/crates/servo-fetch/src/blocking.rs
@@ -1,0 +1,12 @@
+//! Blocking API mirror of the top-level async API.
+
+mod client;
+
+pub use client::{Client, ClientBuilder};
+
+pub use crate::crawl::{crawl_blocking as crawl, crawl_each_blocking as crawl_each};
+pub use crate::fetch::{
+    extract_json_blocking as extract_json, fetch_blocking as fetch, markdown_blocking as markdown,
+    text_blocking as text,
+};
+pub use crate::map::map_blocking as map;

--- a/crates/servo-fetch/src/blocking/client.rs
+++ b/crates/servo-fetch/src/blocking/client.rs
@@ -38,8 +38,11 @@ impl Client {
     }
 
     /// Fetch a page with explicit options.
+    ///
+    /// Unset fields on `opts` fall back to the client's defaults; explicit
+    /// values on `opts` always win.
     pub fn fetch_with(&self, opts: &FetchOptions) -> Result<Page> {
-        fetch_blocking(opts)
+        fetch_blocking(&self.apply_defaults(opts))
     }
 
     /// Fetch and extract readable Markdown.
@@ -59,7 +62,7 @@ impl Client {
 
     /// Capture a PNG screenshot of the page.
     pub fn screenshot(&self, url: &str, opts: &ScreenshotOptions) -> Result<Vec<u8>> {
-        let fopts = self.apply_defaults(FetchOptions::screenshot(url, opts.full_page));
+        let fopts = self.apply_defaults(&FetchOptions::screenshot(url, opts.full_page));
         let page = fetch_blocking(&fopts)?;
         page.screenshot_png()
             .map(<[u8]>::to_vec)
@@ -68,24 +71,33 @@ impl Client {
 
     /// Execute a JavaScript expression after page load and return the result.
     pub fn execute_js(&self, url: &str, expression: impl Into<String>) -> Result<String> {
-        let fopts = self.apply_defaults(FetchOptions::javascript(url, expression));
+        let fopts = self.apply_defaults(&FetchOptions::javascript(url, expression));
         let page = fetch_blocking(&fopts)?;
         page.js_result
             .ok_or_else(|| Error::javascript(anyhow::anyhow!("execute_js returned no result"), Some(url.to_string())))
     }
 
-    fn apply_defaults(&self, mut opts: FetchOptions) -> FetchOptions {
-        opts.timeout = self.inner.timeout;
-        opts.settle = self.inner.settle;
-        opts.visibility = self.inner.visibility;
-        if let Some(ua) = &self.inner.user_agent {
-            opts.user_agent = Some(ua.clone());
+    fn apply_defaults(&self, opts: &FetchOptions) -> FetchOptions {
+        let mut opts = opts.clone();
+        if opts.timeout.is_none() {
+            opts.timeout = Some(self.inner.timeout);
+        }
+        if opts.settle.is_none() {
+            opts.settle = Some(self.inner.settle);
+        }
+        if opts.visibility.is_none() {
+            opts.visibility = Some(self.inner.visibility);
+        }
+        if opts.user_agent.is_none()
+            && let Some(ua) = self.inner.user_agent.as_deref()
+        {
+            opts.user_agent = Some(ua.to_owned());
         }
         opts
     }
 
     fn options(&self, url: &str) -> FetchOptions {
-        self.apply_defaults(FetchOptions::new(url))
+        self.apply_defaults(&FetchOptions::new(url))
     }
 }
 

--- a/crates/servo-fetch/src/blocking/client.rs
+++ b/crates/servo-fetch/src/blocking/client.rs
@@ -1,0 +1,192 @@
+//! Blocking client mirror of [`crate::Client`].
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::error::{Error, Result};
+use crate::fetch::{FetchOptions, Page, fetch_blocking};
+use crate::visibility::VisibilityPolicy;
+use crate::{ScreenshotOptions, client};
+
+/// Blocking client carrying reusable fetch defaults.
+#[derive(Debug, Clone)]
+pub struct Client {
+    inner: Arc<client::ClientInner>,
+}
+
+impl Default for Client {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Client {
+    /// Construct a client with default options.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::builder().build()
+    }
+
+    /// Begin building a client with custom options.
+    pub fn builder() -> ClientBuilder {
+        ClientBuilder::default()
+    }
+
+    /// Fetch a page using the client's default options.
+    pub fn fetch(&self, url: &str) -> Result<Page> {
+        fetch_blocking(&self.options(url))
+    }
+
+    /// Fetch a page with explicit options.
+    pub fn fetch_with(&self, opts: &FetchOptions) -> Result<Page> {
+        fetch_blocking(opts)
+    }
+
+    /// Fetch and extract readable Markdown.
+    pub fn markdown(&self, url: &str) -> Result<String> {
+        self.fetch(url)?.markdown_with_url(url)
+    }
+
+    /// Fetch and extract plain text (`document.body.innerText`).
+    pub fn text(&self, url: &str) -> Result<String> {
+        Ok(self.fetch(url)?.inner_text)
+    }
+
+    /// Fetch and extract structured JSON.
+    pub fn extract_json(&self, url: &str) -> Result<String> {
+        self.fetch(url)?.extract_json_with_url(url)
+    }
+
+    /// Capture a PNG screenshot of the page.
+    pub fn screenshot(&self, url: &str, opts: &ScreenshotOptions) -> Result<Vec<u8>> {
+        let fopts = self.apply_defaults(FetchOptions::screenshot(url, opts.full_page));
+        let page = fetch_blocking(&fopts)?;
+        page.screenshot_png()
+            .map(<[u8]>::to_vec)
+            .ok_or_else(|| Error::screenshot(anyhow::anyhow!("screenshot returned no data"), Some(url.to_string())))
+    }
+
+    /// Execute a JavaScript expression after page load and return the result.
+    pub fn execute_js(&self, url: &str, expression: impl Into<String>) -> Result<String> {
+        let fopts = self.apply_defaults(FetchOptions::javascript(url, expression));
+        let page = fetch_blocking(&fopts)?;
+        page.js_result
+            .ok_or_else(|| Error::javascript(anyhow::anyhow!("execute_js returned no result"), Some(url.to_string())))
+    }
+
+    fn apply_defaults(&self, mut opts: FetchOptions) -> FetchOptions {
+        opts.timeout = self.inner.timeout;
+        opts.settle = self.inner.settle;
+        opts.visibility = self.inner.visibility;
+        if let Some(ua) = &self.inner.user_agent {
+            opts.user_agent = Some(ua.clone());
+        }
+        opts
+    }
+
+    fn options(&self, url: &str) -> FetchOptions {
+        self.apply_defaults(FetchOptions::new(url))
+    }
+}
+
+/// Builder for [`Client`].
+#[must_use = "ClientBuilder does nothing until .build() is called"]
+#[derive(Debug, Default)]
+pub struct ClientBuilder {
+    inner: client::ClientBuilder,
+}
+
+impl ClientBuilder {
+    /// Default page-load timeout (default 30s).
+    pub fn timeout(mut self, timeout: Duration) -> Self {
+        self.inner = self.inner.timeout(timeout);
+        self
+    }
+
+    /// Default settle wait after the load event (default 0).
+    pub fn settle(mut self, settle: Duration) -> Self {
+        self.inner = self.inner.settle(settle);
+        self
+    }
+
+    /// Default User-Agent header.
+    pub fn user_agent(mut self, ua: impl Into<String>) -> Self {
+        self.inner = self.inner.user_agent(ua);
+        self
+    }
+
+    /// Default visibility policy applied during extraction.
+    pub fn visibility(mut self, policy: VisibilityPolicy) -> Self {
+        self.inner = self.inner.visibility(policy);
+        self
+    }
+
+    /// Build the [`Client`].
+    #[must_use]
+    pub fn build(self) -> Client {
+        Client {
+            inner: Arc::new(self.inner.build_inner()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn client_default_uses_30s_timeout() {
+        assert_eq!(Client::default().inner.timeout, Duration::from_secs(30));
+    }
+
+    #[test]
+    fn client_builder_sets_timeout() {
+        let client = Client::builder().timeout(Duration::from_secs(60)).build();
+        assert_eq!(client.inner.timeout, Duration::from_secs(60));
+    }
+
+    #[test]
+    fn client_builder_sets_settle() {
+        let client = Client::builder().settle(Duration::from_millis(500)).build();
+        assert_eq!(client.inner.settle, Duration::from_millis(500));
+    }
+
+    #[test]
+    fn client_builder_sets_visibility() {
+        let client = Client::builder().visibility(VisibilityPolicy::off()).build();
+        assert_eq!(client.inner.visibility, VisibilityPolicy::off());
+    }
+
+    #[test]
+    fn client_builder_sanitizes_user_agent() {
+        let client = Client::builder().user_agent("Bot\r\nX-Evil: yes").build();
+        assert_eq!(client.inner.user_agent.as_deref(), Some("Bot  X-Evil: yes"));
+    }
+
+    #[test]
+    fn client_clone_shares_inner() {
+        let client = Client::new();
+        assert!(Arc::ptr_eq(&client.inner, &client.clone().inner));
+    }
+
+    #[test]
+    fn assert_send_sync() {
+        fn check<T: Send + Sync>() {}
+        check::<Client>();
+        check::<ClientBuilder>();
+    }
+
+    #[test]
+    fn fetch_invalid_url_returns_invalid_url_error() {
+        let client = Client::new();
+        let err = client.fetch("not a url").unwrap_err();
+        assert!(matches!(err, Error::InvalidUrl { .. }));
+    }
+
+    #[test]
+    fn fetch_private_address_is_rejected() {
+        let client = Client::new();
+        let err = client.fetch("http://127.0.0.1/").unwrap_err();
+        assert!(err.is_network(), "got: {err:?}");
+    }
+}

--- a/crates/servo-fetch/src/bridge.rs
+++ b/crates/servo-fetch/src/bridge.rs
@@ -15,7 +15,7 @@ use servo::{
     ConsoleLogLevel, EventLoopWaker, JSValue, LoadStatus, NavigationRequest, Preferences, RenderingContext,
     ServoBuilder, SoftwareRenderingContext, UserContentManager, WebView, WebViewBuilder, WebViewDelegate, WebViewId,
 };
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, oneshot};
 use url::Url;
 
 use crate::{layout, visibility};
@@ -384,6 +384,26 @@ pub(crate) fn fetch_page(opts: FetchOptions<'_>) -> Result<ServoPage> {
         .unwrap_or_else(|_| Err(anyhow!("Servo engine crashed while processing this page")))
 }
 
+pub(crate) async fn fetch_page_async(opts: FetchOptions<'_>) -> Result<ServoPage> {
+    let engine = ensure_engine();
+    let (reply_tx, reply_rx) = oneshot::channel::<Result<ServoPage>>();
+    let request = build_request(
+        opts,
+        Box::new(move |r| {
+            let _ = reply_tx.send(r);
+        }),
+    );
+    engine
+        .requests
+        .send(request)
+        .await
+        .map_err(|_| anyhow!("Servo engine is not running (it may have crashed on a previous request)"))?;
+    engine.wake.signal();
+    reply_rx
+        .await
+        .unwrap_or_else(|_| Err(anyhow!("Servo engine crashed while processing this page")))
+}
+
 fn is_apple_gl_driver_noise(line: &str) -> bool {
     line.contains("GLD_TEXTURE_INDEX_2D is unloadable and bound to sampler type")
 }
@@ -742,8 +762,6 @@ fn jsvalue_to_json(val: &JSValue) -> Result<Value> {
 
 #[cfg(test)]
 mod tests {
-    use tokio::sync::oneshot;
-
     use super::*;
 
     #[test]

--- a/crates/servo-fetch/src/client.rs
+++ b/crates/servo-fetch/src/client.rs
@@ -1,0 +1,241 @@
+//! Async client with reusable defaults.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::error::{Error, Result};
+use crate::fetch::{self, FetchOptions, Page};
+use crate::net::sanitize_user_agent;
+use crate::visibility::VisibilityPolicy;
+
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Async client carrying reusable fetch defaults.
+#[derive(Debug, Clone)]
+pub struct Client {
+    inner: Arc<ClientInner>,
+}
+
+#[derive(Debug)]
+pub(crate) struct ClientInner {
+    pub(crate) timeout: Duration,
+    pub(crate) settle: Duration,
+    pub(crate) user_agent: Option<String>,
+    pub(crate) visibility: VisibilityPolicy,
+}
+
+impl Default for Client {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Client {
+    /// Construct a client with default options.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::builder().build()
+    }
+
+    /// Begin building a client with custom options.
+    pub fn builder() -> ClientBuilder {
+        ClientBuilder::default()
+    }
+
+    /// Fetch a page using the client's default options.
+    pub async fn fetch(&self, url: &str) -> Result<Page> {
+        fetch::fetch(&self.options(url)).await
+    }
+
+    /// Fetch a page with explicit options.
+    pub async fn fetch_with(&self, opts: &FetchOptions) -> Result<Page> {
+        fetch::fetch(opts).await
+    }
+
+    /// Fetch and extract readable Markdown.
+    pub async fn markdown(&self, url: &str) -> Result<String> {
+        self.fetch(url).await?.markdown_with_url(url)
+    }
+
+    /// Fetch and extract plain text (`document.body.innerText`).
+    pub async fn text(&self, url: &str) -> Result<String> {
+        Ok(self.fetch(url).await?.inner_text)
+    }
+
+    /// Fetch and extract structured JSON.
+    pub async fn extract_json(&self, url: &str) -> Result<String> {
+        self.fetch(url).await?.extract_json_with_url(url)
+    }
+
+    /// Capture a PNG screenshot of the page.
+    pub async fn screenshot(&self, url: &str, opts: &ScreenshotOptions) -> Result<Vec<u8>> {
+        let fopts = self.apply_defaults(FetchOptions::screenshot(url, opts.full_page));
+        let page = fetch::fetch(&fopts).await?;
+        page.screenshot_png()
+            .map(<[u8]>::to_vec)
+            .ok_or_else(|| Error::screenshot(anyhow::anyhow!("screenshot returned no data"), Some(url.to_string())))
+    }
+
+    /// Execute a JavaScript expression after page load and return the result.
+    pub async fn execute_js(&self, url: &str, expression: impl Into<String>) -> Result<String> {
+        let fopts = self.apply_defaults(FetchOptions::javascript(url, expression));
+        let page = fetch::fetch(&fopts).await?;
+        page.js_result
+            .ok_or_else(|| Error::javascript(anyhow::anyhow!("execute_js returned no result"), Some(url.to_string())))
+    }
+
+    fn apply_defaults(&self, mut opts: FetchOptions) -> FetchOptions {
+        opts.timeout = self.inner.timeout;
+        opts.settle = self.inner.settle;
+        opts.visibility = self.inner.visibility;
+        if let Some(ua) = &self.inner.user_agent {
+            opts.user_agent = Some(ua.clone());
+        }
+        opts
+    }
+
+    fn options(&self, url: &str) -> FetchOptions {
+        self.apply_defaults(FetchOptions::new(url))
+    }
+}
+
+/// Options for [`Client::screenshot`].
+#[derive(Debug, Default, Clone)]
+#[non_exhaustive]
+pub struct ScreenshotOptions {
+    /// Capture the full scrollable page (rather than only the viewport).
+    pub full_page: bool,
+}
+
+/// Builder for [`Client`].
+#[must_use = "ClientBuilder does nothing until .build() is called"]
+#[derive(Debug, Default)]
+pub struct ClientBuilder {
+    timeout: Option<Duration>,
+    settle: Option<Duration>,
+    user_agent: Option<String>,
+    visibility: Option<VisibilityPolicy>,
+}
+
+impl ClientBuilder {
+    /// Default page-load timeout (default 30s).
+    pub fn timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = Some(timeout);
+        self
+    }
+
+    /// Default settle wait after the load event (default 0).
+    pub fn settle(mut self, settle: Duration) -> Self {
+        self.settle = Some(settle);
+        self
+    }
+
+    /// Default User-Agent header.
+    pub fn user_agent(mut self, ua: impl Into<String>) -> Self {
+        self.user_agent = Some(sanitize_user_agent(ua.into()));
+        self
+    }
+
+    /// Default visibility policy applied during extraction.
+    pub fn visibility(mut self, policy: VisibilityPolicy) -> Self {
+        self.visibility = Some(policy);
+        self
+    }
+
+    /// Build the [`Client`].
+    #[must_use]
+    pub fn build(self) -> Client {
+        Client {
+            inner: Arc::new(self.build_inner()),
+        }
+    }
+
+    pub(crate) fn build_inner(self) -> ClientInner {
+        ClientInner {
+            timeout: self.timeout.unwrap_or(DEFAULT_TIMEOUT),
+            settle: self.settle.unwrap_or_default(),
+            user_agent: self.user_agent,
+            visibility: self.visibility.unwrap_or_default(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn client_default_uses_30s_timeout() {
+        assert_eq!(Client::default().inner.timeout, DEFAULT_TIMEOUT);
+    }
+
+    #[test]
+    fn client_builder_sets_timeout() {
+        let client = Client::builder().timeout(Duration::from_secs(60)).build();
+        assert_eq!(client.inner.timeout, Duration::from_secs(60));
+    }
+
+    #[test]
+    fn client_builder_sets_settle() {
+        let client = Client::builder().settle(Duration::from_millis(500)).build();
+        assert_eq!(client.inner.settle, Duration::from_millis(500));
+    }
+
+    #[test]
+    fn client_builder_sanitizes_user_agent() {
+        let client = Client::builder().user_agent("Bot\r\nX-Evil: yes").build();
+        assert_eq!(client.inner.user_agent.as_deref(), Some("Bot  X-Evil: yes"));
+    }
+
+    #[test]
+    fn client_options_propagates_defaults() {
+        let client = Client::builder()
+            .timeout(Duration::from_secs(60))
+            .settle(Duration::from_millis(500))
+            .user_agent("MyBot")
+            .build();
+        let opts = client.options("https://example.com");
+        assert_eq!(opts.timeout, Duration::from_secs(60));
+        assert_eq!(opts.settle, Duration::from_millis(500));
+        assert_eq!(opts.user_agent.as_deref(), Some("MyBot"));
+    }
+
+    #[test]
+    fn client_clone_shares_inner() {
+        let client = Client::new();
+        assert!(Arc::ptr_eq(&client.inner, &client.clone().inner));
+    }
+
+    #[test]
+    fn screenshot_options_default_is_viewport() {
+        assert!(!ScreenshotOptions::default().full_page);
+    }
+
+    #[test]
+    fn assert_send_sync() {
+        fn check<T: Send + Sync>() {}
+        check::<Client>();
+        check::<ClientBuilder>();
+        check::<ScreenshotOptions>();
+    }
+
+    #[test]
+    fn client_builder_sets_visibility() {
+        let client = Client::builder().visibility(VisibilityPolicy::off()).build();
+        assert_eq!(client.inner.visibility, VisibilityPolicy::off());
+    }
+
+    #[tokio::test]
+    async fn client_fetch_invalid_url_returns_invalid_url_error() {
+        let client = Client::new();
+        let err = client.fetch("not a url").await.unwrap_err();
+        assert!(matches!(err, Error::InvalidUrl { .. }), "got: {err:?}");
+    }
+
+    #[tokio::test]
+    async fn client_fetch_private_address_is_rejected() {
+        let client = Client::new();
+        let err = client.fetch("http://127.0.0.1/").await.unwrap_err();
+        assert!(err.is_network(), "got: {err:?}");
+    }
+}

--- a/crates/servo-fetch/src/client.rs
+++ b/crates/servo-fetch/src/client.rs
@@ -8,8 +8,6 @@ use crate::fetch::{self, FetchOptions, Page};
 use crate::net::sanitize_user_agent;
 use crate::visibility::VisibilityPolicy;
 
-const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
-
 /// Async client carrying reusable fetch defaults.
 #[derive(Debug, Clone)]
 pub struct Client {
@@ -48,8 +46,11 @@ impl Client {
     }
 
     /// Fetch a page with explicit options.
+    ///
+    /// Unset fields on `opts` fall back to the client's defaults; explicit
+    /// values on `opts` always win.
     pub async fn fetch_with(&self, opts: &FetchOptions) -> Result<Page> {
-        fetch::fetch(opts).await
+        fetch::fetch(&self.apply_defaults(opts)).await
     }
 
     /// Fetch and extract readable Markdown.
@@ -69,7 +70,7 @@ impl Client {
 
     /// Capture a PNG screenshot of the page.
     pub async fn screenshot(&self, url: &str, opts: &ScreenshotOptions) -> Result<Vec<u8>> {
-        let fopts = self.apply_defaults(FetchOptions::screenshot(url, opts.full_page));
+        let fopts = self.apply_defaults(&FetchOptions::screenshot(url, opts.full_page));
         let page = fetch::fetch(&fopts).await?;
         page.screenshot_png()
             .map(<[u8]>::to_vec)
@@ -78,24 +79,33 @@ impl Client {
 
     /// Execute a JavaScript expression after page load and return the result.
     pub async fn execute_js(&self, url: &str, expression: impl Into<String>) -> Result<String> {
-        let fopts = self.apply_defaults(FetchOptions::javascript(url, expression));
+        let fopts = self.apply_defaults(&FetchOptions::javascript(url, expression));
         let page = fetch::fetch(&fopts).await?;
         page.js_result
             .ok_or_else(|| Error::javascript(anyhow::anyhow!("execute_js returned no result"), Some(url.to_string())))
     }
 
-    fn apply_defaults(&self, mut opts: FetchOptions) -> FetchOptions {
-        opts.timeout = self.inner.timeout;
-        opts.settle = self.inner.settle;
-        opts.visibility = self.inner.visibility;
-        if let Some(ua) = &self.inner.user_agent {
-            opts.user_agent = Some(ua.clone());
+    fn apply_defaults(&self, opts: &FetchOptions) -> FetchOptions {
+        let mut opts = opts.clone();
+        if opts.timeout.is_none() {
+            opts.timeout = Some(self.inner.timeout);
+        }
+        if opts.settle.is_none() {
+            opts.settle = Some(self.inner.settle);
+        }
+        if opts.visibility.is_none() {
+            opts.visibility = Some(self.inner.visibility);
+        }
+        if opts.user_agent.is_none()
+            && let Some(ua) = self.inner.user_agent.as_deref()
+        {
+            opts.user_agent = Some(ua.to_owned());
         }
         opts
     }
 
     fn options(&self, url: &str) -> FetchOptions {
-        self.apply_defaults(FetchOptions::new(url))
+        self.apply_defaults(&FetchOptions::new(url))
     }
 }
 
@@ -152,7 +162,7 @@ impl ClientBuilder {
 
     pub(crate) fn build_inner(self) -> ClientInner {
         ClientInner {
-            timeout: self.timeout.unwrap_or(DEFAULT_TIMEOUT),
+            timeout: self.timeout.unwrap_or(FetchOptions::DEFAULT_TIMEOUT),
             settle: self.settle.unwrap_or_default(),
             user_agent: self.user_agent,
             visibility: self.visibility.unwrap_or_default(),
@@ -166,7 +176,7 @@ mod tests {
 
     #[test]
     fn client_default_uses_30s_timeout() {
-        assert_eq!(Client::default().inner.timeout, DEFAULT_TIMEOUT);
+        assert_eq!(Client::default().inner.timeout, FetchOptions::DEFAULT_TIMEOUT);
     }
 
     #[test]
@@ -195,9 +205,41 @@ mod tests {
             .user_agent("MyBot")
             .build();
         let opts = client.options("https://example.com");
-        assert_eq!(opts.timeout, Duration::from_secs(60));
-        assert_eq!(opts.settle, Duration::from_millis(500));
+        assert_eq!(opts.timeout, Some(Duration::from_secs(60)));
+        assert_eq!(opts.settle, Some(Duration::from_millis(500)));
         assert_eq!(opts.user_agent.as_deref(), Some("MyBot"));
+    }
+
+    #[test]
+    fn client_apply_defaults_caller_value_wins() {
+        let client = Client::builder()
+            .timeout(Duration::from_secs(60))
+            .user_agent("ClientBot")
+            .build();
+        let user_opts = FetchOptions::new("https://example.com")
+            .timeout(Duration::from_secs(10))
+            .user_agent("UserBot");
+        let merged = client.apply_defaults(&user_opts);
+        // Caller's explicit values win
+        assert_eq!(merged.timeout, Some(Duration::from_secs(10)));
+        assert_eq!(merged.user_agent.as_deref(), Some("UserBot"));
+    }
+
+    #[test]
+    fn client_apply_defaults_fills_unset_fields() {
+        let client = Client::builder()
+            .timeout(Duration::from_secs(60))
+            .settle(Duration::from_millis(750))
+            .user_agent("ClientBot")
+            .visibility(VisibilityPolicy::off())
+            .build();
+        let user_opts = FetchOptions::new("https://example.com");
+        let merged = client.apply_defaults(&user_opts);
+        // None fields filled with client defaults
+        assert_eq!(merged.timeout, Some(Duration::from_secs(60)));
+        assert_eq!(merged.settle, Some(Duration::from_millis(750)));
+        assert_eq!(merged.user_agent.as_deref(), Some("ClientBot"));
+        assert_eq!(merged.visibility, Some(VisibilityPolicy::off()));
     }
 
     #[test]

--- a/crates/servo-fetch/src/crawl.rs
+++ b/crates/servo-fetch/src/crawl.rs
@@ -197,33 +197,47 @@ impl CrawlResult {
     }
 }
 
+/// Crawl a site, invoking `on_page` for each result as it arrives (blocking).
+pub fn crawl_each_blocking<F>(opts: &CrawlOptions, on_page: F) -> crate::error::Result<()>
+where
+    F: FnMut(CrawlResult) + Send,
+{
+    crate::runtime::block_on(crawl_each(opts, on_page)).map_err(|e| crate::error::Error::engine(e, None))?
+}
+
 /// Crawl a site, invoking `on_page` for each result as it arrives.
-#[allow(clippy::needless_pass_by_value)]
-pub fn crawl_each(opts: CrawlOptions, mut on_page: impl FnMut(CrawlResult)) -> crate::error::Result<()> {
+pub async fn crawl_each<F>(opts: &CrawlOptions, mut on_page: F) -> crate::error::Result<()>
+where
+    F: FnMut(CrawlResult) + Send,
+{
     net::ensure_crypto_provider();
-    let plan = build_crawl_plan(&opts)?;
-    crate::runtime::block_on(async {
-        let robots = spawn_blocking({
-            let seed = plan.seed.clone();
-            let user_agent = plan.user_agent.clone();
-            let timeout = Duration::from_secs(plan.timeout_secs);
-            move || crate::robots::RobotsRules::fetch(&seed, user_agent.as_deref(), timeout)
-        })
-        .await
-        .unwrap_or(RobotsPolicy::Unreachable);
-        run(plan, robots, &bridge::ServoFetcher, |r| {
-            on_page(CrawlResult::from_internal(r));
-        })
-        .await;
+    let plan = build_crawl_plan(opts)?;
+    let robots = spawn_blocking({
+        let seed = plan.seed.clone();
+        let user_agent = plan.user_agent.clone();
+        let timeout = Duration::from_secs(plan.timeout_secs);
+        move || crate::robots::RobotsRules::fetch(&seed, user_agent.as_deref(), timeout)
     })
-    .map_err(|e| crate::error::Error::engine(e, None))
+    .await
+    .unwrap_or(RobotsPolicy::Unreachable);
+    run(plan, robots, &bridge::ServoFetcher, |r| {
+        on_page(CrawlResult::from_internal(r));
+    })
+    .await;
+    Ok(())
+}
+
+/// Crawl a site and collect all results (blocking).
+pub fn crawl_blocking(opts: &CrawlOptions) -> crate::error::Result<Vec<CrawlResult>> {
+    let mut results = Vec::new();
+    crawl_each_blocking(opts, |r| results.push(r))?;
+    Ok(results)
 }
 
 /// Crawl a site and collect all results.
-#[allow(clippy::needless_pass_by_value)]
-pub fn crawl(opts: CrawlOptions) -> crate::error::Result<Vec<CrawlResult>> {
+pub async fn crawl(opts: &CrawlOptions) -> crate::error::Result<Vec<CrawlResult>> {
     let mut results = Vec::new();
-    crawl_each(opts, |r| results.push(r))?;
+    crawl_each(opts, |r| results.push(r)).await?;
     Ok(results)
 }
 

--- a/crates/servo-fetch/src/error.rs
+++ b/crates/servo-fetch/src/error.rs
@@ -94,6 +94,22 @@ impl Error {
         }
     }
 
+    /// Construct an [`Error::Screenshot`] from any error type, preserving source chain.
+    pub(crate) fn screenshot(source: impl Into<BoxError>, url: Option<String>) -> Self {
+        Self::Screenshot {
+            url,
+            source: source.into(),
+        }
+    }
+
+    /// Construct an [`Error::JavaScript`] from any error type, preserving source chain.
+    pub(crate) fn javascript(source: impl Into<BoxError>, url: Option<String>) -> Self {
+        Self::JavaScript {
+            url,
+            source: source.into(),
+        }
+    }
+
     /// Returns `true` if this is a timeout error.
     #[must_use]
     pub fn is_timeout(&self) -> bool {

--- a/crates/servo-fetch/src/fetch.rs
+++ b/crates/servo-fetch/src/fetch.rs
@@ -11,7 +11,7 @@ use servo::accesskit::{Node, NodeId};
 use crate::error::Error;
 use crate::net::sanitize_user_agent;
 
-/// Rendered page returned by [`fetch`].
+/// Rendered page returned by [`crate::fetch()`].
 #[derive(Debug, Clone, Default, serde::Serialize)]
 #[non_exhaustive]
 pub struct Page {
@@ -272,25 +272,100 @@ impl FetchOptions {
     }
 }
 
-/// Fetch a single page via the embedded Servo engine.
-#[allow(clippy::needless_pass_by_value)]
-pub fn fetch(opts: FetchOptions) -> crate::error::Result<Page> {
-    crate::net::ensure_crypto_provider();
+/// Fetch a single page via the embedded Servo engine (blocking).
+pub fn fetch_blocking(opts: &FetchOptions) -> crate::error::Result<Page> {
+    if let Some(pdf_page) = pre_fetch(opts)? {
+        return Ok(pdf_page);
+    }
+    let bridge_opts = build_bridge_options(opts);
+    let servo_page = crate::bridge::fetch_page(bridge_opts).map_err(|e| map_engine_error(e, opts))?;
+    Ok(finalize_page(servo_page, opts))
+}
 
+/// Fetch a single page via the embedded Servo engine.
+pub async fn fetch(opts: &FetchOptions) -> crate::error::Result<Page> {
+    if let Some(pdf_page) = pre_fetch_async(opts).await? {
+        return Ok(pdf_page);
+    }
+    let bridge_opts = build_bridge_options(opts);
+    let servo_page = crate::bridge::fetch_page_async(bridge_opts)
+        .await
+        .map_err(|e| map_engine_error(e, opts))?;
+    Ok(finalize_page(servo_page, opts))
+}
+
+/// Fetch a URL and return readable Markdown (blocking).
+pub fn markdown_blocking(url: &str) -> crate::error::Result<String> {
+    fetch_blocking(&FetchOptions::new(url))?.markdown_with_url(url)
+}
+
+/// Fetch a URL and return readable Markdown.
+pub async fn markdown(url: &str) -> crate::error::Result<String> {
+    fetch(&FetchOptions::new(url)).await?.markdown_with_url(url)
+}
+
+/// Fetch a URL and return structured JSON (blocking).
+pub fn extract_json_blocking(url: &str) -> crate::error::Result<String> {
+    fetch_blocking(&FetchOptions::new(url))?.extract_json_with_url(url)
+}
+
+/// Fetch a URL and return structured JSON.
+pub async fn extract_json(url: &str) -> crate::error::Result<String> {
+    fetch(&FetchOptions::new(url)).await?.extract_json_with_url(url)
+}
+
+/// Fetch a URL and return plain text (`document.body.innerText`) (blocking).
+pub fn text_blocking(url: &str) -> crate::error::Result<String> {
+    Ok(fetch_blocking(&FetchOptions::new(url))?.inner_text)
+}
+
+/// Fetch a URL and return plain text (`document.body.innerText`).
+pub async fn text(url: &str) -> crate::error::Result<String> {
+    Ok(fetch(&FetchOptions::new(url)).await?.inner_text)
+}
+
+fn pre_fetch(opts: &FetchOptions) -> crate::error::Result<Option<Page>> {
+    crate::net::ensure_crypto_provider();
     crate::net::validate_url(&opts.url)?;
 
     if matches!(opts.mode, FetchMode::Content)
         && let Some(bytes) = crate::pdf::probe(&opts.url, opts.timeout.as_secs().max(1))
     {
-        let text = crate::extract::extract_pdf(&bytes);
-        return Ok(Page {
-            html: String::new(),
-            inner_text: text,
-            ..Page::default()
-        });
+        return Ok(Some(pdf_page(&bytes)));
     }
 
-    let bridge_opts = crate::bridge::FetchOptions {
+    Ok(None)
+}
+
+async fn pre_fetch_async(opts: &FetchOptions) -> crate::error::Result<Option<Page>> {
+    crate::net::ensure_crypto_provider();
+    crate::net::validate_url(&opts.url)?;
+
+    if matches!(opts.mode, FetchMode::Content) {
+        let url = opts.url.clone();
+        let timeout_secs = opts.timeout.as_secs().max(1);
+        let probe = tokio::task::spawn_blocking(move || crate::pdf::probe(&url, timeout_secs))
+            .await
+            .map_err(|e| Error::engine(anyhow::anyhow!("pdf probe task panicked: {e}"), Some(opts.url.clone())))?;
+        if let Some(bytes) = probe {
+            return Ok(Some(pdf_page(&bytes)));
+        }
+    }
+
+    Ok(None)
+}
+
+fn pdf_page(bytes: &[u8]) -> Page {
+    let text = crate::extract::extract_pdf(bytes);
+    Page {
+        html: String::new(),
+        inner_text: text,
+        ..Page::default()
+    }
+}
+
+fn build_bridge_options(opts: &FetchOptions) -> crate::bridge::FetchOptions<'_> {
+    crate::bridge::FetchOptions {
         url: &opts.url,
         timeout_secs: opts.timeout.as_secs().max(1),
         settle_ms: u64::try_from(opts.settle.as_millis()).unwrap_or(u64::MAX),
@@ -302,40 +377,27 @@ pub fn fetch(opts: FetchOptions) -> crate::error::Result<Page> {
                 expression: expr.clone(),
             },
         },
-    };
+    }
+}
 
-    let servo_page = crate::bridge::fetch_page(bridge_opts).map_err(|e| {
-        if format!("{e:#}").contains("timed out") {
-            Error::Timeout {
-                url: opts.url.clone(),
-                timeout: opts.timeout,
-            }
-        } else {
-            Error::engine(e, Some(opts.url.clone()))
-        }
-    })?;
-
+fn finalize_page(servo_page: crate::bridge::ServoPage, opts: &FetchOptions) -> Page {
     let mut page = Page::from_servo(servo_page);
     page.visibility_policy = opts.visibility;
     if let Some(schema) = opts.extract_schema.as_ref() {
         page.extracted = Some(schema.extract_from(&page.html));
     }
-    Ok(page)
+    page
 }
 
-/// Fetch a URL and return readable Markdown.
-pub fn markdown(url: &str) -> crate::error::Result<String> {
-    fetch(FetchOptions::new(url))?.markdown_with_url(url)
-}
-
-/// Fetch a URL and return structured JSON.
-pub fn extract_json(url: &str) -> crate::error::Result<String> {
-    fetch(FetchOptions::new(url))?.extract_json_with_url(url)
-}
-
-/// Fetch a URL and return plain text (`document.body.innerText`).
-pub fn text(url: &str) -> crate::error::Result<String> {
-    Ok(fetch(FetchOptions::new(url))?.inner_text)
+fn map_engine_error(e: anyhow::Error, opts: &FetchOptions) -> Error {
+    if format!("{e:#}").contains("timed out") {
+        Error::Timeout {
+            url: opts.url.clone(),
+            timeout: opts.timeout,
+        }
+    } else {
+        Error::engine(e, Some(opts.url.clone()))
+    }
 }
 
 #[cfg(test)]
@@ -486,7 +548,7 @@ mod tests {
 
     #[test]
     fn fetch_rejects_invalid_url() {
-        let result = fetch(FetchOptions::new("not a url"));
+        let result = fetch_blocking(&FetchOptions::new("not a url"));
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(matches!(err, Error::InvalidUrl { .. }));
@@ -494,13 +556,13 @@ mod tests {
 
     #[test]
     fn fetch_rejects_private_ip() {
-        let result = fetch(FetchOptions::new("http://127.0.0.1/"));
+        let result = fetch_blocking(&FetchOptions::new("http://127.0.0.1/"));
         assert!(result.is_err());
     }
 
     #[test]
     fn fetch_rejects_file_scheme() {
-        let result = fetch(FetchOptions::new("file:///etc/passwd"));
+        let result = fetch_blocking(&FetchOptions::new("file:///etc/passwd"));
         assert!(result.is_err());
     }
 

--- a/crates/servo-fetch/src/fetch.rs
+++ b/crates/servo-fetch/src/fetch.rs
@@ -203,25 +203,33 @@ pub(crate) enum FetchMode {
 #[derive(Debug, Clone)]
 pub struct FetchOptions {
     pub(crate) url: String,
-    pub(crate) timeout: Duration,
-    pub(crate) settle: Duration,
+    pub(crate) timeout: Option<Duration>,
+    pub(crate) settle: Option<Duration>,
     pub(crate) mode: FetchMode,
     pub(crate) user_agent: Option<String>,
     pub(crate) extract_schema: Option<crate::schema::ExtractSchema>,
-    pub(crate) visibility: crate::visibility::VisibilityPolicy,
+    pub(crate) visibility: Option<crate::visibility::VisibilityPolicy>,
 }
 
 impl FetchOptions {
+    /// Default page-load timeout used when neither `FetchOptions::timeout` nor
+    /// a [`crate::Client`] override is set.
+    pub(crate) const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
+
+    /// Default settle wait used when neither `FetchOptions::settle` nor a
+    /// [`crate::Client`] override is set.
+    pub(crate) const DEFAULT_SETTLE: Duration = Duration::ZERO;
+
     /// Fetch rendered content (default mode).
     pub fn new(url: &str) -> Self {
         Self {
             url: url.into(),
-            timeout: Duration::from_secs(30),
-            settle: Duration::ZERO,
+            timeout: None,
+            settle: None,
             mode: FetchMode::Content,
             user_agent: None,
             extract_schema: None,
-            visibility: crate::visibility::VisibilityPolicy::default(),
+            visibility: None,
         }
     }
 
@@ -243,13 +251,13 @@ impl FetchOptions {
 
     /// Page load timeout (default: 30s).
     pub fn timeout(mut self, timeout: Duration) -> Self {
-        self.timeout = timeout;
+        self.timeout = Some(timeout);
         self
     }
 
     /// Extra wait after load event for SPA hydration (default: 0).
     pub fn settle(mut self, settle: Duration) -> Self {
-        self.settle = settle;
+        self.settle = Some(settle);
         self
     }
 
@@ -267,8 +275,23 @@ impl FetchOptions {
 
     /// Visibility-filtering policy applied during extraction.
     pub fn visibility(mut self, policy: crate::visibility::VisibilityPolicy) -> Self {
-        self.visibility = policy;
+        self.visibility = Some(policy);
         self
+    }
+
+    /// Resolve the effective timeout, falling back to [`Self::DEFAULT_TIMEOUT`].
+    pub(crate) fn effective_timeout(&self) -> Duration {
+        self.timeout.unwrap_or(Self::DEFAULT_TIMEOUT)
+    }
+
+    /// Resolve the effective settle wait, falling back to [`Self::DEFAULT_SETTLE`].
+    pub(crate) fn effective_settle(&self) -> Duration {
+        self.settle.unwrap_or(Self::DEFAULT_SETTLE)
+    }
+
+    /// Resolve the effective visibility policy, falling back to its default.
+    pub(crate) fn effective_visibility(&self) -> crate::visibility::VisibilityPolicy {
+        self.visibility.unwrap_or_default()
     }
 }
 
@@ -329,7 +352,7 @@ fn pre_fetch(opts: &FetchOptions) -> crate::error::Result<Option<Page>> {
     crate::net::validate_url(&opts.url)?;
 
     if matches!(opts.mode, FetchMode::Content)
-        && let Some(bytes) = crate::pdf::probe(&opts.url, opts.timeout.as_secs().max(1))
+        && let Some(bytes) = crate::pdf::probe(&opts.url, opts.effective_timeout().as_secs().max(1))
     {
         return Ok(Some(pdf_page(&bytes)));
     }
@@ -343,7 +366,7 @@ async fn pre_fetch_async(opts: &FetchOptions) -> crate::error::Result<Option<Pag
 
     if matches!(opts.mode, FetchMode::Content) {
         let url = opts.url.clone();
-        let timeout_secs = opts.timeout.as_secs().max(1);
+        let timeout_secs = opts.effective_timeout().as_secs().max(1);
         let probe = tokio::task::spawn_blocking(move || crate::pdf::probe(&url, timeout_secs))
             .await
             .map_err(|e| Error::engine(anyhow::anyhow!("pdf probe task panicked: {e}"), Some(opts.url.clone())))?;
@@ -367,8 +390,8 @@ fn pdf_page(bytes: &[u8]) -> Page {
 fn build_bridge_options(opts: &FetchOptions) -> crate::bridge::FetchOptions<'_> {
     crate::bridge::FetchOptions {
         url: &opts.url,
-        timeout_secs: opts.timeout.as_secs().max(1),
-        settle_ms: u64::try_from(opts.settle.as_millis()).unwrap_or(u64::MAX),
+        timeout_secs: opts.effective_timeout().as_secs().max(1),
+        settle_ms: u64::try_from(opts.effective_settle().as_millis()).unwrap_or(u64::MAX),
         user_agent: opts.user_agent.as_deref(),
         mode: match opts.mode {
             FetchMode::Content => crate::bridge::FetchMode::Content { include_a11y: false },
@@ -382,7 +405,7 @@ fn build_bridge_options(opts: &FetchOptions) -> crate::bridge::FetchOptions<'_> 
 
 fn finalize_page(servo_page: crate::bridge::ServoPage, opts: &FetchOptions) -> Page {
     let mut page = Page::from_servo(servo_page);
-    page.visibility_policy = opts.visibility;
+    page.visibility_policy = opts.effective_visibility();
     if let Some(schema) = opts.extract_schema.as_ref() {
         page.extracted = Some(schema.extract_from(&page.html));
     }
@@ -393,7 +416,7 @@ fn map_engine_error(e: anyhow::Error, opts: &FetchOptions) -> Error {
     if format!("{e:#}").contains("timed out") {
         Error::Timeout {
             url: opts.url.clone(),
-            timeout: opts.timeout,
+            timeout: opts.effective_timeout(),
         }
     } else {
         Error::engine(e, Some(opts.url.clone()))
@@ -408,9 +431,28 @@ mod tests {
     fn fetch_options_defaults() {
         let opts = FetchOptions::new("https://example.com");
         assert_eq!(opts.url, "https://example.com");
-        assert_eq!(opts.timeout, Duration::from_secs(30));
-        assert_eq!(opts.settle, Duration::ZERO);
+        assert_eq!(opts.timeout, None);
+        assert_eq!(opts.settle, None);
+        assert_eq!(opts.visibility, None);
         assert!(matches!(opts.mode, FetchMode::Content));
+    }
+
+    #[test]
+    fn fetch_options_effective_defaults() {
+        let opts = FetchOptions::new("https://example.com");
+        assert_eq!(opts.effective_timeout(), Duration::from_secs(30));
+        assert_eq!(opts.effective_settle(), Duration::ZERO);
+    }
+
+    #[test]
+    fn fetch_options_caller_value_preserved() {
+        let opts = FetchOptions::new("https://example.com")
+            .timeout(Duration::from_secs(45))
+            .settle(Duration::from_millis(250));
+        assert_eq!(opts.timeout, Some(Duration::from_secs(45)));
+        assert_eq!(opts.settle, Some(Duration::from_millis(250)));
+        assert_eq!(opts.effective_timeout(), Duration::from_secs(45));
+        assert_eq!(opts.effective_settle(), Duration::from_millis(250));
     }
 
     #[test]
@@ -430,8 +472,8 @@ mod tests {
         let opts = FetchOptions::new("https://example.com")
             .timeout(Duration::from_secs(60))
             .settle(Duration::from_millis(500));
-        assert_eq!(opts.timeout, Duration::from_secs(60));
-        assert_eq!(opts.settle, Duration::from_millis(500));
+        assert_eq!(opts.timeout, Some(Duration::from_secs(60)));
+        assert_eq!(opts.settle, Some(Duration::from_millis(500)));
     }
 
     #[test]

--- a/crates/servo-fetch/src/lib.rs
+++ b/crates/servo-fetch/src/lib.rs
@@ -1,19 +1,31 @@
 //! Fetch, render, and extract web content as Markdown, JSON, or screenshots with an embedded Servo browser engine.
 //! No Chromium, no containers, no external processes.
 //!
+//! ## Async usage
+//!
 //! ```no_run
-//! let md = servo_fetch::markdown("https://example.com")?;
+//! # async fn run() -> servo_fetch::Result<()> {
+//! let md = servo_fetch::markdown("https://example.com").await?;
+//! # Ok(()) }
+//! ```
+//!
+//! ## Sync usage
+//!
+//! ```no_run
+//! let md = servo_fetch::blocking::markdown("https://example.com")?;
 //! # Ok::<(), servo_fetch::Error>(())
 //! ```
 
 #![deny(unsafe_code)]
 
+pub mod blocking;
 pub mod extract;
 pub mod sanitize;
 pub mod schema;
 pub mod visibility;
 
 pub(crate) mod bridge;
+pub(crate) mod client;
 pub(crate) mod crawl;
 pub(crate) mod error;
 pub(crate) mod fetch;
@@ -27,6 +39,7 @@ pub(crate) mod scope;
 pub(crate) mod screenshot;
 pub(crate) mod sys;
 
+pub use client::{Client, ClientBuilder, ScreenshotOptions};
 pub use crawl::{CrawlOptions, CrawlPage, CrawlResult, crawl, crawl_each};
 pub use error::{Error, Result};
 pub use fetch::{ConsoleLevel, ConsoleMessage, FetchOptions, Page, extract_json, fetch, markdown, text};

--- a/crates/servo-fetch/src/map.rs
+++ b/crates/servo-fetch/src/map.rs
@@ -96,9 +96,13 @@ pub struct MappedUrl {
     pub lastmod: Option<String>,
 }
 
-/// Discover URLs on a site via sitemaps and link extraction (no rendering).
-#[allow(clippy::needless_pass_by_value)]
-pub fn map(opts: MapOptions) -> crate::error::Result<Vec<MappedUrl>> {
+/// Discover URLs on a site via sitemaps and link extraction (blocking).
+pub fn map_blocking(opts: &MapOptions) -> crate::error::Result<Vec<MappedUrl>> {
+    crate::runtime::block_on(map(opts)).map_err(|e| crate::error::Error::engine(e, None))?
+}
+
+/// Discover URLs on a site via sitemaps and link extraction.
+pub async fn map(opts: &MapOptions) -> crate::error::Result<Vec<MappedUrl>> {
     net::ensure_crypto_provider();
     let seed = net::validate_url(&opts.url)?;
 
@@ -118,19 +122,19 @@ pub fn map(opts: MapOptions) -> crate::error::Result<Vec<MappedUrl>> {
         limit: opts.limit,
         include,
         exclude,
-        user_agent: opts.user_agent,
+        user_agent: opts.user_agent.clone(),
         timeout: Duration::from_secs(opts.timeout),
         no_fallback: opts.no_fallback,
     };
 
     let mut results = Vec::new();
-    crate::runtime::block_on(run(&internal, |entry| {
+    run(&internal, |entry| {
         results.push(MappedUrl {
             url: entry.url.clone(),
             lastmod: entry.lastmod.clone(),
         });
-    }))
-    .map_err(|e| crate::error::Error::engine(e, None))?;
+    })
+    .await;
     Ok(results)
 }
 

--- a/crates/servo-fetch/tests/visibility.rs
+++ b/crates/servo-fetch/tests/visibility.rs
@@ -1,6 +1,7 @@
 //! Visibility-aware extraction integration tests.
 
-use servo_fetch::{FetchOptions, NetworkPolicy, VisibilityPolicy, fetch};
+use servo_fetch::blocking::fetch;
+use servo_fetch::{FetchOptions, NetworkPolicy, VisibilityPolicy};
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -52,7 +53,7 @@ async fn moderate_policy_filters_hidden_content() {
     let url = format!("{}/", server.uri());
 
     let md = tokio::task::spawn_blocking(move || {
-        fetch(FetchOptions::new(&url).visibility(VisibilityPolicy::moderate()))
+        fetch(&FetchOptions::new(&url).visibility(VisibilityPolicy::moderate()))
             .expect("fetch")
             .markdown()
             .expect("markdown")


### PR DESCRIPTION
## Summary

Adopt async-primary pattern: top-level functions (`fetch`, `markdown`, `text`, `extract_json`, `crawl`, `crawl_each`, `map`) are now `async fn`; sync counterparts live under `servo_fetch::blocking::*` as zero-cost `pub use` re-exports.

**Breaking change**: top-level sync functions removed — migrate to `servo_fetch::blocking::*`.

## Related issues

N/A

## Test Plan

- `cargo test -p servo-fetch`: all passed
- `cargo test -p servo-fetch-cli`: all passed
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --lib --no-deps`

## Checklist

- [x] Ran `cargo +nightly fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
- [x] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed
- [x] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it