### PR TITLE
ci(release): gate artifact jobs on the CLI tag instead of releases_created

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,7 +81,7 @@ jobs:
   build-release:
     name: Build ${{ matrix.target }}
     needs: release-plz-release
-    if: needs.release-plz-release.outputs.releases_created == 'true'
+    if: needs.release-plz-release.outputs.tag != ''
     runs-on: ${{ matrix.os }}
     timeout-minutes: 90
     permissions:
@@ -225,7 +225,7 @@ jobs:
   publish-crate:
     name: Publish to crates.io
     needs: [release-plz-release, build-release]
-    if: needs.release-plz-release.outputs.releases_created == 'true'
+    if: needs.release-plz-release.outputs.tag != ''
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     permissions:
@@ -252,7 +252,7 @@ jobs:
   publish-docker:
     name: Publish Docker image
     needs: [release-plz-release, build-release]
-    if: needs.release-plz-release.outputs.releases_created == 'true'
+    if: needs.release-plz-release.outputs.tag != ''
     runs-on: ubuntu-24.04
     timeout-minutes: 20
     permissions:
@@ -360,7 +360,7 @@ jobs:
   publish-release:
     name: Publish release
     needs: [release-plz-release, build-release, publish-crate, publish-docker, trivy-scan]
-    if: needs.release-plz-release.outputs.releases_created == 'true'
+    if: needs.release-plz-release.outputs.tag != ''
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     permissions:


### PR DESCRIPTION
## Summary

The release workflow gated the CLI-artifact jobs (build-release, publish-crate, publish-docker, publish-release) on `releases_created == 'true'`. That output is `true` whenever release-plz releases *any* crate, including `servo-fetch` / `servo-fetch-types`. When a release contained only those internal crates (no `servo-fetch-cli`), the CLI tag extracted via `jq` was empty, so `build-release` checked out `refs/tags/` and failed.

## Test Plan

N/A

## Checklist

- [ ] Ran `cargo +nightly fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
- [ ] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed
- [ ] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it