### PR TITLE
chore(security): ignore pyo3 RUSTSEC-2026-0176/0177 pending pythonize 0.29

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -11,6 +11,8 @@ ignore = [
   "RUSTSEC-2025-0100", # unic-char-property unmaintained
   "RUSTSEC-2025-0141", # ml-dsa timing side-channel
   "RUSTSEC-2025-0144", # rsa marvin attack
+  "RUSTSEC-2026-0176", # pyo3 nth() overflow; fixed in pyo3 0.29, blocked on pythonize 0.29 release
+  "RUSTSEC-2026-0177", # pyo3 PyCFunction Sync bound; fixed in pyo3 0.29, blocked on pythonize 0.29 release
 ]
 
 [licenses]


### PR DESCRIPTION
## Summary

pyo3 0.28.3 is flagged by RUSTSEC-2026-0176 (`nth()` overflow) and RUSTSEC-2026-0177 (`PyCFunction::new_closure` missing `Sync`), both fixed in pyo3 0.29. Upgrading is currently blocked because `pythonize` has no 0.29 release yet (it pins pyo3 0.28). This ignores the two advisories in `deny.toml` with a tracking note until `pythonize` 0.29 lands, at which point pyo3 + pythonize will be bumped and the entries removed.

Exposure is minimal: the Python binding does not feed untrusted `n` to pyo3 iterators or share closures across threads.

## Related issues

N/A

## Test Plan

- `cargo deny check` → `advisories ok, bans ok, licenses ok, sources ok`

## Checklist

- [ ] Ran `cargo +nightly fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
- [ ] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed
- [ ] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it
