### PR TITLE
build: exact-pin internal path dependencies to the workspace version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,8 +42,8 @@ schemars = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 servo = { version = "0.1.1", default-features = false, features = ["baked-in-resources", "js_jit"] }
-servo-fetch = { path = "crates/servo-fetch", version = "0.12.0" }
-servo-fetch-types = { path = "crates/servo-fetch-types", version = "0.12.2" }
+servo-fetch = { path = "crates/servo-fetch", version = "=0.12.2" }
+servo-fetch-types = { path = "crates/servo-fetch-types", version = "=0.12.2" }
 tempfile = "3"
 thiserror = "2"
 tokio = { version = "1", features = ["rt-multi-thread"] }


### PR DESCRIPTION
## Summary

Exact-pin internal path dependencies to the workspace version.

## Related issues

N/A

## Test Plan

N/A

## Checklist

- [x] Ran `cargo +nightly fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
- [ ] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed
- [ ] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it
