### PR TITLE
refactor(fetch): convert bridge console types via From

### DIFF
--- a/crates/servo-fetch/src/fetch.rs
+++ b/crates/servo-fetch/src/fetch.rs
@@ -114,21 +114,7 @@ impl Page {
             layout_json: page.layout_json,
             visibility_json: page.visibility_json,
             js_result: page.js_result,
-            console_messages: page
-                .console_messages
-                .into_iter()
-                .map(|m| ConsoleMessage {
-                    level: match m.level {
-                        crate::bridge::ConsoleLevel::Log => ConsoleLevel::Log,
-                        crate::bridge::ConsoleLevel::Debug => ConsoleLevel::Debug,
-                        crate::bridge::ConsoleLevel::Info => ConsoleLevel::Info,
-                        crate::bridge::ConsoleLevel::Warn => ConsoleLevel::Warn,
-                        crate::bridge::ConsoleLevel::Error => ConsoleLevel::Error,
-                        crate::bridge::ConsoleLevel::Trace => ConsoleLevel::Trace,
-                    },
-                    message: m.message,
-                })
-                .collect(),
+            console_messages: page.console_messages.into_iter().map(ConsoleMessage::from).collect(),
             screenshot_png,
             accessibility_tree: page.accessibility_tree,
             a11y: page.a11y.map(Arc::new),
@@ -185,6 +171,29 @@ impl ConsoleLevel {
 impl fmt::Display for ConsoleLevel {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.pad(self.as_str())
+    }
+}
+
+impl From<crate::bridge::ConsoleLevel> for ConsoleLevel {
+    fn from(level: crate::bridge::ConsoleLevel) -> Self {
+        use crate::bridge::ConsoleLevel as Bridge;
+        match level {
+            Bridge::Log => Self::Log,
+            Bridge::Debug => Self::Debug,
+            Bridge::Info => Self::Info,
+            Bridge::Warn => Self::Warn,
+            Bridge::Error => Self::Error,
+            Bridge::Trace => Self::Trace,
+        }
+    }
+}
+
+impl From<crate::bridge::ConsoleMessage> for ConsoleMessage {
+    fn from(msg: crate::bridge::ConsoleMessage) -> Self {
+        Self {
+            level: msg.level.into(),
+            message: msg.message,
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Replace the hand-written `match` inside `Page::from_servo` (bridge → public console types) with `From` impls: `From<bridge::ConsoleLevel>` for `ConsoleLevel` and `From<bridge::ConsoleMessage>` for `ConsoleMessage`. The conversion now lives where it belongs, and `Page::from_servo` reduces to `.map(ConsoleMessage::from)`.

## Related issues

N/A

## Test Plan

- `cargo nextest run -p servo-fetch console`: all passed

## Checklist

- [x] Ran `cargo +nightly fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
- [ ] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed
- [x] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it