### PR TITLE
feat(wire)!: unify process-boundary JSON onto camelCase wire DTOs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6597,6 +6597,7 @@ dependencies = [
  "base64 0.22.1",
  "clap",
  "futures-util",
+ "humantime",
  "libc",
  "predicates",
  "rmcp",
@@ -6605,6 +6606,7 @@ dependencies = [
  "serde",
  "serde_json",
  "servo-fetch",
+ "servo-fetch-types",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -6634,6 +6636,7 @@ name = "servo-fetch-types"
 version = "0.12.2"
 dependencies = [
  "serde",
+ "serde_json",
  "ts-rs",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 servo = { version = "0.1.1", default-features = false, features = ["baked-in-resources", "js_jit"] }
 servo-fetch = { path = "crates/servo-fetch", version = "0.12.0" }
+servo-fetch-types = { path = "crates/servo-fetch-types", version = "0.12.2" }
 tempfile = "3"
 thiserror = "2"
 tokio = { version = "1", features = ["rt-multi-thread"] }

--- a/bindings/node/src/generated/index.ts
+++ b/bindings/node/src/generated/index.ts
@@ -34,30 +34,9 @@ lang?: string,
 url?: string, };
 
 /**
- * Per-URL result of a batch fetch.
- */
-export type BatchResult = { 
-/**
- * The fetched URL.
- */
-url: string, 
-/**
- * Whether the fetch succeeded.
- */
-ok: boolean, 
-/**
- * Markdown content when `ok` is true.
- */
-markdown?: string, 
-/**
- * Error message when `ok` is false.
- */
-error?: string, };
-
-/**
  * Severity of a captured console message.
  */
-export type ConsoleLevel = "log" | "info" | "warn" | "error" | "debug";
+export type ConsoleLevel = "log" | "info" | "warn" | "error" | "debug" | "trace";
 
 /**
  * A console message captured while evaluating JavaScript.
@@ -123,7 +102,20 @@ crawled: number,
 /**
  * Pages that errored.
  */
-errors: number, };
+errors: number, 
+/**
+ * Total wall-clock time in milliseconds.
+ */
+elapsedMs: number, };
+
+/**
+ * Error payload returned by every non-streaming failure.
+ */
+export type ErrorEnvelope = { 
+/**
+ * Human-readable error message.
+ */
+error: string, };
 
 /**
  * Result of evaluating a JavaScript expression on a page.
@@ -143,78 +135,6 @@ result: string,
 console: Array<ConsoleMessage>, };
 
 /**
- * Options shared by every single-page operation.
- */
-export type FetchOptions = { 
-/**
- * Page-load timeout in seconds.
- */
-timeout?: number, 
-/**
- * Extra wait in milliseconds after the `load` event, for SPAs.
- */
-settle?: number, 
-/**
- * Override for the `User-Agent` header.
- */
-userAgent?: string, 
-/**
- * Netscape-format `cookies.txt` contents to inject.
- */
-cookies?: string, 
-/**
- * Visibility filtering policy.
- */
-visibility?: Visibility, 
-/**
- * CSS selector to extract a specific section.
- */
-selector?: string, 
-/**
- * Allow requests to loopback/private addresses, relaxing the SSRF guard.
- */
-allowPrivateAddresses: boolean, };
-
-/**
- * One field within a [`Schema`].
- */
-export type Field = { 
-/**
- * Output key for this field.
- */
-name: string, 
-/**
- * CSS selector relative to the current container.
- */
-selector: string, } & ({ "type": "text" } | { "type": "attribute", 
-/**
- * Attribute name to read (e.g. `href`).
- */
-attribute: string, } | { "type": "html" } | { "type": "innerHtml" } | { "type": "nestedList", 
-/**
- * Nested field definitions.
- */
-fields: Array<Field>, });
-
-/**
- * How a [`Field`] reads its value.
- */
-export type FieldKind = { "type": "text" } | { "type": "attribute", 
-/**
- * Attribute name to read (e.g. `href`).
- */
-attribute: string, } | { "type": "html" } | { "type": "innerHtml" } | { "type": "nestedList", 
-/**
- * Nested field definitions.
- */
-fields: Array<Field>, };
-
-/**
- * Output representation for a single-page fetch.
- */
-export type Format = "markdown" | "json" | "html" | "text" | "accessibilityTree";
-
-/**
  * A URL discovered by sitemap mapping.
  */
 export type MappedUrl = { 
@@ -228,17 +148,17 @@ url: string,
 lastmod?: string, };
 
 /**
- * A declarative CSS-selector extraction schema.
+ * Structured-extraction result for the `--schema` path.
  */
-export type Schema = { 
+export type SchemaExtractResult = { 
 /**
- * Repeated container selector; each match yields one object.
+ * URL the schema ran against.
  */
-baseSelector?: string, 
+url: string, 
 /**
- * Fields read from each container.
+ * Extracted value; shape depends on the schema.
  */
-fields: Array<Field>, };
+extracted: unknown, };
 
 /**
  * Visibility-aware filtering policy applied during extraction.

--- a/bindings/node/src/index.ts
+++ b/bindings/node/src/index.ts
@@ -2,17 +2,10 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { JsonParseError } from "./errors.js";
+import type { Article, CrawlEvent, MappedUrl, SchemaExtractResult } from "./generated/index.js";
 import { type Schema, schemaToJson } from "./schema.js";
 import { runBuffer, runStream, runText } from "./spawn.js";
-import type {
-  Article,
-  BatchResult,
-  CrawlOptions,
-  CrawlResult,
-  FetchOptions,
-  MapOptions,
-  MappedUrl,
-} from "./types.js";
+import type { BatchResult, CrawlOptions, CrawlResult, FetchOptions, MapOptions } from "./types.js";
 
 export { binaryPath } from "./binary.js";
 export {
@@ -26,17 +19,9 @@ export {
   SchemaError,
   ServoFetchError,
 } from "./errors.js";
+export type { Article, MappedUrl, Visibility } from "./generated/index.js";
 export type { Field, Schema } from "./schema.js";
-export type {
-  Article,
-  BatchResult,
-  CrawlOptions,
-  CrawlResult,
-  FetchOptions,
-  MapOptions,
-  MappedUrl,
-  Visibility,
-} from "./types.js";
+export type { BatchResult, CrawlOptions, CrawlResult, FetchOptions, MapOptions } from "./types.js";
 
 function asArray(value: string | string[] | undefined): string[] {
   if (value === undefined) return [];
@@ -91,24 +76,7 @@ export async function extract(url: string, options: FetchOptions = {}): Promise<
   const args = ["--format", "json", ...commonArgs(options)];
   if (options.selector != null) args.push("--selector", options.selector);
   args.push("--", url);
-  const raw = parseJson<{
-    title: string;
-    content: string;
-    text_content: string;
-    byline?: string;
-    excerpt?: string;
-    lang?: string;
-    url?: string;
-  }>(await runText(args, { signal: options.signal }));
-  return {
-    title: raw.title,
-    content: raw.content,
-    textContent: raw.text_content,
-    byline: raw.byline,
-    excerpt: raw.excerpt,
-    lang: raw.lang,
-    url: raw.url,
-  };
+  return parseJson<Article>(await runText(args, { signal: options.signal }));
 }
 
 /** Extract structured data using a declarative CSS-selector schema. */
@@ -122,10 +90,8 @@ export async function extractSchema<T = unknown>(
     const file = join(dir, "schema.json");
     await writeFile(file, schemaToJson(schema));
     const args = [...commonArgs(options), "--schema", file, "--", url];
-    const raw = parseJson<{ url: string; extracted: T }>(
-      await runText(args, { signal: options.signal }),
-    );
-    return raw.extracted;
+    const raw = parseJson<SchemaExtractResult>(await runText(args, { signal: options.signal }));
+    return raw.extracted as T;
   } finally {
     await rm(dir, { recursive: true, force: true });
   }
@@ -203,26 +169,14 @@ function crawlArgs(url: string, o: CrawlOptions): string[] {
 /** Crawl a site, yielding each page as it completes (BFS, respects robots.txt). */
 export async function* crawl(url: string, options: CrawlOptions = {}): AsyncGenerator<CrawlResult> {
   for await (const line of runStream(crawlArgs(url, options), { signal: options.signal })) {
-    const record = parseJson<
-      | {
-          type: "page";
-          url: string;
-          depth: number;
-          fetched_at: string;
-          title?: string;
-          content: string;
-          links_found: number;
-        }
-      | { type: "error"; url: string; depth: number; fetched_at: string; error: string }
-      | { type: "stats" }
-    >(line);
+    const record = parseJson<CrawlEvent>(line);
     if (record.type === "stats") continue;
     if (record.type === "error") {
       yield {
         ok: false,
         url: record.url,
         depth: record.depth,
-        fetchedAt: record.fetched_at,
+        fetchedAt: record.fetchedAt,
         error: record.error,
       };
     } else {
@@ -230,10 +184,10 @@ export async function* crawl(url: string, options: CrawlOptions = {}): AsyncGene
         ok: true,
         url: record.url,
         depth: record.depth,
-        fetchedAt: record.fetched_at,
+        fetchedAt: record.fetchedAt,
         title: record.title ?? null,
         content: record.content,
-        linksFound: record.links_found,
+        linksFound: record.linksFound,
       };
     }
   }

--- a/bindings/node/src/types.ts
+++ b/bindings/node/src/types.ts
@@ -1,5 +1,4 @@
-/** Visibility-aware filtering policy. */
-export type Visibility = "moderate" | "strict" | "off";
+import type { Visibility } from "./generated/index.js";
 
 /** Options shared by every single-page operation. */
 export interface FetchOptions {
@@ -21,19 +20,6 @@ export interface FetchOptions {
   signal?: AbortSignal;
   /** Max bytes to buffer from the binary's stdout before aborting. Default: 128 MiB. */
   maxBuffer?: number;
-}
-
-/** Readability-extracted article (`--format json`). */
-export interface Article {
-  title: string;
-  /** Readable article HTML. */
-  content: string;
-  /** Readable content as Markdown. */
-  textContent: string;
-  byline?: string;
-  excerpt?: string;
-  lang?: string;
-  url?: string;
 }
 
 /** Per-URL result from {@link batchFetch}. */
@@ -98,10 +84,4 @@ export interface MapOptions {
   /** Allow requests to loopback/private addresses, relaxing the SSRF guard (for local testing). */
   allowPrivateAddresses?: boolean;
   signal?: AbortSignal;
-}
-
-/** A URL discovered by {@link map}. */
-export interface MappedUrl {
-  url: string;
-  lastmod?: string;
 }

--- a/bindings/node/test/fixtures/servo-fetch.mjs
+++ b/bindings/node/test/fixtures/servo-fetch.mjs
@@ -19,12 +19,12 @@ if (line.includes("badjson")) {
   write("servo-fetch 9.9.9\n");
 } else if (has("crawl")) {
   write(
-    '{"type":"page","url":"https://e.com/","depth":0,"fetched_at":"2024-01-01T00:00:00.000Z","title":"Home","content":"# Home","links_found":2}\n',
+    '{"type":"page","url":"https://e.com/","depth":0,"fetchedAt":"2024-01-01T00:00:00.000Z","title":"Home","content":"# Home","linksFound":2}\n',
   );
   write(
-    '{"type":"error","url":"https://e.com/bad","depth":1,"fetched_at":"2024-01-01T00:00:01.000Z","error":"boom"}\n',
+    '{"type":"error","url":"https://e.com/bad","depth":1,"fetchedAt":"2024-01-01T00:00:01.000Z","error":"boom"}\n',
   );
-  write('{"type":"stats","crawled":2,"errors":1,"elapsed_ms":5}\n');
+  write('{"type":"stats","crawled":2,"errors":1,"elapsedMs":5}\n');
 } else if (has("map")) {
   write('[{"url":"https://e.com/"},{"url":"https://e.com/a","lastmod":"2024-01-01"}]\n');
 } else if (has("--schema")) {
@@ -32,7 +32,7 @@ if (line.includes("badjson")) {
 } else if (has("--js")) {
   write("JS_RESULT\n");
 } else if (has("json")) {
-  write('{"title":"T","content":"<p>c</p>","text_content":"c","byline":"me"}\n');
+  write('{"title":"T","content":"<p>c</p>","textContent":"c","byline":"me"}\n');
 } else if (has("png")) {
   write("PNGDATA");
 } else {

--- a/bindings/node/test/integration/extract.test.ts
+++ b/bindings/node/test/integration/extract.test.ts
@@ -4,7 +4,7 @@ import { onWindows, useFakeBinary } from "../helpers/fake-binary.js";
 describe.skipIf(onWindows)("extract", () => {
   useFakeBinary();
 
-  it("maps text_content to textContent", async () => {
+  it("returns the structured article", async () => {
     const { extract } = await import("../../src/index.js");
     expect(await extract("https://e.com")).toEqual({
       title: "T",

--- a/crates/servo-fetch-cli/Cargo.toml
+++ b/crates/servo-fetch-cli/Cargo.toml
@@ -34,6 +34,7 @@ anyhow = { workspace = true }
 axum = { workspace = true }
 base64 = { workspace = true }
 clap = { workspace = true }
+humantime = { workspace = true }
 libc = { workspace = true }
 rmcp = { workspace = true }
 rustls = { workspace = true }
@@ -41,6 +42,7 @@ schemars = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 servo-fetch = { workspace = true }
+servo-fetch-types = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["macros", "signal"] }
 tower = { workspace = true }

--- a/crates/servo-fetch-cli/README.md
+++ b/crates/servo-fetch-cli/README.md
@@ -176,7 +176,7 @@ Self-contained `/health` probe for any orchestrator that runs a command and insp
 | ----- | ---- | ----------- |
 | `title` | string | Page title |
 | `content` | string | Raw HTML extracted by Readability |
-| `text_content` | string | Readable text (Markdown) |
+| `textContent` | string | Readable text (Markdown) |
 | `byline` | string | Author or byline (omitted if not detected) |
 | `excerpt` | string | Short excerpt or description (omitted if not detected) |
 | `lang` | string | Document language (omitted if not detected) |

--- a/crates/servo-fetch-cli/src/commands/crawl.rs
+++ b/crates/servo-fetch-cli/src/commands/crawl.rs
@@ -4,20 +4,9 @@ use std::fs;
 use std::io::{self, Write as _};
 use std::time::{Duration, Instant};
 
-use serde::Serialize;
-
 use crate::cli::{CrawlArgs, CrawlFormat};
 use crate::output::{Ext, Sink};
 use crate::progress::Progress;
-
-#[derive(Serialize)]
-struct StatsRecord {
-    #[serde(rename = "type")]
-    kind: &'static str,
-    crawled: u64,
-    errors: u64,
-    elapsed_ms: u64,
-}
 
 /// Crawl a site starting from `args.url` and stream results to stdout or a directory.
 pub(crate) fn run(args: &CrawlArgs) -> anyhow::Result<()> {
@@ -39,14 +28,16 @@ pub(crate) fn run(args: &CrawlArgs) -> anyhow::Result<()> {
 
     servo_fetch::blocking::crawl_each(&opts, |result| {
         completed += 1;
-        if result.outcome.is_err() {
+        let ok = result.outcome.is_ok();
+        if !ok {
             errors += 1;
         }
         if write_err.is_some() {
             return;
         }
+        let url = result.url.clone();
         let res = if json {
-            emit_json(&result, sink)
+            emit_json(&url, result, sink)
         } else {
             emit_markdown(&result, sink)
         };
@@ -54,12 +45,7 @@ pub(crate) fn run(args: &CrawlArgs) -> anyhow::Result<()> {
             write_err = Some(e);
             return;
         }
-        progress.item_done(
-            usize::try_from(completed).unwrap_or(usize::MAX),
-            None,
-            &result.url,
-            result.outcome.is_ok(),
-        );
+        progress.item_done(usize::try_from(completed).unwrap_or(usize::MAX), None, &url, ok);
     })?;
 
     if let Some(e) = write_err {
@@ -104,19 +90,15 @@ fn build_crawl_options(args: &CrawlArgs, json: bool) -> servo_fetch::CrawlOption
     opts
 }
 
-fn emit_json(result: &servo_fetch::CrawlResult, sink: Sink<'_>) -> anyhow::Result<()> {
-    let line = serde_json::to_string(result).expect("CrawlResult is always serializable");
-    sink.writeln(&result.url, Ext::Json, &line)
+fn emit_json(url: &str, result: servo_fetch::CrawlResult, sink: Sink<'_>) -> anyhow::Result<()> {
+    let line = serde_json::to_string(&crate::wire::crawl_event(result)).expect("CrawlEvent is always serializable");
+    sink.writeln(url, Ext::Json, &line)
 }
 
 fn emit_stats(out: &mut impl io::Write, crawled: u64, errors: u64, elapsed: Duration) -> io::Result<()> {
-    let stats = StatsRecord {
-        kind: "stats",
-        crawled,
-        errors,
-        elapsed_ms: u64::try_from(elapsed.as_millis()).unwrap_or(u64::MAX),
-    };
-    let line = serde_json::to_string(&stats).expect("StatsRecord is always serializable");
+    let elapsed_ms = u64::try_from(elapsed.as_millis()).unwrap_or(u64::MAX);
+    let event = crate::wire::crawl_stats(crawled, errors, elapsed_ms);
+    let line = serde_json::to_string(&event).expect("CrawlEvent is always serializable");
     writeln!(out, "{line}")
 }
 

--- a/crates/servo-fetch-cli/src/commands/map.rs
+++ b/crates/servo-fetch-cli/src/commands/map.rs
@@ -24,7 +24,8 @@ pub(crate) fn run(args: &MapArgs) -> anyhow::Result<()> {
 
     let mut out = io::stdout().lock();
     if args.json {
-        let json = serde_json::to_string_pretty(&results)?;
+        let entries: Vec<_> = results.iter().map(crate::wire::mapped_url).collect();
+        let json = serde_json::to_string_pretty(&entries)?;
         writeln!(out, "{json}")?;
     } else {
         for entry in &results {

--- a/crates/servo-fetch-cli/src/main.rs
+++ b/crates/servo-fetch-cli/src/main.rs
@@ -11,6 +11,7 @@ mod output;
 mod progress;
 mod serve;
 mod tools;
+mod wire;
 
 use clap::Parser;
 

--- a/crates/servo-fetch-cli/src/output.rs
+++ b/crates/servo-fetch-cli/src/output.rs
@@ -143,29 +143,20 @@ pub(crate) struct Json<'a> {
 
 impl Json<'_> {
     pub(crate) fn execute(&self, sink: Sink<'_>) -> Result<()> {
-        sink.writeln(self.url, Ext::Json, &self.render()?)
+        sink.writeln(self.url, Ext::Json, &serde_json::to_string_pretty(&self.article()?)?)
     }
 
     /// Emit a single-line NDJSON record for batch output.
     pub(crate) fn execute_compact(&self, sink: Sink<'_>) -> Result<()> {
-        let pretty = self.render()?;
-        let line = serde_json::from_str::<Value>(&pretty)
-            .ok()
-            .and_then(|v| serde_json::to_string(&v).ok())
-            .unwrap_or(pretty);
-        sink.writeln(self.url, Ext::Json, &line)
+        sink.writeln(self.url, Ext::Json, &serde_json::to_string(&self.article()?)?)
     }
 
-    fn render(&self) -> Result<String> {
-        if let Some(selector) = self.selector {
-            let input = servo_fetch::extract::ExtractInput::new(&self.page.html, self.url)
-                .with_layout_json(self.page.layout_json.as_deref())
-                .with_inner_text(Some(&self.page.inner_text))
-                .with_selector(Some(selector));
-            Ok(servo_fetch::extract::extract_json(&input)?)
-        } else {
-            Ok(self.page.extract_json_with_url(self.url)?)
-        }
+    fn article(&self) -> Result<servo_fetch_types::Article> {
+        let data = match self.selector {
+            Some(selector) => self.page.article_with_selector(self.url, selector)?,
+            None => self.page.article(self.url)?,
+        };
+        Ok(crate::wire::article(data))
     }
 }
 
@@ -215,11 +206,9 @@ impl Extracted<'_> {
         sink.writeln(self.url, Ext::Json, &serde_json::to_string(&self.payload())?)
     }
 
-    fn payload(&self) -> Value {
-        serde_json::json!({
-            "url": self.url,
-            "extracted": self.page.extracted.as_ref().unwrap_or(&Value::Null),
-        })
+    fn payload(&self) -> servo_fetch_types::SchemaExtractResult {
+        let extracted = self.page.extracted.clone().unwrap_or(Value::Null);
+        crate::wire::schema_extract(self.url, extracted)
     }
 }
 

--- a/crates/servo-fetch-cli/src/serve/error.rs
+++ b/crates/servo-fetch-cli/src/serve/error.rs
@@ -44,7 +44,7 @@ impl From<ToolError> for ApiError {
 
 impl IntoResponse for ApiError {
     fn into_response(self) -> Response {
-        let body = serde_json::json!({ "error": self.message });
+        let body = servo_fetch_types::ErrorEnvelope { error: self.message };
         (self.status, axum::Json(body)).into_response()
     }
 }

--- a/crates/servo-fetch-cli/src/serve/handlers.rs
+++ b/crates/servo-fetch-cli/src/serve/handlers.rs
@@ -8,9 +8,8 @@ use axum::response::IntoResponse;
 use super::error::ApiError;
 use super::extract::Json;
 use super::params::{
-    BatchFetchRequest, BatchFetchResponse, BatchFormat, CrawlRequest, CrawlResponse, ExecuteJsRequest,
-    ExecuteJsResponse, FetchRequest, FetchResponse, Format, HealthResponse, MapRequest, MapResponse, ScreenshotRequest,
-    VersionResponse,
+    BatchFetchRequest, BatchFetchResponse, BatchFormat, CrawlRequest, CrawlResponse, ExecuteJsRequest, FetchRequest,
+    FetchResponse, Format, HealthResponse, MapRequest, MapResponse, ScreenshotRequest, VersionResponse,
 };
 use crate::tools;
 
@@ -75,7 +74,9 @@ pub(super) async fn screenshot(Json(req): Json<ScreenshotRequest>) -> Result<imp
     ))
 }
 
-pub(super) async fn execute_js(Json(req): Json<ExecuteJsRequest>) -> Result<AxumJson<ExecuteJsResponse>, ApiError> {
+pub(super) async fn execute_js(
+    Json(req): Json<ExecuteJsRequest>,
+) -> Result<AxumJson<servo_fetch_types::EvaluateResult>, ApiError> {
     if req.expression.len() > MAX_JS_LEN {
         return Err(ApiError::bad_request(format!(
             "expression exceeds {MAX_JS_LEN} character limit"
@@ -91,16 +92,12 @@ pub(super) async fn execute_js(Json(req): Json<ExecuteJsRequest>) -> Result<Axum
         result.truncate(servo_fetch::sanitize::floor_char_boundary(&result, MAX_JS_OUTPUT_LEN));
         result.push_str("\n<output truncated>");
     }
-    let console = page
-        .console_messages
-        .iter()
-        .map(|m| format!("[{:?}] {}", m.level, m.message))
-        .collect();
-    Ok(AxumJson(ExecuteJsResponse {
+    let result = servo_fetch::sanitize::sanitize(&result).into_owned();
+    Ok(AxumJson(crate::wire::evaluate_result(
         url,
-        result: servo_fetch::sanitize::sanitize(&result).into_owned(),
-        console,
-    }))
+        result,
+        &page.console_messages,
+    )))
 }
 
 pub(super) async fn batch_fetch(Json(req): Json<BatchFetchRequest>) -> Result<AxumJson<BatchFetchResponse>, ApiError> {

--- a/crates/servo-fetch-cli/src/serve/params.rs
+++ b/crates/servo-fetch-cli/src/serve/params.rs
@@ -96,13 +96,6 @@ pub(super) struct BatchFetchResponse {
 }
 
 #[derive(Debug, Serialize)]
-pub(super) struct ExecuteJsResponse {
-    pub url: String,
-    pub result: String,
-    pub console: Vec<String>,
-}
-
-#[derive(Debug, Serialize)]
 pub(super) struct CrawlResponse {
     pub results: Vec<FetchResponse>,
 }

--- a/crates/servo-fetch-cli/src/tools/common.rs
+++ b/crates/servo-fetch-cli/src/tools/common.rs
@@ -35,11 +35,11 @@ pub(crate) fn extract(page: &Page, url: &str, json: bool, selector: Option<&str>
         .with_inner_text(Some(&page.inner_text))
         .with_selector(selector);
     if json {
-        extract::extract_json(&input)
+        let data = extract::extract_article(&input).map_err(|e| ToolError::internal(e.to_string()))?;
+        serde_json::to_string_pretty(&crate::wire::article(data)).map_err(|e| ToolError::internal(e.to_string()))
     } else {
-        extract::extract_text(&input)
+        extract::extract_text(&input).map_err(|e| ToolError::internal(e.to_string()))
     }
-    .map_err(|e| ToolError::internal(e.to_string()))
 }
 
 pub(crate) fn paginate(content: &str, start: usize, max_len: usize) -> String {

--- a/crates/servo-fetch-cli/src/tools/fetch.rs
+++ b/crates/servo-fetch-cli/src/tools/fetch.rs
@@ -117,7 +117,10 @@ fn fetch_and_render(
         .with_selector(selector);
 
     let full = if json {
-        extract::extract_json(&input).unwrap_or_default()
+        match extract::extract_article(&input) {
+            Ok(data) => serde_json::to_string_pretty(&crate::wire::article(data)).unwrap_or_default(),
+            Err(_) => String::new(),
+        }
     } else {
         extract::extract_text(&input).unwrap_or_default()
     };

--- a/crates/servo-fetch-cli/src/wire.rs
+++ b/crates/servo-fetch-cli/src/wire.rs
@@ -1,0 +1,101 @@
+//! Domain-to-wire conversions.
+
+use serde_json::Value;
+use servo_fetch::CrawlResult;
+use servo_fetch::extract::ArticleData;
+use servo_fetch_types as wire;
+
+pub(crate) fn article(a: ArticleData) -> wire::Article {
+    let ArticleData {
+        title,
+        content,
+        text_content,
+        byline,
+        excerpt,
+        lang,
+        url,
+    } = a;
+    wire::Article {
+        title,
+        content,
+        text_content,
+        byline,
+        excerpt,
+        lang,
+        url,
+    }
+}
+
+pub(crate) fn mapped_url(m: &servo_fetch::MappedUrl) -> wire::MappedUrl {
+    let servo_fetch::MappedUrl { url, lastmod } = m;
+    wire::MappedUrl {
+        url: url.clone(),
+        lastmod: lastmod.clone(),
+    }
+}
+
+pub(crate) fn crawl_event(result: CrawlResult) -> wire::CrawlEvent {
+    let fetched_at = humantime::format_rfc3339_millis(result.fetched_at).to_string();
+    let depth = result.depth as u64;
+    match result.outcome {
+        Ok(page) => wire::CrawlEvent::Page {
+            url: result.url,
+            depth,
+            fetched_at,
+            title: page.title,
+            content: page.content,
+            links_found: page.links_found as u64,
+        },
+        Err(e) => wire::CrawlEvent::Error {
+            url: result.url,
+            depth,
+            fetched_at,
+            error: e.to_string(),
+        },
+    }
+}
+
+pub(crate) fn crawl_stats(crawled: u64, errors: u64, elapsed_ms: u64) -> wire::CrawlEvent {
+    wire::CrawlEvent::Stats {
+        crawled,
+        errors,
+        elapsed_ms,
+    }
+}
+
+pub(crate) fn schema_extract(url: &str, extracted: Value) -> wire::SchemaExtractResult {
+    wire::SchemaExtractResult {
+        url: url.to_owned(),
+        extracted,
+    }
+}
+
+fn console_level(level: servo_fetch::ConsoleLevel) -> wire::ConsoleLevel {
+    use servo_fetch::ConsoleLevel as C;
+    match level {
+        C::Info => wire::ConsoleLevel::Info,
+        C::Warn => wire::ConsoleLevel::Warn,
+        C::Error => wire::ConsoleLevel::Error,
+        C::Debug => wire::ConsoleLevel::Debug,
+        C::Trace => wire::ConsoleLevel::Trace,
+        _ => wire::ConsoleLevel::Log,
+    }
+}
+
+pub(crate) fn evaluate_result(
+    url: String,
+    result: String,
+    console: &[servo_fetch::ConsoleMessage],
+) -> wire::EvaluateResult {
+    wire::EvaluateResult {
+        url,
+        result,
+        console: console
+            .iter()
+            .map(|m| wire::ConsoleMessage {
+                level: console_level(m.level),
+                message: m.message.clone(),
+            })
+            .collect(),
+    }
+}

--- a/crates/servo-fetch-cli/tests/cli.rs
+++ b/crates/servo-fetch-cli/tests/cli.rs
@@ -212,7 +212,7 @@ fn crawl_produces_ndjson() {
         assert!(lines.len() >= 2, "expected page + stats record, got: {lines:?}");
         let page: Value = serde_json::from_str(lines[0]).expect("valid NDJSON");
         assert_eq!(page["type"], "page");
-        assert!(page["fetched_at"].is_string(), "fetched_at must be present");
+        assert!(page["fetchedAt"].is_string(), "fetchedAt must be present");
         let stats: Value = serde_json::from_str(lines.last().unwrap()).expect("valid stats NDJSON");
         assert_eq!(stats["type"], "stats");
         assert!(stats["crawled"].as_u64().is_some_and(|n| n >= 1));

--- a/crates/servo-fetch-types/Cargo.toml
+++ b/crates/servo-fetch-types/Cargo.toml
@@ -10,6 +10,7 @@ description = "Wire DTOs shared by the servo-fetch CLI, HTTP/MCP servers, daemon
 
 [dependencies]
 serde = { workspace = true }
+serde_json = { workspace = true }
 ts-rs = { version = "11", optional = true }
 
 [features]

--- a/crates/servo-fetch-types/src/wire.rs
+++ b/crates/servo-fetch-types/src/wire.rs
@@ -13,56 +13,6 @@ pub enum Visibility {
     Off,
 }
 
-/// Output representation for a single-page fetch.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(feature = "codegen", derive(ts_rs::TS), ts(export, export_to = "index.ts"))]
-#[serde(rename_all = "camelCase")]
-pub enum Format {
-    /// Readability-extracted Markdown.
-    Markdown,
-    /// Readability-extracted structured data.
-    Json,
-    /// Raw rendered HTML, post-JS execution.
-    Html,
-    /// Plain text (`document.body.innerText`).
-    Text,
-    /// Serialized accessibility tree.
-    AccessibilityTree,
-}
-
-/// Options shared by every single-page operation.
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(feature = "codegen", derive(ts_rs::TS), ts(export, export_to = "index.ts"))]
-#[serde(rename_all = "camelCase", default)]
-pub struct FetchOptions {
-    /// Page-load timeout in seconds.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[cfg_attr(feature = "codegen", ts(optional))]
-    pub timeout: Option<u32>,
-    /// Extra wait in milliseconds after the `load` event, for SPAs.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[cfg_attr(feature = "codegen", ts(optional))]
-    pub settle: Option<u32>,
-    /// Override for the `User-Agent` header.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[cfg_attr(feature = "codegen", ts(optional))]
-    pub user_agent: Option<String>,
-    /// Netscape-format `cookies.txt` contents to inject.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[cfg_attr(feature = "codegen", ts(optional))]
-    pub cookies: Option<String>,
-    /// Visibility filtering policy.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[cfg_attr(feature = "codegen", ts(optional))]
-    pub visibility: Option<Visibility>,
-    /// CSS selector to extract a specific section.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[cfg_attr(feature = "codegen", ts(optional))]
-    pub selector: Option<String>,
-    /// Allow requests to loopback/private addresses, relaxing the SSRF guard.
-    pub allow_private_addresses: bool,
-}
-
 /// Readability-extracted article.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "codegen", derive(ts_rs::TS), ts(export, export_to = "index.ts"))]
@@ -107,6 +57,8 @@ pub enum ConsoleLevel {
     Error,
     /// `console.debug`.
     Debug,
+    /// `console.trace`.
+    Trace,
 }
 
 /// A console message captured while evaluating JavaScript.
@@ -144,7 +96,8 @@ pub enum CrawlEvent {
         /// URL of the crawled page.
         url: String,
         /// Link depth from the seed URL.
-        depth: u32,
+        #[cfg_attr(feature = "codegen", ts(type = "number"))]
+        depth: u64,
         /// RFC 3339 timestamp when the fetch completed.
         fetched_at: String,
         /// Page title, if any.
@@ -154,7 +107,8 @@ pub enum CrawlEvent {
         /// Extracted content (Markdown or JSON per request).
         content: String,
         /// Number of links discovered on the page.
-        links_found: u32,
+        #[cfg_attr(feature = "codegen", ts(type = "number"))]
+        links_found: u64,
     },
     /// A page that failed to fetch.
     #[serde(rename_all = "camelCase")]
@@ -162,7 +116,8 @@ pub enum CrawlEvent {
         /// URL that failed.
         url: String,
         /// Link depth from the seed URL.
-        depth: u32,
+        #[cfg_attr(feature = "codegen", ts(type = "number"))]
+        depth: u64,
         /// RFC 3339 timestamp when the attempt completed.
         fetched_at: String,
         /// Failure description.
@@ -172,10 +127,36 @@ pub enum CrawlEvent {
     #[serde(rename_all = "camelCase")]
     Stats {
         /// Pages crawled successfully.
-        crawled: u32,
+        #[cfg_attr(feature = "codegen", ts(type = "number"))]
+        crawled: u64,
         /// Pages that errored.
-        errors: u32,
+        #[cfg_attr(feature = "codegen", ts(type = "number"))]
+        errors: u64,
+        /// Total wall-clock time in milliseconds.
+        #[cfg_attr(feature = "codegen", ts(type = "number"))]
+        elapsed_ms: u64,
     },
+}
+
+/// Structured-extraction result for the `--schema` path.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "codegen", derive(ts_rs::TS), ts(export, export_to = "index.ts"))]
+#[serde(rename_all = "camelCase")]
+pub struct SchemaExtractResult {
+    /// URL the schema ran against.
+    pub url: String,
+    /// Extracted value; shape depends on the schema.
+    #[cfg_attr(feature = "codegen", ts(type = "unknown"))]
+    pub extracted: serde_json::Value,
+}
+
+/// Error payload returned by every non-streaming failure.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "codegen", derive(ts_rs::TS), ts(export, export_to = "index.ts"))]
+#[serde(rename_all = "camelCase")]
+pub struct ErrorEnvelope {
+    /// Human-readable error message.
+    pub error: String,
 }
 
 /// A URL discovered by sitemap mapping.
@@ -189,73 +170,4 @@ pub struct MappedUrl {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[cfg_attr(feature = "codegen", ts(optional))]
     pub lastmod: Option<String>,
-}
-
-/// Per-URL result of a batch fetch.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(feature = "codegen", derive(ts_rs::TS), ts(export, export_to = "index.ts"))]
-#[serde(rename_all = "camelCase")]
-pub struct BatchResult {
-    /// The fetched URL.
-    pub url: String,
-    /// Whether the fetch succeeded.
-    pub ok: bool,
-    /// Markdown content when `ok` is true.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[cfg_attr(feature = "codegen", ts(optional))]
-    pub markdown: Option<String>,
-    /// Error message when `ok` is false.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[cfg_attr(feature = "codegen", ts(optional))]
-    pub error: Option<String>,
-}
-
-/// A declarative CSS-selector extraction schema.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(feature = "codegen", derive(ts_rs::TS), ts(export, export_to = "index.ts"))]
-#[serde(rename_all = "camelCase")]
-pub struct Schema {
-    /// Repeated container selector; each match yields one object.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[cfg_attr(feature = "codegen", ts(optional))]
-    pub base_selector: Option<String>,
-    /// Fields read from each container.
-    pub fields: Vec<Field>,
-}
-
-/// One field within a [`Schema`].
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(feature = "codegen", derive(ts_rs::TS), ts(export, export_to = "index.ts"))]
-#[serde(rename_all = "camelCase")]
-pub struct Field {
-    /// Output key for this field.
-    pub name: String,
-    /// CSS selector relative to the current container.
-    pub selector: String,
-    /// How to read the value once the selector matches.
-    #[serde(flatten)]
-    pub kind: FieldKind,
-}
-
-/// How a [`Field`] reads its value.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(feature = "codegen", derive(ts_rs::TS), ts(export, export_to = "index.ts"))]
-#[serde(tag = "type", rename_all = "camelCase")]
-pub enum FieldKind {
-    /// Descendant text of the first match.
-    Text,
-    /// A named attribute on the first match.
-    Attribute {
-        /// Attribute name to read (e.g. `href`).
-        attribute: String,
-    },
-    /// Outer HTML of the first match.
-    Html,
-    /// Inner HTML of the first match.
-    InnerHtml,
-    /// Repeated sub-object per match, using nested fields.
-    NestedList {
-        /// Nested field definitions.
-        fields: Vec<Field>,
-    },
 }

--- a/crates/servo-fetch/src/crawl.rs
+++ b/crates/servo-fetch/src/crawl.rs
@@ -153,6 +153,7 @@ pub struct CrawlPage {
     pub links_found: usize,
 }
 
+/// Mirrors the canonical wire shape `servo_fetch_types::CrawlEvent`; keep both in sync.
 impl serde::Serialize for CrawlResult {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         use serde::ser::SerializeMap;
@@ -163,12 +164,12 @@ impl serde::Serialize for CrawlResult {
                 map.serialize_entry("type", "page")?;
                 map.serialize_entry("url", &self.url)?;
                 map.serialize_entry("depth", &self.depth)?;
-                map.serialize_entry("fetched_at", &fetched_at)?;
+                map.serialize_entry("fetchedAt", &fetched_at)?;
                 if let Some(t) = &page.title {
                     map.serialize_entry("title", t)?;
                 }
                 map.serialize_entry("content", &page.content)?;
-                map.serialize_entry("links_found", &page.links_found)?;
+                map.serialize_entry("linksFound", &page.links_found)?;
                 map.end()
             }
             Err(e) => {
@@ -176,7 +177,7 @@ impl serde::Serialize for CrawlResult {
                 map.serialize_entry("type", "error")?;
                 map.serialize_entry("url", &self.url)?;
                 map.serialize_entry("depth", &self.depth)?;
-                map.serialize_entry("fetched_at", &fetched_at)?;
+                map.serialize_entry("fetchedAt", &fetched_at)?;
                 map.serialize_entry("error", &e.to_string())?;
                 map.end()
             }
@@ -502,7 +503,9 @@ fn process_ok_fetch(
         .with_selector(ctx.opts.selector.as_deref());
 
     let content = if ctx.opts.json {
-        crate::extract::extract_json(&input).ok()
+        crate::extract::extract_article(&input)
+            .ok()
+            .and_then(|a| serde_json::to_string(&a).ok())
     } else {
         crate::extract::extract_text(&input).ok()
     };

--- a/crates/servo-fetch/src/extract.rs
+++ b/crates/servo-fetch/src/extract.rs
@@ -29,8 +29,8 @@ pub enum ExtractError {
 }
 
 /// Structured article data for JSON output.
-#[derive(Serialize)]
-#[non_exhaustive]
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ArticleData {
     /// Page title.
     pub title: String,
@@ -165,11 +165,11 @@ pub fn extract_text(input: &ExtractInput<'_>) -> Result<String, ExtractError> {
     Ok(clean_markdown(&out))
 }
 
-/// Extract readable content as JSON.
-pub fn extract_json(input: &ExtractInput<'_>) -> Result<String, ExtractError> {
+/// Extract readable content as structured article data.
+pub fn extract_article(input: &ExtractInput<'_>) -> Result<ArticleData, ExtractError> {
     if let Some(selector) = input.selector {
         let text = extract_by_selector(input, selector)?;
-        let data = ArticleData {
+        return Ok(ArticleData {
             title: String::new(),
             content: String::new(),
             text_content: text,
@@ -177,11 +177,10 @@ pub fn extract_json(input: &ExtractInput<'_>) -> Result<String, ExtractError> {
             excerpt: None,
             lang: None,
             url: Some(input.url.to_string()),
-        };
-        return Ok(serde_json::to_string_pretty(&data)?);
+        });
     }
     let article = parse_article(input);
-    let data = ArticleData {
+    Ok(ArticleData {
         title: article.title,
         content: article.content,
         text_content: article.text_content,
@@ -189,8 +188,12 @@ pub fn extract_json(input: &ExtractInput<'_>) -> Result<String, ExtractError> {
         excerpt: article.excerpt,
         lang: article.lang,
         url: Some(input.url.to_string()),
-    };
-    Ok(serde_json::to_string_pretty(&data)?)
+    })
+}
+
+/// Extract readable content as JSON.
+pub fn extract_json(input: &ExtractInput<'_>) -> Result<String, ExtractError> {
+    Ok(serde_json::to_string_pretty(&extract_article(input)?)?)
 }
 
 struct ParsedArticle {

--- a/crates/servo-fetch/src/fetch.rs
+++ b/crates/servo-fetch/src/fetch.rs
@@ -70,6 +70,22 @@ impl Page {
         Ok(crate::extract::extract_json(&self.extract_input(url, None))?)
     }
 
+    /// Extract structured article data, using the original URL for link resolution.
+    pub fn article(&self, url: &str) -> crate::error::Result<crate::extract::ArticleData> {
+        Ok(crate::extract::extract_article(&self.extract_input(url, None))?)
+    }
+
+    /// Extract structured article data from the subtree matched by a CSS selector.
+    pub fn article_with_selector(
+        &self,
+        url: &str,
+        selector: &str,
+    ) -> crate::error::Result<crate::extract::ArticleData> {
+        Ok(crate::extract::extract_article(
+            &self.extract_input(url, Some(selector)),
+        )?)
+    }
+
     /// Extract readable Markdown from the subtree matched by a CSS selector.
     pub fn markdown_with_selector(&self, url: &str, selector: &str) -> crate::error::Result<String> {
         Ok(crate::extract::extract_text(&self.extract_input(url, Some(selector)))?)
@@ -573,7 +589,7 @@ mod tests {
             .unwrap();
         let parsed: Value = serde_json::from_str(&json).expect("valid JSON");
         assert_eq!(parsed["url"].as_str(), Some("https://example.com/page"));
-        assert!(parsed["text_content"].as_str().unwrap().contains("scoped"));
+        assert!(parsed["textContent"].as_str().unwrap().contains("scoped"));
     }
 
     #[test]

--- a/crates/servo-fetch/tests/extract.rs
+++ b/crates/servo-fetch/tests/extract.rs
@@ -37,7 +37,7 @@ fn json_output_is_valid() {
     let json = extract::extract_json(&input(&html)).unwrap();
     let parsed: serde_json::Value = serde_json::from_str(&json).expect("valid JSON");
     assert!(parsed.get("title").is_some());
-    assert!(parsed.get("text_content").is_some());
+    assert!(parsed.get("textContent").is_some());
 }
 
 #[test]
@@ -45,7 +45,7 @@ fn json_simple_page() {
     let html = fixture("simple.html");
     let json = extract::extract_json(&input(&html)).unwrap();
     let parsed: serde_json::Value = serde_json::from_str(&json).expect("valid JSON");
-    assert!(parsed["text_content"].as_str().unwrap().contains("Hello World"));
+    assert!(parsed["textContent"].as_str().unwrap().contains("Hello World"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Routes every cross-process JSON output (CLI `--format json`, crawl NDJSON, `map`, schema extract, serve `execute_js`/errors) through the shared `servo-fetch-types` DTOs, serialized as **camelCase**. The Node binding now consumes the ts-rs–generated types directly instead of hand-mapping snake_case; core `extract_json` / `Page` output and `CrawlResult` serialization emit camelCase to match. 

## Test Plan

- `cargo test`: all passed
- `pnpm test`: all passed

## Checklist

- [x] Ran `cargo +nightly fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
- [x] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed
- [x] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it