### PR TITLE
docs: add map example

### DIFF
--- a/crates/servo-fetch/examples/map.rs
+++ b/crates/servo-fetch/examples/map.rs
@@ -1,0 +1,24 @@
+//! Discover URLs from a site's sitemap without rendering pages.
+
+use servo_fetch::{MapOptions, MappedUrl, map};
+
+#[tokio::main]
+async fn main() -> Result<(), servo_fetch::Error> {
+    let urls: Vec<MappedUrl> = map(
+        &MapOptions::new("https://example.com")
+            .limit(25)
+            .include(&["/**"])
+            .exclude(&["/admin/**", "/private/**"])
+            .timeout(15),
+    )
+    .await?;
+
+    for entry in urls {
+        match entry.lastmod.as_deref() {
+            Some(lastmod) => println!("{} (last modified {lastmod})", entry.url),
+            None => println!("{}", entry.url),
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- add a runnable `map.rs` example for sitemap-based URL discovery
- show `MapOptions` builder settings and iterate over `MappedUrl` entries

Closes #276.

## Testing

- `git diff --check`
- Not run: `cargo check -p servo-fetch --example map` (`cargo` is not available in this shell)

This PR was prepared with AI assistance under human supervision. I kept the change small and included the checks I ran below.
