### PR TITLE
docs: document breaking change marker convention

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,8 @@ Conventional Commits, **subject-only** by default. Use the body only when critic
 
 Examples: `fix(build): drop +crt-static on Windows to match mozjs-sys CRT`, `chore(deps): bump rustls`.
 
+**Breaking changes:** mark with `!` in the subject (`feat(api)!: split sync and async`, `refactor(error)!: rename Error::Timeout`). The marker drives release-plz's minor/major bump and the `### Breaking Changes` changelog section. Put migration guidance for users in the release PR's `CHANGELOG.md` under `### Migration Guide`, not in commit bodies (release-plz does not surface commit bodies).
+
 ### Branch names
 
 Kebab-case under a type prefix: `fix/windows-crt-mismatch`, `refactor/wiremock-body-mime-consistency`, `ci/trivy-image-scan`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,6 +78,10 @@ fix: handle empty body in extract
 refactor: simplify bridge error handling
 ```
 
+### Breaking changes
+
+Mark breaking changes with `!` in the subject — for example, `feat(api)!: split sync and async` or `refactor(error)!: rename Error::Timeout`. The subject marker keeps the breaking nature visible in commit logs, PR titles, and the auto-generated changelog.
+
 ## Pull request guidelines
 
 - Keep PRs focused on a single change


### PR DESCRIPTION
## Summary

Document the breaking change marker (`!` in the commit subject) in `CONTRIBUTING.md` and `AGENTS.md`.

## Related issues

N/A

## Test Plan

N/A

## Checklist

- [ ] Ran `cargo +nightly fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
- [x] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed
- [x] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it