### PR TITLE
feat(types): add request DTOs to the wire crate

### DIFF
--- a/bindings/node/src/generated/index.ts
+++ b/bindings/node/src/generated/index.ts
@@ -109,6 +109,63 @@ errors: number,
 elapsedMs: number, };
 
 /**
+ * Parameters for the `crawl` method.
+ */
+export type CrawlRequest = { 
+/**
+ * Seed URL to crawl (http/https only).
+ */
+url: string, 
+/**
+ * Maximum number of pages to crawl (default: 50).
+ */
+limit?: number, 
+/**
+ * Maximum link depth from the seed URL (default: 3).
+ */
+maxDepth?: number, 
+/**
+ * URL path glob patterns to include.
+ */
+include?: Array<string>, 
+/**
+ * URL path glob patterns to exclude.
+ */
+exclude?: Array<string>, 
+/**
+ * Maximum parallel page fetches (default: 1).
+ */
+concurrency?: number, 
+/**
+ * Minimum dispatch interval in milliseconds (default: 500; 0 disables).
+ */
+delayMs?: number, 
+/**
+ * CSS selector to extract a specific section per page.
+ */
+selector?: string, 
+/**
+ * Per-page load timeout in seconds (default: 30).
+ */
+timeout?: number, 
+/**
+ * Extra wait in milliseconds after the load event, per page (default: 0).
+ */
+settleMs?: number, 
+/**
+ * Override the User-Agent header.
+ */
+userAgent?: string, 
+/**
+ * Path to a Netscape-format cookies.txt file.
+ */
+cookiesFile?: string, 
+/**
+ * Allow loopback/private addresses, relaxing the SSRF guard.
+ */
+allowPrivateAddresses?: boolean, };
+
+/**
  * Error payload returned by every non-streaming failure.
  */
 export type ErrorEnvelope = { 
@@ -116,6 +173,39 @@ export type ErrorEnvelope = {
  * Human-readable error message.
  */
 error: string, };
+
+/**
+ * Parameters for the `evaluate` method.
+ */
+export type EvaluateRequest = { 
+/**
+ * URL to load before evaluating.
+ */
+url: string, 
+/**
+ * JavaScript expression to evaluate.
+ */
+expression: string, 
+/**
+ * Page-load timeout in seconds (default: 30).
+ */
+timeout?: number, 
+/**
+ * Extra wait in milliseconds after the load event (default: 0).
+ */
+settleMs?: number, 
+/**
+ * Override the User-Agent header.
+ */
+userAgent?: string, 
+/**
+ * Path to a Netscape-format cookies.txt file.
+ */
+cookiesFile?: string, 
+/**
+ * Allow loopback/private addresses, relaxing the SSRF guard.
+ */
+allowPrivateAddresses?: boolean, };
 
 /**
  * Result of evaluating a JavaScript expression on a page.
@@ -135,6 +225,89 @@ result: string,
 console: Array<ConsoleMessage>, };
 
 /**
+ * Output format for a single-page fetch.
+ */
+export type FetchFormat = "markdown" | "json" | "html" | "text";
+
+/**
+ * Parameters for the `fetch` method.
+ */
+export type FetchRequest = { 
+/**
+ * URL to fetch (http/https only).
+ */
+url: string, 
+/**
+ * Output format.
+ */
+format: FetchFormat, 
+/**
+ * CSS selector to extract a specific section.
+ */
+selector?: string, 
+/**
+ * Page-load timeout in seconds (default: 30).
+ */
+timeout?: number, 
+/**
+ * Extra wait in milliseconds after the load event (default: 0).
+ */
+settleMs?: number, 
+/**
+ * Override the User-Agent header.
+ */
+userAgent?: string, 
+/**
+ * Path to a Netscape-format cookies.txt file.
+ */
+cookiesFile?: string, 
+/**
+ * Visibility filtering policy (default: moderate).
+ */
+visibility?: Visibility, 
+/**
+ * Allow loopback/private addresses, relaxing the SSRF guard.
+ */
+allowPrivateAddresses?: boolean, };
+
+/**
+ * Parameters for the `map` method.
+ */
+export type MapRequest = { 
+/**
+ * URL to discover links from (http/https only).
+ */
+url: string, 
+/**
+ * Maximum number of URLs to discover (default: 5000).
+ */
+limit?: number, 
+/**
+ * URL path glob patterns to include.
+ */
+include?: Array<string>, 
+/**
+ * URL path glob patterns to exclude.
+ */
+exclude?: Array<string>, 
+/**
+ * Override the User-Agent header.
+ */
+userAgent?: string, 
+/**
+ * Per-request timeout in seconds (default: 30).
+ */
+timeout?: number, 
+/**
+ * Skip the HTML link fallback when no sitemap is found.
+ */
+noFallback?: boolean, 
+/**
+ * Allow loopback/private addresses, relaxing the SSRF guard.
+ */
+allowPrivateAddresses?: boolean, };
+
+/**
  * A URL discovered by sitemap mapping.
  */
 export type MappedUrl = { 
@@ -148,6 +321,43 @@ url: string,
 lastmod?: string, };
 
 /**
+ * Parameters for the `extractSchema` method.
+ */
+export type SchemaExtractRequest = { 
+/**
+ * URL to extract from (http/https only).
+ */
+url: string, 
+/**
+ * CSS-selector extraction schema.
+ */
+schema: unknown, 
+/**
+ * Page-load timeout in seconds (default: 30).
+ */
+timeout?: number, 
+/**
+ * Extra wait in milliseconds after the load event (default: 0).
+ */
+settleMs?: number, 
+/**
+ * Override the User-Agent header.
+ */
+userAgent?: string, 
+/**
+ * Path to a Netscape-format cookies.txt file.
+ */
+cookiesFile?: string, 
+/**
+ * Visibility filtering policy (default: moderate).
+ */
+visibility?: Visibility, 
+/**
+ * Allow loopback/private addresses, relaxing the SSRF guard.
+ */
+allowPrivateAddresses?: boolean, };
+
+/**
  * Structured-extraction result for the `--schema` path.
  */
 export type SchemaExtractResult = { 
@@ -159,6 +369,39 @@ url: string,
  * Extracted value; shape depends on the schema.
  */
 extracted: unknown, };
+
+/**
+ * Parameters for the `screenshot` method.
+ */
+export type ScreenshotRequest = { 
+/**
+ * URL to capture (http/https only).
+ */
+url: string, 
+/**
+ * Capture the full scrollable page instead of just the viewport.
+ */
+fullPage?: boolean, 
+/**
+ * Page-load timeout in seconds (default: 30).
+ */
+timeout?: number, 
+/**
+ * Extra wait in milliseconds after the load event (default: 0).
+ */
+settleMs?: number, 
+/**
+ * Override the User-Agent header.
+ */
+userAgent?: string, 
+/**
+ * Path to a Netscape-format cookies.txt file.
+ */
+cookiesFile?: string, 
+/**
+ * Allow loopback/private addresses, relaxing the SSRF guard.
+ */
+allowPrivateAddresses?: boolean, };
 
 /**
  * Visibility-aware filtering policy applied during extraction.

--- a/crates/servo-fetch-types/src/lib.rs
+++ b/crates/servo-fetch-types/src/lib.rs
@@ -1,6 +1,8 @@
 //! Wire DTOs shared by the servo-fetch CLI, servers, daemon, and language
 //! bindings — the single source of truth for the wire format.
 
+mod request;
 mod wire;
 
+pub use request::*;
 pub use wire::*;

--- a/crates/servo-fetch-types/src/request.rs
+++ b/crates/servo-fetch-types/src/request.rs
@@ -1,0 +1,255 @@
+//! Request DTOs.
+
+use serde::{Deserialize, Serialize};
+
+use crate::Visibility;
+
+/// Output format for a single-page fetch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[cfg_attr(feature = "codegen", derive(ts_rs::TS), ts(export, export_to = "index.ts"))]
+#[serde(rename_all = "lowercase")]
+pub enum FetchFormat {
+    /// Readability-extracted Markdown.
+    #[default]
+    Markdown,
+    /// Readability-extracted structured article JSON.
+    Json,
+    /// Raw rendered HTML (post-JS execution).
+    Html,
+    /// Plain text (`document.body.innerText`).
+    Text,
+}
+
+/// Parameters for the `fetch` method.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "codegen", derive(ts_rs::TS), ts(export, export_to = "index.ts"))]
+#[serde(rename_all = "camelCase")]
+pub struct FetchRequest {
+    /// URL to fetch (http/https only).
+    pub url: String,
+    /// Output format.
+    #[serde(default)]
+    pub format: FetchFormat,
+    /// CSS selector to extract a specific section.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "codegen", ts(optional))]
+    pub selector: Option<String>,
+    /// Page-load timeout in seconds (default: 30).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "codegen", ts(optional, type = "number"))]
+    pub timeout: Option<u64>,
+    /// Extra wait in milliseconds after the load event (default: 0).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "codegen", ts(optional, type = "number"))]
+    pub settle_ms: Option<u64>,
+    /// Override the User-Agent header.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "codegen", ts(optional))]
+    pub user_agent: Option<String>,
+    /// Path to a Netscape-format cookies.txt file.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "codegen", ts(optional))]
+    pub cookies_file: Option<String>,
+    /// Visibility filtering policy (default: moderate).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "codegen", ts(optional))]
+    pub visibility: Option<Visibility>,
+    /// Allow loopback/private addresses, relaxing the SSRF guard.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "codegen", ts(optional))]
+    pub allow_private_addresses: Option<bool>,
+}
+
+/// Parameters for the `screenshot` method.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "codegen", derive(ts_rs::TS), ts(export, export_to = "index.ts"))]
+#[serde(rename_all = "camelCase")]
+pub struct ScreenshotRequest {
+    /// URL to capture (http/https only).
+    pub url: String,
+    /// Capture the full scrollable page instead of just the viewport.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "codegen", ts(optional))]
+    pub full_page: Option<bool>,
+    /// Page-load timeout in seconds (default: 30).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "codegen", ts(optional, type = "number"))]
+    pub timeout: Option<u64>,
+    /// Extra wait in milliseconds after the load event (default: 0).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "codegen", ts(optional, type = "number"))]
+    pub settle_ms: Option<u64>,
+    /// Override the User-Agent header.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "codegen", ts(optional))]
+    pub user_agent: Option<String>,
+    /// Path to a Netscape-format cookies.txt file.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "codegen", ts(optional))]
+    pub cookies_file: Option<String>,
+    /// Allow loopback/private addresses, relaxing the SSRF guard.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "codegen", ts(optional))]
+    pub allow_private_addresses: Option<bool>,
+}
+
+/// Parameters for the `evaluate` method.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "codegen", derive(ts_rs::TS), ts(export, export_to = "index.ts"))]
+#[serde(rename_all = "camelCase")]
+pub struct EvaluateRequest {
+    /// URL to load before evaluating.
+    pub url: String,
+    /// JavaScript expression to evaluate.
+    pub expression: String,
+    /// Page-load timeout in seconds (default: 30).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "codegen", ts(optional, type = "number"))]
+    pub timeout: Option<u64>,
+    /// Extra wait in milliseconds after the load event (default: 0).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "codegen", ts(optional, type = "number"))]
+    pub settle_ms: Option<u64>,
+    /// Override the User-Agent header.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "codegen", ts(optional))]
+    pub user_agent: Option<String>,
+    /// Path to a Netscape-format cookies.txt file.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "codegen", ts(optional))]
+    pub cookies_file: Option<String>,
+    /// Allow loopback/private addresses, relaxing the SSRF guard.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "codegen", ts(optional))]
+    pub allow_private_addresses: Option<bool>,
+}
+
+/// Parameters for the `extractSchema` method.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "codegen", derive(ts_rs::TS), ts(export, export_to = "index.ts"))]
+#[serde(rename_all = "camelCase")]
+pub struct SchemaExtractRequest {
+    /// URL to extract from (http/https only).
+    pub url: String,
+    /// CSS-selector extraction schema.
+    #[cfg_attr(feature = "codegen", ts(type = "unknown"))]
+    pub schema: serde_json::Value,
+    /// Page-load timeout in seconds (default: 30).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "codegen", ts(optional, type = "number"))]
+    pub timeout: Option<u64>,
+    /// Extra wait in milliseconds after the load event (default: 0).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "codegen", ts(optional, type = "number"))]
+    pub settle_ms: Option<u64>,
+    /// Override the User-Agent header.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "codegen", ts(optional))]
+    pub user_agent: Option<String>,
+    /// Path to a Netscape-format cookies.txt file.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "codegen", ts(optional))]
+    pub cookies_file: Option<String>,
+    /// Visibility filtering policy (default: moderate).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "codegen", ts(optional))]
+    pub visibility: Option<Visibility>,
+    /// Allow loopback/private addresses, relaxing the SSRF guard.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "codegen", ts(optional))]
+    pub allow_private_addresses: Option<bool>,
+}
+
+/// Parameters for the `crawl` method.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "codegen", derive(ts_rs::TS), ts(export, export_to = "index.ts"))]
+#[serde(rename_all = "camelCase")]
+pub struct CrawlRequest {
+    /// Seed URL to crawl (http/https only).
+    pub url: String,
+    /// Maximum number of pages to crawl (default: 50).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "codegen", ts(optional, type = "number"))]
+    pub limit: Option<u64>,
+    /// Maximum link depth from the seed URL (default: 3).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "codegen", ts(optional, type = "number"))]
+    pub max_depth: Option<u64>,
+    /// URL path glob patterns to include.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "codegen", ts(optional))]
+    pub include: Option<Vec<String>>,
+    /// URL path glob patterns to exclude.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "codegen", ts(optional))]
+    pub exclude: Option<Vec<String>>,
+    /// Maximum parallel page fetches (default: 1).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "codegen", ts(optional, type = "number"))]
+    pub concurrency: Option<u64>,
+    /// Minimum dispatch interval in milliseconds (default: 500; 0 disables).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "codegen", ts(optional, type = "number"))]
+    pub delay_ms: Option<u64>,
+    /// CSS selector to extract a specific section per page.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "codegen", ts(optional))]
+    pub selector: Option<String>,
+    /// Per-page load timeout in seconds (default: 30).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "codegen", ts(optional, type = "number"))]
+    pub timeout: Option<u64>,
+    /// Extra wait in milliseconds after the load event, per page (default: 0).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "codegen", ts(optional, type = "number"))]
+    pub settle_ms: Option<u64>,
+    /// Override the User-Agent header.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "codegen", ts(optional))]
+    pub user_agent: Option<String>,
+    /// Path to a Netscape-format cookies.txt file.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "codegen", ts(optional))]
+    pub cookies_file: Option<String>,
+    /// Allow loopback/private addresses, relaxing the SSRF guard.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "codegen", ts(optional))]
+    pub allow_private_addresses: Option<bool>,
+}
+
+/// Parameters for the `map` method.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "codegen", derive(ts_rs::TS), ts(export, export_to = "index.ts"))]
+#[serde(rename_all = "camelCase")]
+pub struct MapRequest {
+    /// URL to discover links from (http/https only).
+    pub url: String,
+    /// Maximum number of URLs to discover (default: 5000).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "codegen", ts(optional, type = "number"))]
+    pub limit: Option<u64>,
+    /// URL path glob patterns to include.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "codegen", ts(optional))]
+    pub include: Option<Vec<String>>,
+    /// URL path glob patterns to exclude.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "codegen", ts(optional))]
+    pub exclude: Option<Vec<String>>,
+    /// Override the User-Agent header.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "codegen", ts(optional))]
+    pub user_agent: Option<String>,
+    /// Per-request timeout in seconds (default: 30).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "codegen", ts(optional, type = "number"))]
+    pub timeout: Option<u64>,
+    /// Skip the HTML link fallback when no sitemap is found.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "codegen", ts(optional))]
+    pub no_fallback: Option<bool>,
+    /// Allow loopback/private addresses, relaxing the SSRF guard.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "codegen", ts(optional))]
+    pub allow_private_addresses: Option<bool>,
+}


### PR DESCRIPTION
## Summary

Adds request DTOs to `servo-fetch-types` as the input counterpart to the existing output wire types: `FetchFormat` plus `FetchRequest`, `ScreenshotRequest`, `EvaluateRequest`, `SchemaExtractRequest`, `CrawlRequest`, and `MapRequest`. Fields mirror the existing serve/MCP params and Node options; everything but `url`/`expression`/`schema` is optional.

## Test Plan

- `cargo test -p servo-fetch-types --features codegen`: all passed

## Checklist

- [x] Ran `cargo +nightly fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
- [ ] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed
- [ ] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it