### PR TITLE
ci(release): track internal crates so release-plz syncs path-dep versions

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -21,13 +21,21 @@ git_release_body = """
 name = "servo-fetch-cli"
 changelog_update = true
 changelog_path = "CHANGELOG.md"
-changelog_include = ["servo-fetch", "servo-fetch-python"]
+changelog_include = ["servo-fetch", "servo-fetch-types", "servo-fetch-python"]
 release = true
 git_tag_enable = true
 git_tag_name = "v{{ version }}"
 git_release_enable = true
 git_release_name = "v{{ version }}"
 git_release_draft = true
+
+[[package]]
+name = "servo-fetch"
+release = true
+
+[[package]]
+name = "servo-fetch-types"
+release = true
 
 [changelog]
 protect_breaking_commits = true


### PR DESCRIPTION
## Summary

Track internal crates so release-plz syncs path-dep versions.

## Related issues

N/A

## Test Plan

N/A

## Checklist

- [x] Ran `cargo +nightly fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
- [ ] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed
- [ ] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it
