### PR TITLE
ci: install cargo-deny via taiki-e/install-action instead

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,7 +199,10 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: EmbarkStudios/cargo-deny-action@bb137d7af7e4fb67e5f82a49c4fce4fad40782fe # v2.0.20
+      - uses: taiki-e/install-action@50b4a718b59c718df4ef27a3b445f86cd57b9f00 # v2.80.0
+        with:
+          tool: cargo-deny
+      - run: cargo deny check
 
   cargo-shear:
     name: Unused Dependencies


### PR DESCRIPTION
## Summary

Install `cargo-deny` via `taiki-e/install-action` and run `cargo deny check` directly, instead of the `EmbarkStudios/cargo-deny-action` Docker action.

## Related issues

Refs #287 — its `Licenses & Advisories` job failed on a Docker Hub pull timeout, which this removes.

## Test Plan

- `actionlint` and `zizmor` clean on `ci.yml`

## Checklist

- [ ] Ran `cargo +nightly fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
- [ ] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed
- [x] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it