### PR TITLE
feat(cookies): add session-cookie injection from cookies.txt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6558,6 +6558,7 @@ version = "0.12.0"
 dependencies = [
  "anyhow",
  "bitflags 2.11.1",
+ "cookie 0.18.1",
  "cssparser",
  "dom_query",
  "dom_smoothie",
@@ -6577,6 +6578,7 @@ dependencies = [
  "serde",
  "serde_json",
  "servo",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ axum = "0.8"
 base64 = "0.22"
 bitflags = "2"
 clap = { version = "4", features = ["derive"] }
+cookie = "0.18"
 cssparser = "0.36"
 dom_query = "0.27"
 dom_smoothie = "0.17"

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ servo-fetch "https://example.com" --format json            # Structured JSON
 servo-fetch "https://example.com" --format png -o page.png # PNG screenshot
 servo-fetch "https://example.com" --js "document.title"    # Run JavaScript
 servo-fetch "https://example.com" --schema schema.json     # Schema-driven JSON
+servo-fetch "https://example.com" --cookies cookies.txt    # Send session cookies (cookies.txt)
 servo-fetch URL1 URL2 URL3                                 # Parallel batch
 servo-fetch "https://example.com" --output page.md         # Save to a single file
 servo-fetch URL1 URL2 --output-dir ./out/                  # Save each URL to its own file
@@ -249,7 +250,7 @@ See [SECURITY.md](./SECURITY.md) for details.
 
 ## Limitations
 
-- Sites behind login walls or CAPTCHAs are not supported.
+- Authenticated pages work via session cookies (`--cookies` / `FetchOptions::cookies`); interactive login flows and CAPTCHAs are not supported.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ servo-fetch "https://example.com" --format json            # Structured JSON
 servo-fetch "https://example.com" --format png -o page.png # PNG screenshot
 servo-fetch "https://example.com" --js "document.title"    # Run JavaScript
 servo-fetch "https://example.com" --schema schema.json     # Schema-driven JSON
-servo-fetch "https://example.com" --cookies cookies.txt    # Send session cookies (cookies.txt)
+servo-fetch "https://example.com" --cookies cookies.txt    # Send session cookies
 servo-fetch URL1 URL2 URL3                                 # Parallel batch
 servo-fetch "https://example.com" --output page.md         # Save to a single file
 servo-fetch URL1 URL2 --output-dir ./out/                  # Save each URL to its own file
@@ -250,7 +250,7 @@ See [SECURITY.md](./SECURITY.md) for details.
 
 ## Limitations
 
-- Authenticated pages work via session cookies (`--cookies` / `FetchOptions::cookies`); interactive login flows and CAPTCHAs are not supported.
+- Authenticated pages work via session cookies (`--cookies` / `FetchOptions::cookies`).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ See [SECURITY.md](./SECURITY.md) for details.
 
 ## Limitations
 
-- Authenticated pages work via session cookies (`--cookies` / `FetchOptions::cookies`).
+- Sites behind CAPTCHAs are not supported.
 
 ## Contributing
 

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -49,6 +49,24 @@ page = servo_fetch.fetch("https://shop.example.com", schema=schema)
 page.extracted  # [{"title": "...", "price": "...", "url": "..."}]
 ```
 
+## Session Cookies
+
+To fetch authenticated pages, pass a `str` or `os.PathLike` path to a
+Netscape-format `cookies.txt` via `cookies_file`:
+
+```python
+import servo_fetch
+
+page = servo_fetch.fetch("https://app.example.com/dashboard", cookies_file="cookies.txt")
+
+# Also accepted by Client.fetch / Client.crawl and their async equivalents.
+client = servo_fetch.Client(user_agent="MyBot/1.0")
+pages = client.crawl("https://app.example.com", cookies_file="cookies.txt", max_pages=20)
+```
+
+A missing or malformed file raises `servo_fetch.CookieError`. Cookies are scoped
+to the target's site, so out-of-scope entries in the file are ignored.
+
 ## Async
 
 ```python

--- a/bindings/python/python/servo_fetch/__init__.py
+++ b/bindings/python/python/servo_fetch/__init__.py
@@ -3,6 +3,7 @@
 from ._native import (
     Client,
     ConsoleMessage,
+    CookieError,
     CrawlResult,
     EngineError,
     FetchTimeoutError,
@@ -23,6 +24,7 @@ __all__ = [
     "AsyncClient",
     "Client",
     "ConsoleMessage",
+    "CookieError",
     "CrawlResult",
     "EngineError",
     "FetchTimeoutError",

--- a/bindings/python/python/servo_fetch/_native.pyi
+++ b/bindings/python/python/servo_fetch/_native.pyi
@@ -116,6 +116,7 @@ class Client:
         screenshot: bool = False,
         javascript: str | None = None,
         schema: Schema | None = None,
+        cookies_file: str | os.PathLike[str] | None = None,
     ) -> Page: ...
     def crawl(
         self,
@@ -127,6 +128,7 @@ class Client:
         exclude: str | list[str] | None = None,
         concurrency: int = 1,
         delay_ms: int = 0,
+        cookies_file: str | os.PathLike[str] | None = None,
     ) -> list[CrawlResult]: ...
     def crawl_each(
         self,
@@ -140,6 +142,7 @@ class Client:
         concurrency: int = 1,
         delay_ms: int = 0,
         abort: threading.Event | None = None,
+        cookies_file: str | os.PathLike[str] | None = None,
     ) -> None: ...
     def map(
         self,
@@ -156,6 +159,7 @@ class FetchTimeoutError(ServoFetchError): ...
 class NetworkError(ServoFetchError): ...
 class EngineError(ServoFetchError): ...
 class SchemaError(ServoFetchError): ...
+class CookieError(ServoFetchError): ...
 
 def fetch(
     url: str,
@@ -166,4 +170,5 @@ def fetch(
     screenshot: bool = False,
     javascript: str | None = None,
     schema: Schema | None = None,
+    cookies_file: str | os.PathLike[str] | None = None,
 ) -> Page: ...

--- a/bindings/python/python/servo_fetch/async_api.py
+++ b/bindings/python/python/servo_fetch/async_api.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import os
 import threading
 from collections.abc import AsyncIterator
 from typing import cast
@@ -25,6 +26,7 @@ async def fetch_async(
     screenshot: bool = False,
     javascript: str | None = None,
     schema: Schema | None = None,
+    cookies_file: str | os.PathLike[str] | None = None,
 ) -> Page:
     """Asynchronously fetch a single URL."""
     return await asyncio.to_thread(
@@ -36,6 +38,7 @@ async def fetch_async(
         screenshot=screenshot,
         javascript=javascript,
         schema=schema,
+        cookies_file=cookies_file,
     )
 
 
@@ -60,6 +63,7 @@ class AsyncClient:
         screenshot: bool = False,
         javascript: str | None = None,
         schema: Schema | None = None,
+        cookies_file: str | os.PathLike[str] | None = None,
     ) -> Page:
         return await asyncio.to_thread(
             self._inner.fetch,
@@ -69,6 +73,7 @@ class AsyncClient:
             screenshot=screenshot,
             javascript=javascript,
             schema=schema,
+            cookies_file=cookies_file,
         )
 
     async def crawl(
@@ -81,6 +86,7 @@ class AsyncClient:
         exclude: str | list[str] | None = None,
         concurrency: int = 1,
         delay_ms: int = 0,
+        cookies_file: str | os.PathLike[str] | None = None,
     ) -> list[CrawlResult]:
         return await asyncio.to_thread(
             self._inner.crawl,
@@ -91,6 +97,7 @@ class AsyncClient:
             exclude=exclude,
             concurrency=concurrency,
             delay_ms=delay_ms,
+            cookies_file=cookies_file,
         )
 
     async def crawl_stream(
@@ -103,6 +110,7 @@ class AsyncClient:
         exclude: str | list[str] | None = None,
         concurrency: int = 1,
         delay_ms: int = 0,
+        cookies_file: str | os.PathLike[str] | None = None,
     ) -> AsyncIterator[CrawlResult]:
         """Crawl a site, yielding each page as it completes."""
         loop = asyncio.get_running_loop()
@@ -125,6 +133,7 @@ class AsyncClient:
                     exclude=exclude,
                     concurrency=concurrency,
                     delay_ms=delay_ms,
+                    cookies_file=cookies_file,
                 )
             finally:
                 fut = asyncio.run_coroutine_threadsafe(queue.put(_SENTINEL), loop)

--- a/bindings/python/src/client.rs
+++ b/bindings/python/src/client.rs
@@ -2,6 +2,7 @@
 
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::path::PathBuf;
 use std::time::Duration;
 
 use pyo3::prelude::*;
@@ -34,7 +35,7 @@ impl Client {
     }
 
     /// Fetch a single URL, merging client defaults with per-call overrides.
-    #[pyo3(signature = (url, *, timeout=None, settle=None, screenshot=false, javascript=None, schema=None))]
+    #[pyo3(signature = (url, *, timeout=None, settle=None, screenshot=false, javascript=None, schema=None, cookies_file=None))]
     #[allow(clippy::too_many_arguments)]
     fn fetch(
         &self,
@@ -45,6 +46,7 @@ impl Client {
         screenshot: bool,
         javascript: Option<String>,
         schema: Option<Bound<'_, Schema>>,
+        cookies_file: Option<PathBuf>,
     ) -> PyResult<Page> {
         let timeout = timeout.or(Some(self.timeout.as_secs_f64()));
         let settle = settle.or(Some(self.settle.as_secs_f64()));
@@ -56,6 +58,7 @@ impl Client {
             screenshot,
             javascript,
             schema,
+            cookies_file,
         })?;
         let page = py
             .detach(|| servo_fetch::blocking::fetch(&prepared.opts))
@@ -78,6 +81,7 @@ impl Client {
         exclude=None,
         concurrency=1,
         delay_ms=0,
+        cookies_file=None,
     ))]
     #[allow(clippy::too_many_arguments)]
     fn crawl(
@@ -90,6 +94,7 @@ impl Client {
         exclude: Option<&Bound<'_, PyAny>>,
         concurrency: usize,
         delay_ms: u64,
+        cookies_file: Option<PathBuf>,
     ) -> PyResult<Vec<CrawlResult>> {
         let opts = build_crawl_opts(
             &url,
@@ -102,13 +107,14 @@ impl Client {
             exclude,
             concurrency,
             delay_ms,
+            cookies_file,
         )?;
         let results = py.detach(|| servo_fetch::blocking::crawl(&opts)).map_err(map_error)?;
         Ok(results.into_iter().map(CrawlResult::from_core).collect())
     }
 
     /// Crawl a site, invoking `callback(CrawlResult)` as each page completes.
-    #[pyo3(signature = (url, callback, *, max_pages=50, max_depth=3, include=None, exclude=None, concurrency=1, delay_ms=0, abort=None))]
+    #[pyo3(signature = (url, callback, *, max_pages=50, max_depth=3, include=None, exclude=None, concurrency=1, delay_ms=0, abort=None, cookies_file=None))]
     #[allow(clippy::too_many_arguments)]
     fn crawl_each(
         &self,
@@ -122,6 +128,7 @@ impl Client {
         concurrency: usize,
         delay_ms: u64,
         abort: Option<Py<PyAny>>,
+        cookies_file: Option<PathBuf>,
     ) -> PyResult<()> {
         let opts = build_crawl_opts(
             &url,
@@ -134,6 +141,7 @@ impl Client {
             exclude,
             concurrency,
             delay_ms,
+            cookies_file,
         )?;
 
         let stop = AtomicBool::new(false);
@@ -228,6 +236,7 @@ fn build_crawl_opts(
     exclude: Option<&Bound<'_, PyAny>>,
     concurrency: usize,
     delay_ms: u64,
+    cookies_file: Option<PathBuf>,
 ) -> PyResult<servo_fetch::CrawlOptions> {
     validate::url(url)?;
     let include = strings_from_any(include)?;
@@ -249,6 +258,12 @@ fn build_crawl_opts(
     };
     if let Some(ua) = user_agent {
         opts = opts.user_agent(ua);
+    }
+    if let Some(path) = &cookies_file {
+        let cookies = servo_fetch::load_cookies(path).map_err(map_error)?;
+        if !cookies.is_empty() {
+            opts = opts.cookies(cookies);
+        }
     }
     Ok(opts)
 }

--- a/bindings/python/src/client.rs
+++ b/bindings/python/src/client.rs
@@ -1,8 +1,8 @@
 //! `Client` pyclass: shared defaults + per-call overrides.
 
+use std::path::PathBuf;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::path::PathBuf;
 use std::time::Duration;
 
 use pyo3::prelude::*;

--- a/bindings/python/src/errors.rs
+++ b/bindings/python/src/errors.rs
@@ -40,6 +40,12 @@ create_exception!(
     ServoFetchError,
     "Schema parse, validation, or I/O failure."
 );
+create_exception!(
+    servo_fetch,
+    CookieError,
+    ServoFetchError,
+    "Failed to load or parse a cookies file."
+);
 
 pub(crate) fn map_error(err: servo_fetch::Error) -> PyErr {
     match &err {
@@ -54,6 +60,7 @@ pub(crate) fn map_error(err: servo_fetch::Error) -> PyErr {
         servo_fetch::Error::AddressNotAllowed { host } => NetworkError::new_err(format!("address not allowed: {host}")),
         servo_fetch::Error::Engine { source, .. } => EngineError::new_err(source.to_string()),
         servo_fetch::Error::Schema(e) => SchemaError::new_err(e.to_string()),
+        servo_fetch::Error::Cookies { .. } => CookieError::new_err(err.to_string()),
         _ => ServoFetchError::new_err(err.to_string()),
     }
 }
@@ -75,5 +82,6 @@ pub(crate) fn register(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> 
     m.add("NetworkError", py.get_type::<NetworkError>())?;
     m.add("EngineError", py.get_type::<EngineError>())?;
     m.add("SchemaError", py.get_type::<SchemaError>())?;
+    m.add("CookieError", py.get_type::<CookieError>())?;
     Ok(())
 }

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -1,5 +1,7 @@
 //! PyO3 bindings for servo-fetch.
 
+use std::path::PathBuf;
+
 use pyo3::prelude::*;
 
 mod client;
@@ -16,7 +18,7 @@ use crate::opts::{BuildOpts, prepare};
 
 /// Fetch, render, and extract a single URL.
 #[pyfunction]
-#[pyo3(signature = (url, *, timeout=None, settle=None, user_agent=None, screenshot=false, javascript=None, schema=None))]
+#[pyo3(signature = (url, *, timeout=None, settle=None, user_agent=None, screenshot=false, javascript=None, schema=None, cookies_file=None))]
 #[allow(clippy::too_many_arguments)]
 fn fetch(
     py: Python<'_>,
@@ -27,6 +29,7 @@ fn fetch(
     screenshot: bool,
     javascript: Option<String>,
     schema: Option<Bound<'_, schema::Schema>>,
+    cookies_file: Option<PathBuf>,
 ) -> PyResult<page::Page> {
     let prepared = prepare(BuildOpts {
         url,
@@ -36,6 +39,7 @@ fn fetch(
         screenshot,
         javascript,
         schema,
+        cookies_file,
     })?;
     let servo_page = py
         .detach(|| servo_fetch::blocking::fetch(&prepared.opts))

--- a/bindings/python/src/opts.rs
+++ b/bindings/python/src/opts.rs
@@ -1,5 +1,7 @@
 //! Build [`servo_fetch::FetchOptions`] from Python kwargs.
 
+use std::path::PathBuf;
+
 use pyo3::prelude::*;
 
 use crate::schema::Schema;
@@ -13,6 +15,7 @@ pub(crate) struct BuildOpts<'py> {
     pub screenshot: bool,
     pub javascript: Option<String>,
     pub schema: Option<Bound<'py, Schema>>,
+    pub cookies_file: Option<PathBuf>,
 }
 
 pub(crate) struct Prepared {
@@ -51,6 +54,12 @@ pub(crate) fn prepare(args: BuildOpts<'_>) -> PyResult<Prepared> {
     }
     if let Some(schema) = schema_inner {
         opts = opts.schema(schema);
+    }
+    if let Some(path) = &args.cookies_file {
+        let cookies = servo_fetch::load_cookies(path).map_err(crate::errors::map_error)?;
+        if !cookies.is_empty() {
+            opts = opts.cookies(cookies);
+        }
     }
 
     Ok(Prepared {

--- a/bindings/python/src/schema.rs
+++ b/bindings/python/src/schema.rs
@@ -173,7 +173,8 @@ impl Schema {
     /// Load a schema from a JSON file on disk. Accepts `str` or `os.PathLike`.
     #[staticmethod]
     fn from_file(path: PathBuf) -> PyResult<Self> {
-        let inner = servo_fetch::schema::ExtractSchema::from_path(&path).map_err(|e| SchemaError::new_err(e.to_string()))?;
+        let inner =
+            servo_fetch::schema::ExtractSchema::from_path(&path).map_err(|e| SchemaError::new_err(e.to_string()))?;
         Ok(Self { inner })
     }
 

--- a/bindings/python/src/schema.rs
+++ b/bindings/python/src/schema.rs
@@ -1,5 +1,7 @@
 //! `Schema` and `Field` pyclasses over `servo_fetch::schema`.
 
+use std::path::PathBuf;
+
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 
@@ -170,11 +172,8 @@ impl Schema {
 
     /// Load a schema from a JSON file on disk. Accepts `str` or `os.PathLike`.
     #[staticmethod]
-    fn from_file(py: Python<'_>, path: &Bound<'_, PyAny>) -> PyResult<Self> {
-        let os = py.import("os")?;
-        let path_str: String = os.call_method1("fspath", (path,))?.extract()?;
-        let inner = servo_fetch::schema::ExtractSchema::from_path(&path_str)
-            .map_err(|e| SchemaError::new_err(e.to_string()))?;
+    fn from_file(path: PathBuf) -> PyResult<Self> {
+        let inner = servo_fetch::schema::ExtractSchema::from_path(&path).map_err(|e| SchemaError::new_err(e.to_string()))?;
         Ok(Self { inner })
     }
 

--- a/bindings/python/tests/test_cookies.py
+++ b/bindings/python/tests/test_cookies.py
@@ -1,0 +1,54 @@
+"""Cookie-file loading via the `cookies_file` kwarg — offline error paths."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+import servo_fetch
+from servo_fetch import CookieError, ServoFetchError, fetch_async
+
+URL = "https://example.com"
+
+
+def test_cookie_error_subclasses_servo_fetch_error() -> None:
+    assert issubclass(CookieError, ServoFetchError)
+
+
+@pytest.mark.parametrize(
+    "call",
+    [
+        pytest.param(lambda cf: servo_fetch.fetch(URL, cookies_file=cf), id="fetch"),
+        pytest.param(lambda cf: servo_fetch.Client().fetch(URL, cookies_file=cf), id="client.fetch"),
+        pytest.param(lambda cf: servo_fetch.Client().crawl(URL, cookies_file=cf), id="client.crawl"),
+    ],
+)
+def test_missing_cookie_file_raises(call: Callable[[str], object], tmp_path: Path) -> None:
+    with pytest.raises(CookieError, match="failed to load cookies"):
+        call(str(tmp_path / "nope.txt"))
+
+
+def test_cookies_file_wrong_type_raises() -> None:
+    with pytest.raises(TypeError, match="PathLike"):
+        servo_fetch.fetch(URL, cookies_file=123)
+
+
+@pytest.mark.asyncio
+async def test_fetch_async_missing_cookie_file_raises(tmp_path: Path) -> None:
+    with pytest.raises(CookieError, match="failed to load cookies"):
+        await fetch_async(URL, cookies_file=str(tmp_path / "nope.txt"))
+
+
+@pytest.mark.skipif(
+    os.environ.get("SERVO_FETCH_E2E") != "1",
+    reason="set SERVO_FETCH_E2E=1 to run end-to-end tests",
+)
+def test_fetch_with_valid_cookie_file(tmp_path: Path) -> None:
+    cookies = tmp_path / "cookies.txt"
+    cookies.write_text("app.example.com\tFALSE\t/\tFALSE\t0\tsession\tabc123\n")
+    url = os.environ.get("SERVO_FETCH_TEST_URL", URL)
+    page = servo_fetch.fetch(url, cookies_file=cookies)
+    assert isinstance(page, servo_fetch.Page)

--- a/crates/servo-fetch-cli/README.md
+++ b/crates/servo-fetch-cli/README.md
@@ -164,6 +164,7 @@ Self-contained `/health` probe for any orchestrator that runs a command and insp
 | `-t, --timeout <SECS>` | Page load timeout in seconds (default: 30) |
 | `--settle <MS>` | Extra wait after load event in ms (default: 0, max: 10000) |
 | `--user-agent <UA>` | Override the User-Agent string |
+| `--cookies <FILE>` | Load session cookies from a Netscape/Mozilla cookies.txt file |
 | `-v, --verbose` | Increase log verbosity (`-v` info, `-vv` debug, `-vvv` trace) |
 | `-q, --quiet` | Suppress all logs except errors |
 
@@ -196,6 +197,7 @@ Self-contained `/health` probe for any orchestrator that runs a command and insp
 | `--concurrency <N>` | Maximum parallel page fetches (default: 1; completion order when >1) |
 | `--delay-ms <MS>` | Minimum dispatch interval in ms (default: 500; 0 disables rate limiting) |
 | `--user-agent <UA>` | Override the User-Agent string |
+| `--cookies <FILE>` | Load session cookies from a Netscape/Mozilla cookies.txt file |
 | `-t, --timeout <SECS>` | Page load timeout in seconds per page (default: 30) |
 | `--settle <MS>` | Extra wait after load event in ms per page (default: 0, max: 10000) |
 

--- a/crates/servo-fetch-cli/src/cli.rs
+++ b/crates/servo-fetch-cli/src/cli.rs
@@ -66,6 +66,10 @@ pub(crate) struct FetchArgs {
     #[arg(long, value_name = "UA")]
     pub user_agent: Option<String>,
 
+    /// Load cookies from a Netscape/Mozilla cookies.txt file (curl/wget compatible).
+    #[arg(long, value_name = "FILE")]
+    pub cookies: Option<PathBuf>,
+
     /// Path to a CSS-selector schema file for structured JSON extraction
     #[arg(long, value_name = "FILE", conflicts_with_all = ["js", "selector", "format"])]
     pub schema: Option<PathBuf>,
@@ -215,6 +219,10 @@ pub(crate) struct CrawlArgs {
     /// Override the User-Agent string
     #[arg(long, value_name = "UA")]
     pub user_agent: Option<String>,
+
+    /// Load cookies from a Netscape/Mozilla cookies.txt file (curl/wget compatible).
+    #[arg(long, value_name = "FILE")]
+    pub cookies: Option<PathBuf>,
 
     /// Write each crawled page's output to a file in this directory.
     #[arg(long, value_name = "DIR")]

--- a/crates/servo-fetch-cli/src/cli.rs
+++ b/crates/servo-fetch-cli/src/cli.rs
@@ -66,7 +66,7 @@ pub(crate) struct FetchArgs {
     #[arg(long, value_name = "UA")]
     pub user_agent: Option<String>,
 
-    /// Load cookies from a Netscape/Mozilla cookies.txt file (curl/wget compatible).
+    /// Load cookies from a Netscape-format cookies.txt file.
     #[arg(long, value_name = "FILE")]
     pub cookies: Option<PathBuf>,
 
@@ -220,7 +220,7 @@ pub(crate) struct CrawlArgs {
     #[arg(long, value_name = "UA")]
     pub user_agent: Option<String>,
 
-    /// Load cookies from a Netscape/Mozilla cookies.txt file (curl/wget compatible).
+    /// Load cookies from a Netscape-format cookies.txt file.
     #[arg(long, value_name = "FILE")]
     pub cookies: Option<PathBuf>,
 

--- a/crates/servo-fetch-cli/src/commands/crawl.rs
+++ b/crates/servo-fetch-cli/src/commands/crawl.rs
@@ -26,7 +26,10 @@ pub(crate) fn run(args: &CrawlArgs) -> anyhow::Result<()> {
     }
     let json = matches!(args.format, CrawlFormat::Json);
     let sink = Sink::from_dir(args.output_dir.as_deref());
-    let opts = build_crawl_options(args, json);
+    let mut opts = build_crawl_options(args, json);
+    if let Some(path) = &args.cookies {
+        opts = opts.cookies(servo_fetch::load_cookies(path)?);
+    }
 
     let progress = Progress::new();
     let mut completed = 0u64;

--- a/crates/servo-fetch-cli/src/commands/fetch.rs
+++ b/crates/servo-fetch-cli/src/commands/fetch.rs
@@ -84,6 +84,7 @@ async fn run_batch(args: &FetchArgs, urls: &[String]) -> Result<()> {
     progress.header(&format!("Fetching {total} URLs..."));
 
     let schema = args.schema.as_ref().map(|p| load_schema(p)).transpose()?;
+    let cookies = args.cookies.as_ref().map(servo_fetch::load_cookies).transpose()?;
 
     let sem = std::sync::Arc::new(tokio::sync::Semaphore::new(4));
     let (tx, mut rx) = tokio::sync::mpsc::channel::<(String, std::result::Result<Page, servo_fetch::Error>)>(total);
@@ -97,6 +98,7 @@ async fn run_batch(args: &FetchArgs, urls: &[String]) -> Result<()> {
         let user_agent = args.user_agent.clone();
         let schema = schema.clone();
         let visibility = args.visibility.to_policy();
+        let cookies = cookies.clone();
         tokio::task::spawn_blocking(move || {
             let mut opts = FetchOptions::new(&url_str)
                 .timeout(Duration::from_secs(timeout))
@@ -107,6 +109,9 @@ async fn run_batch(args: &FetchArgs, urls: &[String]) -> Result<()> {
             }
             if let Some(s) = schema {
                 opts = opts.schema(s);
+            }
+            if let Some(c) = cookies {
+                opts = opts.cookies(c);
             }
             let result = servo_fetch::blocking::fetch(&opts);
             let _ = tx.blocking_send((url_str, result));
@@ -196,6 +201,10 @@ fn build_fetch_options(args: &FetchArgs, url: &str) -> Result<FetchOptions> {
     };
     let opts = match args.schema {
         Some(ref path) => opts.schema(load_schema(path)?),
+        None => opts,
+    };
+    let opts = match args.cookies {
+        Some(ref path) => opts.cookies(servo_fetch::load_cookies(path)?),
         None => opts,
     };
     Ok(opts)

--- a/crates/servo-fetch/Cargo.toml
+++ b/crates/servo-fetch/Cargo.toml
@@ -16,6 +16,7 @@ include = ["src/**/*", "Cargo.toml", "LICENSE-MIT", "LICENSE-APACHE", "README.md
 servo = { workspace = true }
 anyhow = { workspace = true }
 bitflags = { workspace = true }
+cookie = { workspace = true }
 cssparser = { workspace = true }
 dom_query = { workspace = true }
 dom_smoothie = { workspace = true }
@@ -48,6 +49,7 @@ os_pipe = "1"
 servo = { workspace = true, features = ["no-wgl"] }
 
 [dev-dependencies]
+tempfile = { workspace = true }
 tokio = { workspace = true, features = ["macros", "test-util"] }
 wiremock = { workspace = true }
 

--- a/crates/servo-fetch/README.md
+++ b/crates/servo-fetch/README.md
@@ -35,14 +35,15 @@ let md = servo_fetch::blocking::markdown("https://example.com")?;
 ### Fetch with options
 
 ```rust
-use servo_fetch::{fetch, FetchOptions};
+use servo_fetch::{fetch, load_cookies, FetchOptions};
 use std::time::Duration;
 
 let page = fetch(
     &FetchOptions::new("https://spa-site.com")
         .timeout(Duration::from_secs(60))
         .settle(Duration::from_millis(3000))
-        .user_agent("MyBot/1.0"),
+        .user_agent("MyBot/1.0")
+        .cookies(load_cookies("cookies.txt")?),
 ).await?;
 println!("{}", page.html);
 let md = page.markdown()?;

--- a/crates/servo-fetch/src/bridge.rs
+++ b/crates/servo-fetch/src/bridge.rs
@@ -18,6 +18,7 @@ use servo::{
 use tokio::sync::{mpsc, oneshot};
 use url::Url;
 
+use crate::cookies::CookieSpec;
 use crate::{layout, visibility};
 
 const EXTRACTION_BUDGET: Duration = Duration::from_secs(10);
@@ -254,6 +255,7 @@ pub(crate) struct FetchOptions<'a> {
     pub settle_ms: u64,
     pub mode: FetchMode,
     pub user_agent: Option<&'a str>,
+    pub cookies: &'a [CookieSpec],
 }
 
 /// What to do once the page has loaded. Variants are mutually exclusive.
@@ -271,6 +273,7 @@ struct FetchRequest {
     settle_ms: u64,
     mode: FetchMode,
     user_agent: Option<String>,
+    cookies: Vec<CookieSpec>,
     reply: ReplyFn,
 }
 
@@ -353,6 +356,7 @@ fn build_request(opts: FetchOptions<'_>, reply: ReplyFn) -> FetchRequest {
         settle_ms: opts.settle_ms,
         mode: opts.mode,
         user_agent: opts.user_agent.map(String::from),
+        cookies: opts.cookies.to_vec(),
         reply,
     }
 }
@@ -479,13 +483,8 @@ fn accept_request(
     req: FetchRequest,
     pending: &mut HashMap<WebViewId, PendingFetch>,
 ) {
-    match start_fetch(servo, rc_ctx, delegate, ucm, req) {
-        Ok(p) => {
-            pending.insert(p.webview.id(), p);
-        }
-        Err((req, err)) => {
-            (req.reply)(Err(err));
-        }
+    if let Some(p) = start_fetch(servo, rc_ctx, delegate, ucm, req) {
+        pending.insert(p.webview.id(), p);
     }
 }
 
@@ -518,25 +517,34 @@ fn start_fetch(
     delegate: &Rc<SharedDelegate>,
     ucm: &Rc<UserContentManager>,
     req: FetchRequest,
-) -> std::result::Result<PendingFetch, (FetchRequest, anyhow::Error)> {
+) -> Option<PendingFetch> {
     let parsed_url = match Url::parse(&req.url) {
         Ok(u) => u,
-        Err(e) => return Err((req, anyhow!("bad url: {e}"))),
+        Err(e) => {
+            (req.reply)(Err(anyhow!("bad url: {e}")));
+            return None;
+        }
     };
 
     let ua = req.user_agent.as_deref().unwrap_or_else(|| default_user_agent());
     servo.set_preference("user_agent", servo::PrefValue::Str(ua.to_owned()));
+
+    crate::cookies::seed(servo, &parsed_url, &req.cookies);
 
     let dedicated_ctx = if matches!(req.mode, FetchMode::Screenshot { .. }) {
         let size = PhysicalSize::new(layout::VIEWPORT_WIDTH, layout::VIEWPORT_HEIGHT);
         match SoftwareRenderingContext::new(size) {
             Ok(ctx) => {
                 if let Err(e) = ctx.make_current() {
-                    return Err((req, anyhow!("failed to make screenshot context current: {e:?}")));
+                    (req.reply)(Err(anyhow!("failed to make screenshot context current: {e:?}")));
+                    return None;
                 }
                 Some(Rc::new(ctx))
             }
-            Err(e) => return Err((req, anyhow!("failed to create screenshot context: {e:?}"))),
+            Err(e) => {
+                (req.reply)(Err(anyhow!("failed to create screenshot context: {e:?}")));
+                return None;
+            }
         }
     } else {
         None
@@ -560,7 +568,7 @@ fn start_fetch(
 
     let state = delegate.register(webview.id());
     let deadline = Instant::now() + Duration::from_secs(req.timeout_secs);
-    Ok(PendingFetch {
+    Some(PendingFetch {
         webview,
         request: req,
         deadline,
@@ -933,6 +941,7 @@ mod tests {
             settle_ms: 0,
             mode: FetchMode::Content { include_a11y: false },
             user_agent: None,
+            cookies: Vec::new(),
             reply,
         }
     }
@@ -945,6 +954,7 @@ mod tests {
             settle_ms: 100,
             mode: FetchMode::Content { include_a11y: false },
             user_agent: Some("test-ua"),
+            cookies: &[],
         };
         let req = build_request(opts, Box::new(|_| {}));
         assert_eq!(req.url, "test://example");

--- a/crates/servo-fetch/src/cookies.rs
+++ b/crates/servo-fetch/src/cookies.rs
@@ -37,7 +37,7 @@ impl std::fmt::Debug for CookieSpec {
     }
 }
 
-/// Load cookies from a Netscape/Mozilla `cookies.txt` file (curl/wget compatible).
+/// Load cookies from a Netscape format `cookies.txt` file.
 pub fn load_cookies(path: impl AsRef<Path>) -> Result<Vec<CookieSpec>> {
     let path = path.as_ref();
     let fail = |reason: String| Error::Cookies {

--- a/crates/servo-fetch/src/cookies.rs
+++ b/crates/servo-fetch/src/cookies.rs
@@ -1,0 +1,297 @@
+//! Load a Netscape `cookies.txt` file and seed Servo's cookie jar before navigation.
+
+use std::io::Read;
+use std::path::Path;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use url::Url;
+
+use crate::error::{Error, Result};
+
+const MAX_FILE_BYTES: u64 = 4 << 20;
+const MAX_COOKIES: usize = 3000;
+
+/// A cookie to seed into the jar before navigation.
+#[derive(Clone, PartialEq, Eq)]
+pub struct CookieSpec {
+    name: String,
+    value: String,
+    domain: String,
+    path: String,
+    secure: bool,
+    http_only: bool,
+    include_subdomains: bool,
+}
+
+impl std::fmt::Debug for CookieSpec {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CookieSpec")
+            .field("name", &self.name)
+            .field("value", &"<redacted>")
+            .field("domain", &self.domain)
+            .field("path", &self.path)
+            .field("secure", &self.secure)
+            .field("http_only", &self.http_only)
+            .field("include_subdomains", &self.include_subdomains)
+            .finish()
+    }
+}
+
+/// Load cookies from a Netscape/Mozilla `cookies.txt` file (curl/wget compatible).
+pub fn load_cookies(path: impl AsRef<Path>) -> Result<Vec<CookieSpec>> {
+    let path = path.as_ref();
+    let fail = |reason: String| Error::Cookies {
+        path: path.display().to_string(),
+        reason,
+    };
+    let mut text = String::new();
+    std::fs::File::open(path)
+        .and_then(|f| f.take(MAX_FILE_BYTES + 1).read_to_string(&mut text))
+        .map_err(|e| fail(e.to_string()))?;
+    if text.len() as u64 > MAX_FILE_BYTES {
+        return Err(fail(format!("file exceeds {MAX_FILE_BYTES} bytes")));
+    }
+    parse_cookies(&text).map_err(|e| fail(e.to_string()))
+}
+
+#[derive(Debug, thiserror::Error)]
+enum ParseError {
+    #[error("line {line}: expected 7 tab-separated fields, found {found}")]
+    FieldCount { line: usize, found: usize },
+    #[error("line {line}: illegal character in cookie name or value")]
+    IllegalChar { line: usize },
+    #[error("too many cookies (max {max})")]
+    TooMany { max: usize },
+}
+
+fn parse_cookies(text: &str) -> std::result::Result<Vec<CookieSpec>, ParseError> {
+    let now = now_unix();
+    let mut out = Vec::new();
+    for (i, raw) in text.lines().enumerate() {
+        let line = i + 1;
+        let (http_only, rest) = match raw.strip_prefix("#HttpOnly_") {
+            Some(rest) => (true, rest),
+            None if raw.trim().is_empty() || raw.starts_with('#') => continue,
+            None => (false, raw),
+        };
+        let fields: Vec<&str> = rest.split('\t').collect();
+        let [domain, include_sub, cpath, secure, expires, name, value] = fields[..] else {
+            return Err(ParseError::FieldCount {
+                line,
+                found: fields.len(),
+            });
+        };
+        if has_control(name) || name.contains([';', '=']) || has_control(value) || value.contains(';') {
+            return Err(ParseError::IllegalChar { line });
+        }
+        if expires
+            .split('.')
+            .next()
+            .and_then(|s| s.trim().parse::<i64>().ok())
+            .is_some_and(|e| e > 0 && e <= now)
+        {
+            continue;
+        }
+        if out.len() >= MAX_COOKIES {
+            return Err(ParseError::TooMany { max: MAX_COOKIES });
+        }
+        out.push(CookieSpec {
+            name: name.to_owned(),
+            value: value.to_owned(),
+            domain: domain.to_owned(),
+            path: if cpath.is_empty() { "/" } else { cpath }.to_owned(),
+            secure: secure.eq_ignore_ascii_case("TRUE"),
+            http_only,
+            include_subdomains: include_sub.eq_ignore_ascii_case("TRUE"),
+        });
+    }
+    Ok(out)
+}
+
+/// Seed `specs` into the jar, scoped to `target`'s site and the network policy.
+pub(crate) fn seed(servo: &servo::Servo, target: &Url, specs: &[CookieSpec]) {
+    if specs.is_empty() {
+        return;
+    }
+    let policy = crate::bridge::engine_policy();
+    let manager = servo.site_data_manager();
+    for spec in specs {
+        if let Some((url, cookie)) = cookie_for(target, spec, policy) {
+            manager.set_cookie_for_url(url, cookie);
+        }
+    }
+}
+
+/// Build a jar entry keyed by the cookie's own origin, or `None` if it is out of
+/// `target`'s site or disallowed by `policy`.
+fn cookie_for(
+    target: &Url,
+    spec: &CookieSpec,
+    policy: crate::net::NetworkPolicy,
+) -> Option<(Url, cookie::Cookie<'static>)> {
+    let host = spec.domain.trim_start_matches('.');
+    let scheme = if spec.secure { "https" } else { "http" };
+    let url = Url::parse(&format!("{scheme}://{host}{}", spec.path)).ok()?;
+    if crate::net::validate_url_with_policy(url.as_str(), policy).is_err() || !crate::scope::is_same_site(target, &url)
+    {
+        tracing::warn!(domain = %host, "skipped out-of-scope or disallowed cookie");
+        return None;
+    }
+    let mut builder = cookie::Cookie::build((spec.name.clone(), spec.value.clone()))
+        .path(spec.path.clone())
+        .secure(spec.secure)
+        .http_only(spec.http_only);
+    if spec.domain.starts_with('.') || spec.include_subdomains {
+        builder = builder.domain(url.host_str().unwrap_or(host).to_owned());
+    }
+    Some((url, builder.build()))
+}
+
+fn has_control(s: &str) -> bool {
+    s.bytes().any(|b| b < 0x20 || b == 0x7f)
+}
+
+fn now_unix() -> i64 {
+    let secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    i64::try_from(secs).unwrap_or(i64::MAX)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write as _;
+
+    use super::*;
+    use crate::net::NetworkPolicy;
+
+    fn spec(domain: &str, secure: bool) -> CookieSpec {
+        CookieSpec {
+            name: "n".into(),
+            value: "v".into(),
+            domain: domain.into(),
+            path: "/".into(),
+            secure,
+            http_only: false,
+            include_subdomains: false,
+        }
+    }
+
+    #[test]
+    fn parses_standard_line() {
+        let specs = parse_cookies(".example.com\tTRUE\t/\tTRUE\t0\tsid\tabc123\n").unwrap();
+        assert_eq!(specs.len(), 1);
+        let c = &specs[0];
+        assert_eq!((c.name.as_str(), c.value.as_str()), ("sid", "abc123"));
+        assert_eq!(c.domain, ".example.com");
+        assert!(c.secure && c.include_subdomains && !c.http_only);
+    }
+
+    #[test]
+    fn handles_httponly_prefix_and_comments() {
+        let specs = parse_cookies("# a comment\n\n#HttpOnly_app.example.com\tFALSE\t/\tFALSE\t0\ttok\tv\n").unwrap();
+        assert_eq!(specs.len(), 1);
+        assert!(specs[0].http_only);
+        assert_eq!(specs[0].domain, "app.example.com");
+    }
+
+    #[test]
+    fn drops_expired_keeps_session() {
+        // integer- and float-formatted past timestamps are dropped; 0 = session is kept.
+        let specs = parse_cookies(
+            "x.com\tFALSE\t/\tFALSE\t100\told\tv\nx.com\tFALSE\t/\tFALSE\t1700000000.5\tfloat\tv\nx.com\tFALSE\t/\tFALSE\t0\tlive\tv\n",
+        )
+        .unwrap();
+        assert_eq!(specs.len(), 1);
+        assert_eq!(specs[0].name, "live");
+    }
+
+    #[test]
+    fn empty_path_defaults_to_root() {
+        assert_eq!(parse_cookies("x.com\tFALSE\t\tFALSE\t0\tn\tv\n").unwrap()[0].path, "/");
+    }
+
+    #[test]
+    fn rejects_wrong_field_count() {
+        assert!(parse_cookies("x.com\tFALSE\t/\tFALSE\t0\tn\n").is_err());
+    }
+
+    #[test]
+    fn rejects_illegal_chars() {
+        assert!(parse_cookies("x.com\tFALSE\t/\tFALSE\t0\tn\ta;b\n").is_err());
+        assert!(parse_cookies("x.com\tFALSE\t/\tFALSE\t0\tn=x\tv\n").is_err());
+        // '=' is legal in a value (e.g. base64 padding).
+        assert!(parse_cookies("x.com\tFALSE\t/\tFALSE\t0\tn\tYWJj==\n").is_ok());
+        // errors never echo the offending value.
+        let err = parse_cookies("x.com\tFALSE\t/\tFALSE\t0\tn\tval\rinjected\n")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("illegal character") && !err.contains("injected"));
+    }
+
+    #[test]
+    fn load_reads_and_parses_file() {
+        let mut f = tempfile::NamedTempFile::new().unwrap();
+        f.write_all(b".example.com\tTRUE\t/\tFALSE\t0\tn\tv\n").unwrap();
+        let specs = load_cookies(f.path()).unwrap();
+        assert_eq!(
+            specs,
+            vec![CookieSpec {
+                name: "n".to_owned(),
+                value: "v".to_owned(),
+                domain: ".example.com".to_owned(),
+                path: "/".to_owned(),
+                secure: false,
+                http_only: false,
+                include_subdomains: true,
+            }]
+        );
+    }
+
+    #[test]
+    fn missing_file_reports_path() {
+        let err = load_cookies("/no/such/cookies.txt").unwrap_err();
+        assert!(matches!(err, Error::Cookies { .. }));
+    }
+
+    #[test]
+    fn debug_redacts_value() {
+        let mut c = spec("example.com", false);
+        c.value = "SUPERSECRET".into();
+        let dbg = format!("{c:?}");
+        assert!(dbg.contains("<redacted>") && !dbg.contains("SUPERSECRET"));
+    }
+
+    #[test]
+    fn rejects_too_many_cookies() {
+        let text = "x.com\tFALSE\t/\tFALSE\t0\tn\tv\n".repeat(MAX_COOKIES + 1);
+        assert!(matches!(parse_cookies(&text), Err(ParseError::TooMany { .. })));
+    }
+
+    #[test]
+    fn cookie_for_scopes_to_same_site() {
+        let target = Url::parse("https://example.com/").unwrap();
+        assert!(cookie_for(&target, &spec("app.example.com", false), NetworkPolicy::STRICT).is_some());
+        assert!(cookie_for(&target, &spec("evil.com", false), NetworkPolicy::STRICT).is_none());
+    }
+
+    #[test]
+    fn cookie_for_derives_origin_and_domain_attr() {
+        let target = Url::parse("https://example.com/").unwrap();
+        // host-only over https: secure flag picks the https origin, no Domain attribute.
+        let (url, c) = cookie_for(&target, &spec("example.com", true), NetworkPolicy::STRICT).unwrap();
+        assert_eq!(url.scheme(), "https");
+        assert!(c.domain().is_none());
+        // leading dot makes it a domain cookie scoped to the registrable host.
+        let (_, c) = cookie_for(&target, &spec(".example.com", false), NetworkPolicy::STRICT).unwrap();
+        assert_eq!(c.domain(), Some("example.com"));
+    }
+
+    #[test]
+    fn cookie_for_blocks_private_under_strict_only() {
+        let target = Url::parse("http://127.0.0.1/").unwrap();
+        assert!(cookie_for(&target, &spec("127.0.0.1", false), NetworkPolicy::STRICT).is_none());
+        assert!(cookie_for(&target, &spec("127.0.0.1", false), NetworkPolicy::PERMISSIVE).is_some());
+    }
+}

--- a/crates/servo-fetch/src/crawl.rs
+++ b/crates/servo-fetch/src/crawl.rs
@@ -31,6 +31,7 @@ pub struct CrawlOptions {
     pub(crate) user_agent: Option<String>,
     pub(crate) concurrency: usize,
     pub(crate) delay: Option<Duration>,
+    pub(crate) cookies: Vec<crate::cookies::CookieSpec>,
 }
 
 impl CrawlOptions {
@@ -49,6 +50,7 @@ impl CrawlOptions {
             user_agent: None,
             concurrency: 1,
             delay: Some(Duration::from_millis(500)),
+            cookies: Vec::new(),
         }
     }
 
@@ -116,6 +118,12 @@ impl CrawlOptions {
     /// Minimum dispatch interval (default: `Some(500ms)`). `None` disables rate limiting.
     pub fn delay(mut self, delay: Option<Duration>) -> Self {
         self.delay = delay;
+        self
+    }
+
+    /// Seed session cookies before crawling, scoped to the seed's site.
+    pub fn cookies(mut self, cookies: Vec<crate::cookies::CookieSpec>) -> Self {
+        self.cookies = cookies;
         self
     }
 }
@@ -266,6 +274,7 @@ fn build_crawl_plan(opts: &CrawlOptions) -> crate::error::Result<CrawlPlan> {
         user_agent: opts.user_agent.clone(),
         concurrency: opts.concurrency,
         delay: opts.delay,
+        cookies: opts.cookies.clone(),
     })
 }
 
@@ -285,6 +294,7 @@ pub(crate) struct CrawlPlan {
     pub concurrency: usize,
     /// Dispatch interval; `None` disables rate limiting.
     pub delay: Option<Duration>,
+    pub cookies: Vec<crate::cookies::CookieSpec>,
 }
 
 /// Result for a single crawled page.
@@ -442,6 +452,7 @@ fn spawn_fetch(
     let timeout = opts.timeout_secs;
     let settle = opts.settle_ms;
     let user_agent = opts.user_agent.clone();
+    let cookies = opts.cookies.clone();
     let f = fetcher.clone();
     in_flight.spawn_blocking(move || {
         let result = f
@@ -451,6 +462,7 @@ fn spawn_fetch(
                 settle_ms: settle,
                 mode: bridge::FetchMode::Content { include_a11y: false },
                 user_agent: user_agent.as_deref(),
+                cookies: &cookies,
             })
             .map_err(|e| crate::error::Error::engine(e, Some(url_str.clone())));
         FetchOutcome {
@@ -671,6 +683,7 @@ mod tests {
             user_agent: None,
             concurrency: 1,
             delay: None,
+            cookies: Vec::new(),
         };
         configure(&mut opts);
         let mut results = Vec::new();

--- a/crates/servo-fetch/src/error.rs
+++ b/crates/servo-fetch/src/error.rs
@@ -72,6 +72,15 @@ pub enum Error {
     #[error(transparent)]
     Extract(#[from] crate::extract::ExtractError),
 
+    /// Failed to load or parse a cookies file.
+    #[error("failed to load cookies from {path}: {reason}")]
+    Cookies {
+        /// The cookies file path.
+        path: String,
+        /// Why loading failed.
+        reason: String,
+    },
+
     /// Schema-based structured extraction failed.
     #[error(transparent)]
     Schema(#[from] crate::schema::SchemaError),

--- a/crates/servo-fetch/src/fetch.rs
+++ b/crates/servo-fetch/src/fetch.rs
@@ -209,6 +209,7 @@ pub struct FetchOptions {
     pub(crate) user_agent: Option<String>,
     pub(crate) extract_schema: Option<crate::schema::ExtractSchema>,
     pub(crate) visibility: Option<crate::visibility::VisibilityPolicy>,
+    pub(crate) cookies: Vec<crate::cookies::CookieSpec>,
 }
 
 impl FetchOptions {
@@ -230,6 +231,7 @@ impl FetchOptions {
             user_agent: None,
             extract_schema: None,
             visibility: None,
+            cookies: Vec::new(),
         }
     }
 
@@ -276,6 +278,12 @@ impl FetchOptions {
     /// Visibility-filtering policy applied during extraction.
     pub fn visibility(mut self, policy: crate::visibility::VisibilityPolicy) -> Self {
         self.visibility = Some(policy);
+        self
+    }
+
+    /// Seed session cookies before navigation, scoped to the target's site.
+    pub fn cookies(mut self, cookies: Vec<crate::cookies::CookieSpec>) -> Self {
+        self.cookies = cookies;
         self
     }
 
@@ -393,6 +401,7 @@ fn build_bridge_options(opts: &FetchOptions) -> crate::bridge::FetchOptions<'_> 
         timeout_secs: opts.effective_timeout().as_secs().max(1),
         settle_ms: u64::try_from(opts.effective_settle().as_millis()).unwrap_or(u64::MAX),
         user_agent: opts.user_agent.as_deref(),
+        cookies: &opts.cookies,
         mode: match opts.mode {
             FetchMode::Content => crate::bridge::FetchMode::Content { include_a11y: false },
             FetchMode::Screenshot { full_page } => crate::bridge::FetchMode::Screenshot { full_page },

--- a/crates/servo-fetch/src/lib.rs
+++ b/crates/servo-fetch/src/lib.rs
@@ -26,6 +26,7 @@ pub mod visibility;
 
 pub(crate) mod bridge;
 pub(crate) mod client;
+pub(crate) mod cookies;
 pub(crate) mod crawl;
 pub(crate) mod error;
 pub(crate) mod fetch;
@@ -40,6 +41,7 @@ pub(crate) mod screenshot;
 pub(crate) mod sys;
 
 pub use client::{Client, ClientBuilder, ScreenshotOptions};
+pub use cookies::{CookieSpec, load_cookies};
 pub use crawl::{CrawlOptions, CrawlPage, CrawlResult, crawl, crawl_each};
 pub use error::{Error, Result};
 pub use fetch::{ConsoleLevel, ConsoleMessage, FetchOptions, Page, extract_json, fetch, markdown, text};

--- a/skills/servo-fetch/SKILL.md
+++ b/skills/servo-fetch/SKILL.md
@@ -129,6 +129,7 @@ servo-fetch https://example.com --format png -o out.png          # Save PNG scre
 servo-fetch https://example.com --js "document.title"            # Run JavaScript and print result
 servo-fetch https://example.com --selector article               # Extract a section by CSS selector
 servo-fetch https://example.com --schema schema.json             # Schema-driven JSON
+servo-fetch https://example.com --cookies cookies.txt            # Send session cookies (cookies.txt)
 servo-fetch https://example.com --format html                    # Raw HTML
 servo-fetch https://example.com --format text                    # Plain text
 servo-fetch https://example.com -t 60                            # Custom timeout

--- a/skills/servo-fetch/SKILL.md
+++ b/skills/servo-fetch/SKILL.md
@@ -129,7 +129,7 @@ servo-fetch https://example.com --format png -o out.png          # Save PNG scre
 servo-fetch https://example.com --js "document.title"            # Run JavaScript and print result
 servo-fetch https://example.com --selector article               # Extract a section by CSS selector
 servo-fetch https://example.com --schema schema.json             # Schema-driven JSON
-servo-fetch https://example.com --cookies cookies.txt            # Send session cookies (cookies.txt)
+servo-fetch https://example.com --cookies cookies.txt            # Send session cookies
 servo-fetch https://example.com --format html                    # Raw HTML
 servo-fetch https://example.com --format text                    # Plain text
 servo-fetch https://example.com -t 60                            # Custom timeout


### PR DESCRIPTION
## Summary

Adds session-cookie injection: load a Netscape/Mozilla `cookies.txt` and seed it into Servo's cookie jar before navigation, scoped to the target's registrable domain and the SSRF policy. Adds `load_cookies()` + opaque `CookieSpec`, `FetchOptions`/`CrawlOptions::cookies()`, and `--cookies <FILE>` on `fetch`/`crawl`.

## Related issues

Closes #168

## Test Plan

- `cargo test`: all passed
- E2E on macOS against a local server: verified the cookie is sent on the wire, cross-domain cookies are scoped out, `#HttpOnly_` is honored, Secure cookies are not sent over http, and the crawl/batch paths carry cookies; malformed/missing files exit non-zero without leaking values.

## Checklist

- [x] Ran `cargo +nightly fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
- [x] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed
- [x] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it