### PR TITLE
chore(release): protect breaking commits and surface them at top of changelog

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -30,6 +30,7 @@ git_release_name = "v{{ version }}"
 git_release_draft = true
 
 [changelog]
+protect_breaking_commits = true
 header = """
 # Changelog
 
@@ -43,6 +44,15 @@ body = """
 {% else %}\
 ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
 {% endif %}\
+{%- set breaking_commits = commits | filter(attribute="breaking", value=true) %}
+{%- if breaking_commits | length > 0 %}
+
+### Breaking Changes
+
+{% for commit in breaking_commits %}\
+- {% if commit.scope %}*({{ commit.scope }})* {% endif %}{{ commit.message | upper_first }}
+{% endfor %}\
+{%- endif %}\
 {% for group, commits in commits | group_by(attribute="group") %}
 ### {{ group | striptags | trim }}
 


### PR DESCRIPTION
## Summary

Surface breaking changes prominently in the auto-generated CHANGELOG:

- `protect_breaking_commits = true` keeps breaking-marked commits in the changelog even if they match a `skip` rule (defense in depth).
- New top-of-version `Breaking Changes` section lists every commit whose `breaking` attribute is true. The inline `[**breaking**]` annotation in per-group entries is kept on purpose.

## Test Plan

- `git-cliff --config release-plz.toml ...` parses the template without errors.

## Checklist

- [ ] Ran `cargo +nightly fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
- [ ] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed
- [ ] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it