### PR TITLE
feat(cli): return sysexits exit codes by error category

### DIFF
--- a/crates/servo-fetch-cli/README.md
+++ b/crates/servo-fetch-cli/README.md
@@ -230,6 +230,25 @@ RUST_LOG="servo_fetch=trace,servo=debug" servo-fetch "..." # include Servo inter
 
 `RUST_LOG` uses [`tracing-subscriber`'s directive syntax](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html) and always wins over CLI flags.
 
+## Exit codes
+
+`0` on success. On failure the human-readable message goes to stderr and the
+exit code carries the failure category, following the
+[`sysexits.h`](https://man.freebsd.org/cgi/man.cgi?sysexits) convention so
+scripts can branch without parsing stderr:
+
+| Code | Name | Cause |
+| ---- | ---- | ----- |
+| `0` | `EX_OK` | Success (also returned when stdout is closed early, e.g. `\| head`) |
+| `64` | `EX_USAGE` | Invalid URL or argument |
+| `65` | `EX_DATAERR` | Invalid extraction schema |
+| `66` | `EX_NOINPUT` | Cookies file missing or unreadable |
+| `69` | `EX_UNAVAILABLE` | Blocked address (private/loopback) or unreachable host |
+| `70` | `EX_SOFTWARE` | Engine, JavaScript, screenshot, or extraction failure |
+| `74` | `EX_IOERR` | I/O error |
+| `75` | `EX_TEMPFAIL` | Navigation timeout (retryable) |
+| `1` | — | Any other error |
+
 ## Environment Variables
 
 | Variable | Description |

--- a/crates/servo-fetch-cli/src/exit.rs
+++ b/crates/servo-fetch-cli/src/exit.rs
@@ -3,6 +3,7 @@
 use std::io::{self, Write as _};
 
 use anyhow::{Error, Result};
+use servo_fetch::Error as FetchError;
 
 pub(crate) fn exit_code(result: Result<()>) -> i32 {
     match result {
@@ -10,9 +11,39 @@ pub(crate) fn exit_code(result: Result<()>) -> i32 {
         Err(err) if is_broken_pipe(&err) => 0,
         Err(err) => {
             eprintln!("error: {err:#}");
-            1
+            error_exit_code(&err)
         }
     }
+}
+
+/// Map a failure to a sysexits.
+fn error_exit_code(err: &Error) -> i32 {
+    match err.chain().find_map(|cause| cause.downcast_ref::<FetchError>()) {
+        Some(FetchError::InvalidUrl { .. }) => sysexits::USAGE,
+        Some(FetchError::Schema(_)) => sysexits::DATAERR,
+        Some(FetchError::Cookies { .. }) => sysexits::NOINPUT,
+        Some(FetchError::AddressNotAllowed { .. }) => sysexits::UNAVAILABLE,
+        Some(
+            FetchError::Engine { .. }
+            | FetchError::JavaScript { .. }
+            | FetchError::Screenshot { .. }
+            | FetchError::Extract(_),
+        ) => sysexits::SOFTWARE,
+        Some(FetchError::Io(_)) => sysexits::IOERR,
+        Some(FetchError::Timeout { .. }) => sysexits::TEMPFAIL,
+        _ => 1,
+    }
+}
+
+/// Exit codes from [`sysexits.h`](https://man.freebsd.org/cgi/man.cgi?sysexits).
+mod sysexits {
+    pub(super) const USAGE: i32 = 64;
+    pub(super) const DATAERR: i32 = 65;
+    pub(super) const NOINPUT: i32 = 66;
+    pub(super) const UNAVAILABLE: i32 = 69;
+    pub(super) const SOFTWARE: i32 = 70;
+    pub(super) const IOERR: i32 = 74;
+    pub(super) const TEMPFAIL: i32 = 75;
 }
 
 fn is_broken_pipe(err: &Error) -> bool {
@@ -50,11 +81,6 @@ mod tests {
     }
 
     #[test]
-    fn other_error_is_one() {
-        assert_eq!(exit_code(Err(anyhow::anyhow!("boom"))), 1);
-    }
-
-    #[test]
     fn broken_pipe_detected_through_chain() {
         let io = io::Error::new(io::ErrorKind::BrokenPipe, "pipe");
         let err = Error::new(io).context("while writing");
@@ -65,5 +91,16 @@ mod tests {
     fn non_broken_pipe_not_detected() {
         let err = anyhow::anyhow!("something else");
         assert!(!is_broken_pipe(&err));
+    }
+
+    #[test]
+    fn maps_servo_error_to_sysexits_code() {
+        let err = Error::from(servo_fetch::load_cookies("/no/such/cookies.txt").unwrap_err());
+        assert_eq!(error_exit_code(&err), 66); // EX_NOINPUT
+    }
+
+    #[test]
+    fn unknown_error_is_one() {
+        assert_eq!(error_exit_code(&anyhow::anyhow!("boom")), 1);
     }
 }


### PR DESCRIPTION
## Summary

CLI errors now exit with a [`sysexits.h`](https://man.freebsd.org/cgi/man.cgi?sysexits) code per failure category (64 usage, 65 dataerr, 66 noinput, 69 unavailable, 70 software, 74 ioerr, 75 tempfail) instead of always `1`, so scripts and language bindings can branch on the category without parsing stderr.

## Related issues

N/A

## Test Plan

- `cargo test -p servo-fetch-cli` (exit:: unit tests: sysexits mapping, broken-pipe → 0, unknown → 1)

## Checklist

- [x] Ran `cargo +nightly fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
- [x] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed
- [x] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it