### PR TITLE
chore(deps): bump servo to 0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6162,9 +6162,9 @@ dependencies = [
 
 [[package]]
 name = "servo"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0070e405abc520d91ff75db643bca36f9d13e99b9b3448c6bcc154769d4a75fe"
+checksum = "2311cff3de4f2352ea13a9db0718262645202c0773f668a4aad20cc07fe6b06f"
 dependencies = [
  "accesskit",
  "bitflags 2.11.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ rustls = { version = "0.23", default-features = false, features = ["aws-lc-rs"] 
 schemars = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-servo = { version = "0.1.0", default-features = false, features = ["baked-in-resources", "js_jit"] }
+servo = { version = "0.1.1", default-features = false, features = ["baked-in-resources", "js_jit"] }
 servo-fetch = { path = "crates/servo-fetch", version = "0.12.0" }
 tempfile = "3"
 thiserror = "2"


### PR DESCRIPTION
## Summary

Bump servo to `0.1.1`.

## Related issues

N/A

## Test Plan

```bash
cargo build --workspace --locked
cargo nextest run --workspace --locked
nextest --run-ignored only -p servo-fetch-cli --profile ci-e2e
nextest --run-ignored only -p servo-fetch --profile ci-e2e
```

## Checklist

- [x] Ran `cargo +nightly fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
- [ ] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed
- [ ] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it
