### PR TITLE
feat(cli): add stdio JSON-RPC server for the warm-process model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6610,6 +6610,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-util",
  "tower",
  "tower-http",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ servo-fetch-types = { path = "crates/servo-fetch-types", version = "=0.12.2" }
 tempfile = "3"
 thiserror = "2"
 tokio = { version = "1", features = ["rt-multi-thread"] }
+tokio-util = { version = "0.7", features = ["codec"] }
 tower = "0.5"
 tower-http = { version = "0.6", features = ["trace", "request-id"] }
 tracing = "0.1"

--- a/bindings/node/src/generated/index.ts
+++ b/bindings/node/src/generated/index.ts
@@ -159,11 +159,24 @@ userAgent?: string,
 /**
  * Path to a Netscape-format cookies.txt file.
  */
-cookiesFile?: string, 
+cookiesFile?: string, };
+
 /**
- * Allow loopback/private addresses, relaxing the SSRF guard.
+ * Terminal summary returned by the `crawl` method once the stream completes.
  */
-allowPrivateAddresses?: boolean, };
+export type CrawlStats = { 
+/**
+ * Pages crawled successfully.
+ */
+crawled: number, 
+/**
+ * Pages that errored.
+ */
+errors: number, 
+/**
+ * Total wall-clock time in milliseconds.
+ */
+elapsedMs: number, };
 
 /**
  * Error payload returned by every non-streaming failure.
@@ -201,11 +214,7 @@ userAgent?: string,
 /**
  * Path to a Netscape-format cookies.txt file.
  */
-cookiesFile?: string, 
-/**
- * Allow loopback/private addresses, relaxing the SSRF guard.
- */
-allowPrivateAddresses?: boolean, };
+cookiesFile?: string, };
 
 /**
  * Result of evaluating a JavaScript expression on a page.
@@ -225,22 +234,13 @@ result: string,
 console: Array<ConsoleMessage>, };
 
 /**
- * Output format for a single-page fetch.
+ * Parameters for the `extract` method (Readability article JSON).
  */
-export type FetchFormat = "markdown" | "json" | "html" | "text";
-
-/**
- * Parameters for the `fetch` method.
- */
-export type FetchRequest = { 
+export type ExtractRequest = { 
 /**
  * URL to fetch (http/https only).
  */
 url: string, 
-/**
- * Output format.
- */
-format: FetchFormat, 
 /**
  * CSS selector to extract a specific section.
  */
@@ -264,11 +264,66 @@ cookiesFile?: string,
 /**
  * Visibility filtering policy (default: moderate).
  */
-visibility?: Visibility, 
+visibility?: Visibility, };
+
 /**
- * Allow loopback/private addresses, relaxing the SSRF guard.
+ * Output format for the `fetch` method (all string-valued).
  */
-allowPrivateAddresses?: boolean, };
+export type FetchFormat = "markdown" | "html" | "text";
+
+/**
+ * Parameters for the `fetch` method (Markdown/HTML/text — returns a string).
+ */
+export type FetchRequest = { 
+/**
+ * URL to fetch (http/https only).
+ */
+url: string, 
+/**
+ * Output format (default: markdown).
+ */
+format?: FetchFormat, 
+/**
+ * CSS selector to extract a specific section (Markdown only).
+ */
+selector?: string, 
+/**
+ * Page-load timeout in seconds (default: 30).
+ */
+timeout?: number, 
+/**
+ * Extra wait in milliseconds after the load event (default: 0).
+ */
+settleMs?: number, 
+/**
+ * Override the User-Agent header.
+ */
+userAgent?: string, 
+/**
+ * Path to a Netscape-format cookies.txt file.
+ */
+cookiesFile?: string, 
+/**
+ * Visibility filtering policy (default: moderate).
+ */
+visibility?: Visibility, };
+
+/**
+ * Result of the `initialize` handshake.
+ */
+export type InitializeResult = { 
+/**
+ * Wire protocol version the server speaks.
+ */
+protocolVersion: number, 
+/**
+ * Server name and version.
+ */
+serverInfo: ServerInfo, 
+/**
+ * Capabilities the server advertises.
+ */
+capabilities: ServerCapabilities, };
 
 /**
  * Parameters for the `map` method.
@@ -301,11 +356,7 @@ timeout?: number,
 /**
  * Skip the HTML link fallback when no sitemap is found.
  */
-noFallback?: boolean, 
-/**
- * Allow loopback/private addresses, relaxing the SSRF guard.
- */
-allowPrivateAddresses?: boolean, };
+noFallback?: boolean, };
 
 /**
  * A URL discovered by sitemap mapping.
@@ -351,11 +402,7 @@ cookiesFile?: string,
 /**
  * Visibility filtering policy (default: moderate).
  */
-visibility?: Visibility, 
-/**
- * Allow loopback/private addresses, relaxing the SSRF guard.
- */
-allowPrivateAddresses?: boolean, };
+visibility?: Visibility, };
 
 /**
  * Structured-extraction result for the `--schema` path.
@@ -397,11 +444,25 @@ userAgent?: string,
 /**
  * Path to a Netscape-format cookies.txt file.
  */
-cookiesFile?: string, 
+cookiesFile?: string, };
+
 /**
- * Allow loopback/private addresses, relaxing the SSRF guard.
+ * Capabilities advertised by the server (none yet; reserved for forward compatibility).
  */
-allowPrivateAddresses?: boolean, };
+export type ServerCapabilities = Record<string, never>;
+
+/**
+ * Server name and version, reported by `initialize`.
+ */
+export type ServerInfo = { 
+/**
+ * Server name.
+ */
+name: string, 
+/**
+ * Server version.
+ */
+version: string, };
 
 /**
  * Visibility-aware filtering policy applied during extraction.

--- a/crates/servo-fetch-cli/Cargo.toml
+++ b/crates/servo-fetch-cli/Cargo.toml
@@ -29,11 +29,16 @@ path = "tests/mcp.rs"
 name = "parallel"
 path = "tests/parallel.rs"
 
+[[test]]
+name = "rpc"
+path = "tests/rpc.rs"
+
 [dependencies]
 anyhow = { workspace = true }
 axum = { workspace = true }
 base64 = { workspace = true }
 clap = { workspace = true }
+futures-util = { workspace = true }
 humantime = { workspace = true }
 libc = { workspace = true }
 rmcp = { workspace = true }
@@ -44,7 +49,8 @@ serde_json = { workspace = true }
 servo-fetch = { workspace = true }
 servo-fetch-types = { workspace = true }
 thiserror = { workspace = true }
-tokio = { workspace = true, features = ["macros", "signal"] }
+tokio = { workspace = true, features = ["macros", "signal", "io-std", "io-util", "sync"] }
+tokio-util = { workspace = true }
 tower = { workspace = true }
 tower-http = { workspace = true }
 tracing = { workspace = true }

--- a/crates/servo-fetch-cli/src/cli.rs
+++ b/crates/servo-fetch-cli/src/cli.rs
@@ -145,6 +145,9 @@ pub(crate) enum Command {
     Map(MapArgs),
     /// Probe the local /health endpoint. Exits 0 on 2xx, 1 otherwise.
     Healthcheck(HealthcheckArgs),
+    /// Serve JSON-RPC over stdio for language bindings.
+    #[command(hide = true)]
+    Rpc(RpcArgs),
 }
 
 impl Command {
@@ -269,6 +272,9 @@ pub(crate) struct HealthcheckArgs {
     #[arg(long, value_name = "PORT", default_value_t = 3000)]
     pub port: u16,
 }
+
+#[derive(Args, Debug)]
+pub(crate) struct RpcArgs {}
 
 #[cfg(test)]
 mod tests {

--- a/crates/servo-fetch-cli/src/commands.rs
+++ b/crates/servo-fetch-cli/src/commands.rs
@@ -3,4 +3,5 @@ pub(crate) mod fetch;
 pub(crate) mod healthcheck;
 pub(crate) mod map;
 pub(crate) mod mcp;
+pub(crate) mod rpc;
 pub(crate) mod serve;

--- a/crates/servo-fetch-cli/src/commands/rpc.rs
+++ b/crates/servo-fetch-cli/src/commands/rpc.rs
@@ -1,0 +1,6 @@
+//! Stdio JSON-RPC server subcommand (internal; spawned by language bindings).
+
+pub(crate) fn run() -> anyhow::Result<()> {
+    let rt = tokio::runtime::Runtime::new()?;
+    rt.block_on(crate::rpc::run())
+}

--- a/crates/servo-fetch-cli/src/main.rs
+++ b/crates/servo-fetch-cli/src/main.rs
@@ -9,6 +9,7 @@ mod logging;
 mod mcp;
 mod output;
 mod progress;
+mod rpc;
 mod serve;
 mod tools;
 mod wire;
@@ -43,6 +44,7 @@ fn dispatch(args: &Cli) -> anyhow::Result<()> {
         Some(Command::Crawl(crawl)) => commands::crawl::run(crawl),
         Some(Command::Map(map)) => commands::map::run(map),
         Some(Command::Healthcheck(hc)) => commands::healthcheck::run(hc),
+        Some(Command::Rpc(_)) => commands::rpc::run(),
         None => commands::fetch::run(&args.fetch),
     }
 }

--- a/crates/servo-fetch-cli/src/mcp/server.rs
+++ b/crates/servo-fetch-cli/src/mcp/server.rs
@@ -11,13 +11,10 @@ use super::params::{
     BatchFetchParams, BatchFormat, CrawlParams, ExecuteJsParams, FetchParams, MapParams, OutputFormat, ScreenshotParams,
 };
 use super::tools;
-
-const MAX_JS_LEN: usize = 10_000;
-const MAX_JS_OUTPUT_LEN: usize = 1_000_000;
-const MAX_TIMEOUT_SECS: u64 = 300;
-const MAX_SELECTOR_LEN: usize = 1_000;
-const MAX_SETTLE_MS: u64 = 10_000;
-const MAX_BATCH_URLS: usize = 20;
+use crate::tools::limits::{
+    MAX_BATCH_URLS, MAX_CRAWL_DEPTH, MAX_CRAWL_PAGES, MAX_JS_LEN, MAX_JS_OUTPUT_LEN, MAX_MAP_URLS, MAX_SELECTOR_LEN,
+    MAX_SETTLE_MS, MAX_TIMEOUT_SECS,
+};
 
 #[derive(Debug, Clone)]
 pub(crate) struct ServoFetchMcp {
@@ -195,8 +192,8 @@ impl ServoFetchMcp {
     )]
     async fn crawl(&self, Parameters(p): Parameters<CrawlParams>) -> Result<CallToolResult, ErrorData> {
         let url = tools::validated_url(&p.url)?;
-        let limit = p.limit.unwrap_or(20).clamp(1, 500);
-        let max_depth = p.max_depth.unwrap_or(3).clamp(1, 10);
+        let limit = p.limit.unwrap_or(20).clamp(1, MAX_CRAWL_PAGES);
+        let max_depth = p.max_depth.unwrap_or(3).clamp(1, MAX_CRAWL_DEPTH);
         let timeout = p.timeout.unwrap_or(30).clamp(1, MAX_TIMEOUT_SECS);
         let settle_ms = p.settle_ms.unwrap_or(0).min(MAX_SETTLE_MS);
         let max_len = p.max_length.unwrap_or(5000);
@@ -238,7 +235,7 @@ impl ServoFetchMcp {
     )]
     async fn map(&self, Parameters(p): Parameters<MapParams>) -> Result<CallToolResult, ErrorData> {
         let url = tools::validated_url(&p.url)?;
-        let limit = p.limit.unwrap_or(5000).clamp(1, 100_000);
+        let limit = p.limit.unwrap_or(5000).clamp(1, MAX_MAP_URLS);
 
         let urls = tools::discover_urls(
             &url,

--- a/crates/servo-fetch-cli/src/rpc.rs
+++ b/crates/servo-fetch-cli/src/rpc.rs
@@ -1,0 +1,129 @@
+//! Stdio JSON-RPC server that keeps the Servo engine warm for language bindings.
+
+mod dispatch;
+mod protocol;
+mod transport;
+
+use std::any::Any;
+use std::collections::HashMap;
+use std::panic::AssertUnwindSafe;
+use std::sync::{Arc, Mutex};
+
+use futures_util::{FutureExt as _, StreamExt as _};
+use protocol::{CancelParams, Incoming, RequestId, Response, ResponseError, code};
+use serde_json::Value;
+use tokio::sync::mpsc::{self, UnboundedSender};
+use tokio_util::codec::LinesCodecError;
+use tokio_util::sync::CancellationToken;
+
+type Cancellations = Arc<Mutex<HashMap<RequestId, CancellationToken>>>;
+
+/// Serve JSON-RPC over stdio until stdin closes or an `exit` notification arrives.
+pub(crate) async fn run() -> anyhow::Result<()> {
+    let (tx, rx) = mpsc::unbounded_channel::<String>();
+    let writer = tokio::spawn(transport::write_loop(tokio::io::stdout(), rx));
+    let cancels: Cancellations = Arc::new(Mutex::new(HashMap::new()));
+    let mut reader = transport::frame_reader(tokio::io::stdin());
+
+    while let Some(frame) = reader.next().await {
+        let line = match frame {
+            Ok(line) => line,
+            Err(LinesCodecError::MaxLineLengthExceeded) => {
+                // FramedRead ends the stream after a decode error, so report and stop.
+                let _ = tx.send(error_line(code::INVALID_REQUEST, "frame exceeds maximum length"));
+                break;
+            }
+            Err(LinesCodecError::Io(e)) => {
+                tracing::warn!("rpc transport error: {e}");
+                break;
+            }
+        };
+        if line.trim().is_empty() {
+            continue;
+        }
+        let incoming: Incoming = match serde_json::from_str(&line) {
+            Ok(msg) => msg,
+            Err(e) => {
+                let _ = tx.send(error_line(code::PARSE_ERROR, &e.to_string()));
+                continue;
+            }
+        };
+        match incoming.id {
+            Some(id) => spawn_request(id, incoming.method, incoming.params, &tx, &cancels),
+            None => match incoming.method.as_str() {
+                "$/cancelRequest" => cancel(incoming.params, &cancels),
+                "exit" => break,
+                _ => {}
+            },
+        }
+    }
+
+    // EOF/exit: let in-flight requests finish, then drain.
+    drop(tx);
+    if let Err(e) = writer.await {
+        tracing::error!("rpc writer task panicked: {e}");
+    }
+    Ok(())
+}
+
+fn spawn_request(id: RequestId, method: String, params: Value, tx: &UnboundedSender<String>, cancels: &Cancellations) {
+    let token = CancellationToken::new();
+    {
+        let mut guard = cancels.lock().expect("cancellations poisoned");
+        if guard.contains_key(&id) {
+            if let Ok(line) = serde_json::to_string(&Response::failure(id, ResponseError::duplicate_id())) {
+                let _ = tx.send(line);
+            }
+            return;
+        }
+        guard.insert(id.clone(), token.clone());
+    }
+
+    let tx = tx.clone();
+    let cancels = cancels.clone();
+    tokio::spawn(async move {
+        let dispatched = AssertUnwindSafe(dispatch::dispatch(&method, params, &id, &tx)).catch_unwind();
+        let outcome = tokio::select! {
+            biased;
+            () = token.cancelled() => Err(ResponseError::cancelled()),
+            result = dispatched => result.unwrap_or_else(|payload| {
+                tracing::error!("rpc handler `{method}` panicked: {}", panic_message(payload.as_ref()));
+                Err(ResponseError::new(code::INTERNAL_ERROR, "handler panicked"))
+            }),
+        };
+        // Always deregister and answer exactly once, even on panic/cancel.
+        cancels.lock().expect("cancellations poisoned").remove(&id);
+        let response = match outcome {
+            Ok(result) => Response::success(id, result),
+            Err(error) => Response::failure(id, error),
+        };
+        if let Ok(line) = serde_json::to_string(&response) {
+            let _ = tx.send(line);
+        }
+    });
+}
+
+fn cancel(params: Value, cancels: &Cancellations) {
+    if let Ok(params) = serde_json::from_value::<CancelParams>(params) {
+        if let Some(token) = cancels.lock().expect("cancellations poisoned").get(&params.id) {
+            token.cancel();
+        }
+    }
+}
+
+fn panic_message(payload: &(dyn Any + Send)) -> &str {
+    payload
+        .downcast_ref::<&str>()
+        .copied()
+        .or_else(|| payload.downcast_ref::<String>().map(String::as_str))
+        .unwrap_or("unknown panic payload")
+}
+
+fn error_line(code: i32, message: &str) -> String {
+    serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": Value::Null,
+        "error": { "code": code, "message": message },
+    })
+    .to_string()
+}

--- a/crates/servo-fetch-cli/src/rpc/dispatch.rs
+++ b/crates/servo-fetch-cli/src/rpc/dispatch.rs
@@ -1,0 +1,324 @@
+//! JSON-RPC method handlers — request DTO in, typed wire result out.
+
+use std::time::{Duration, Instant};
+
+use base64::Engine as _;
+use serde::de::DeserializeOwned;
+use serde_json::{Value, json};
+use servo_fetch::{FetchOptions, MapOptions, VisibilityPolicy};
+use servo_fetch_types::{
+    CrawlRequest, CrawlStats, EvaluateRequest, ExtractRequest, FetchFormat, FetchRequest, InitializeResult, MapRequest,
+    SchemaExtractRequest, ScreenshotRequest, ServerCapabilities, ServerInfo, Visibility,
+};
+use tokio::sync::mpsc::UnboundedSender;
+
+use super::protocol::{Notification, PROTOCOL_VERSION, RequestId, ResponseError, code};
+use crate::tools::limits::{
+    MAX_CRAWL_CONCURRENCY, MAX_CRAWL_DEPTH, MAX_CRAWL_PAGES, MAX_JS_LEN, MAX_MAP_URLS, MAX_SELECTOR_LEN, MAX_SETTLE_MS,
+    MAX_TIMEOUT_SECS,
+};
+use crate::tools::{self, ToolError};
+
+/// Route a request to its handler (`id`/`tx` drive `crawl` progress streaming).
+pub(crate) async fn dispatch(
+    method: &str,
+    params: Value,
+    id: &RequestId,
+    tx: &UnboundedSender<String>,
+) -> Result<Value, ResponseError> {
+    match method {
+        "initialize" => Ok(initialize()),
+        "fetch" => fetch(params).await,
+        "extract" => extract(params).await,
+        "screenshot" => screenshot(params).await,
+        "evaluate" => evaluate(params).await,
+        "extractSchema" => extract_schema(params).await,
+        "map" => map(params).await,
+        "crawl" => crawl(params, id, tx).await,
+        other => Err(ResponseError::method_not_found(other)),
+    }
+}
+
+fn initialize() -> Value {
+    serde_json::to_value(InitializeResult {
+        protocol_version: PROTOCOL_VERSION,
+        server_info: ServerInfo {
+            name: "servo-fetch".to_owned(),
+            version: env!("CARGO_PKG_VERSION").to_owned(),
+        },
+        capabilities: ServerCapabilities::default(),
+    })
+    .expect("InitializeResult is always serializable")
+}
+
+async fn fetch(params: Value) -> Result<Value, ResponseError> {
+    let req: FetchRequest = parse(params)?;
+    let url = tools::validated_url(&req.url)?;
+    validate_selector(req.selector.as_deref())?;
+
+    let opts = FetchOptions::new(&url)
+        .timed(req.timeout, req.settle_ms)
+        .visibility(visibility_policy(req.visibility));
+    let page = tools::fetch_with(with_ua_and_cookies(opts, req.user_agent, req.cookies_file)?).await?;
+
+    match req.format.unwrap_or_default() {
+        FetchFormat::Html => Ok(json!(page.html)),
+        FetchFormat::Text => Ok(json!(page.inner_text)),
+        FetchFormat::Markdown => {
+            let md = match req.selector.as_deref() {
+                Some(s) => page.markdown_with_selector(&url, s),
+                None => page.markdown_with_url(&url),
+            }?;
+            Ok(json!(md))
+        }
+    }
+}
+
+async fn extract(params: Value) -> Result<Value, ResponseError> {
+    let req: ExtractRequest = parse(params)?;
+    let url = tools::validated_url(&req.url)?;
+    validate_selector(req.selector.as_deref())?;
+
+    let opts = FetchOptions::new(&url)
+        .timed(req.timeout, req.settle_ms)
+        .visibility(visibility_policy(req.visibility));
+    let page = tools::fetch_with(with_ua_and_cookies(opts, req.user_agent, req.cookies_file)?).await?;
+
+    let data = match req.selector.as_deref() {
+        Some(s) => page.article_with_selector(&url, s),
+        None => page.article(&url),
+    }?;
+    Ok(serde_json::to_value(crate::wire::article(data))?)
+}
+
+async fn screenshot(params: Value) -> Result<Value, ResponseError> {
+    let req: ScreenshotRequest = parse(params)?;
+    let url = tools::validated_url(&req.url)?;
+
+    let opts = FetchOptions::screenshot(&url, req.full_page.unwrap_or(false)).timed(req.timeout, req.settle_ms);
+    let page = tools::fetch_with(with_ua_and_cookies(opts, req.user_agent, req.cookies_file)?).await?;
+
+    let png = page
+        .screenshot_png()
+        .ok_or_else(|| ResponseError::new(code::FETCH_ERROR, "screenshot capture failed"))?;
+    Ok(json!(base64::engine::general_purpose::STANDARD.encode(png)))
+}
+
+async fn evaluate(params: Value) -> Result<Value, ResponseError> {
+    let req: EvaluateRequest = parse(params)?;
+    if req.expression.len() > MAX_JS_LEN {
+        return Err(ResponseError::invalid_params(format!(
+            "expression exceeds {MAX_JS_LEN} character limit"
+        )));
+    }
+    let url = tools::validated_url(&req.url)?;
+
+    let opts = FetchOptions::javascript(&url, &req.expression).timed(req.timeout, req.settle_ms);
+    let page = tools::fetch_with(with_ua_and_cookies(opts, req.user_agent, req.cookies_file)?).await?;
+
+    let result = page.js_result.unwrap_or_default();
+    Ok(serde_json::to_value(crate::wire::evaluate_result(
+        url,
+        result,
+        &page.console_messages,
+    ))?)
+}
+
+async fn extract_schema(params: Value) -> Result<Value, ResponseError> {
+    let req: SchemaExtractRequest = parse(params)?;
+    let url = tools::validated_url(&req.url)?;
+    let schema = servo_fetch::schema::ExtractSchema::from_json(&req.schema.to_string())
+        .map_err(|e| ResponseError::invalid_params(format!("schema: {e}")))?;
+
+    let opts = FetchOptions::new(&url)
+        .timed(req.timeout, req.settle_ms)
+        .visibility(visibility_policy(req.visibility))
+        .schema(schema);
+    let page = tools::fetch_with(with_ua_and_cookies(opts, req.user_agent, req.cookies_file)?).await?;
+
+    let extracted = page.extracted.unwrap_or(Value::Null);
+    Ok(serde_json::to_value(crate::wire::schema_extract(&url, extracted))?)
+}
+
+async fn map(params: Value) -> Result<Value, ResponseError> {
+    let req: MapRequest = parse(params)?;
+    let url = tools::validated_url(&req.url)?;
+    let limit = clamp_usize(req.limit, 5000, MAX_MAP_URLS);
+
+    let mut opts = MapOptions::new(&url).limit(limit);
+    if let Some(include) = req.include.as_deref().filter(|v| !v.is_empty()) {
+        opts = opts.include(&glob_refs(include));
+    }
+    if let Some(exclude) = req.exclude.as_deref().filter(|v| !v.is_empty()) {
+        opts = opts.exclude(&glob_refs(exclude));
+    }
+    if let Some(ua) = req.user_agent.as_deref() {
+        opts = opts.user_agent(ua);
+    }
+    if let Some(secs) = req.timeout {
+        opts = opts.timeout(secs);
+    }
+    if req.no_fallback.unwrap_or(false) {
+        opts = opts.no_fallback(true);
+    }
+    let entries = tools::map_with(opts).await?;
+
+    let mapped: Vec<_> = entries.iter().map(crate::wire::mapped_url).collect();
+    Ok(serde_json::to_value(mapped)?)
+}
+
+async fn crawl(params: Value, id: &RequestId, tx: &UnboundedSender<String>) -> Result<Value, ResponseError> {
+    let req: CrawlRequest = parse(params)?;
+    let url = tools::validated_url(&req.url)?;
+    validate_selector(req.selector.as_deref())?;
+
+    let mut opts = servo_fetch::CrawlOptions::new(&url)
+        .limit(clamp_usize(req.limit, 50, MAX_CRAWL_PAGES))
+        .max_depth(clamp_usize(req.max_depth, 3, MAX_CRAWL_DEPTH))
+        .timeout(Duration::from_secs(timeout_secs(req.timeout)))
+        .settle(Duration::from_millis(settle_ms(req.settle_ms)))
+        .concurrency(clamp_usize(req.concurrency, 1, MAX_CRAWL_CONCURRENCY))
+        .delay(match req.delay_ms {
+            Some(0) => None,
+            Some(ms) => Some(Duration::from_millis(ms)),
+            None => Some(Duration::from_millis(500)),
+        });
+    if let Some(s) = req.selector.as_deref() {
+        opts = opts.selector(s);
+    }
+    if let Some(globs) = req.include.as_deref().filter(|g| !g.is_empty()) {
+        opts = opts.include(&glob_refs(globs));
+    }
+    if let Some(globs) = req.exclude.as_deref().filter(|g| !g.is_empty()) {
+        opts = opts.exclude(&glob_refs(globs));
+    }
+    if let Some(ua) = req.user_agent {
+        opts = opts.user_agent(ua);
+    }
+    if let Some(path) = req.cookies_file {
+        opts = opts.cookies(load_cookies(&path)?);
+    }
+
+    // Stream each page as a `$/progress` notification. Buffering is bounded by
+    // the crawl `limit`; the run loop cancels by dropping this future.
+    let started = Instant::now();
+    let mut crawled = 0u64;
+    let mut errors = 0u64;
+    {
+        let crawled = &mut crawled;
+        let errors = &mut errors;
+        let tx = tx.clone();
+        let id = id.clone();
+        servo_fetch::crawl_each(&opts, move |result| {
+            if result.outcome.is_ok() {
+                *crawled += 1;
+            } else {
+                *errors += 1;
+            }
+            if let Ok(value) = serde_json::to_value(crate::wire::crawl_event(result)) {
+                let note = Notification::new("$/progress", json!({ "token": &id, "value": value }));
+                if let Ok(line) = serde_json::to_string(&note) {
+                    let _ = tx.send(line);
+                }
+            }
+        })
+        .await
+        .map_err(|e| ResponseError::new(code::FETCH_ERROR, format!("{e:#}")))?;
+    }
+
+    let elapsed_ms = u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX);
+    Ok(serde_json::to_value(CrawlStats {
+        crawled,
+        errors,
+        elapsed_ms,
+    })?)
+}
+
+trait FetchOptionsExt {
+    fn timed(self, timeout: Option<u64>, settle: Option<u64>) -> Self;
+}
+
+impl FetchOptionsExt for FetchOptions {
+    fn timed(self, timeout: Option<u64>, settle: Option<u64>) -> Self {
+        self.timeout(Duration::from_secs(timeout_secs(timeout)))
+            .settle(Duration::from_millis(settle_ms(settle)))
+    }
+}
+
+fn glob_refs(globs: &[String]) -> Vec<&str> {
+    globs.iter().map(String::as_str).collect()
+}
+
+fn with_ua_and_cookies(
+    mut opts: FetchOptions,
+    user_agent: Option<String>,
+    cookies_file: Option<String>,
+) -> Result<FetchOptions, ResponseError> {
+    if let Some(ua) = user_agent {
+        opts = opts.user_agent(ua);
+    }
+    if let Some(path) = cookies_file {
+        opts = opts.cookies(load_cookies(&path)?);
+    }
+    Ok(opts)
+}
+
+fn load_cookies(path: &str) -> Result<Vec<servo_fetch::CookieSpec>, ResponseError> {
+    servo_fetch::load_cookies(path).map_err(|e| ResponseError::invalid_params(format!("cookies '{path}': {e:#}")))
+}
+
+fn visibility_policy(v: Option<Visibility>) -> VisibilityPolicy {
+    match v {
+        Some(Visibility::Strict) => VisibilityPolicy::strict(),
+        Some(Visibility::Off) => VisibilityPolicy::off(),
+        Some(Visibility::Moderate) | None => VisibilityPolicy::moderate(),
+    }
+}
+
+fn validate_selector(selector: Option<&str>) -> Result<(), ResponseError> {
+    if selector.is_some_and(|s| s.len() > MAX_SELECTOR_LEN) {
+        return Err(ResponseError::invalid_params(format!(
+            "selector exceeds {MAX_SELECTOR_LEN} character limit"
+        )));
+    }
+    Ok(())
+}
+
+fn parse<T: DeserializeOwned>(params: Value) -> Result<T, ResponseError> {
+    serde_json::from_value(params).map_err(|e| ResponseError::invalid_params(e.to_string()))
+}
+
+fn timeout_secs(timeout: Option<u64>) -> u64 {
+    timeout.unwrap_or(30).clamp(1, MAX_TIMEOUT_SECS)
+}
+
+fn settle_ms(settle: Option<u64>) -> u64 {
+    settle.unwrap_or(0).min(MAX_SETTLE_MS)
+}
+
+fn clamp_usize(value: Option<u64>, default: usize, max: usize) -> usize {
+    value.map_or(default, |n| usize::try_from(n).unwrap_or(max).clamp(1, max))
+}
+
+impl From<ToolError> for ResponseError {
+    fn from(err: ToolError) -> Self {
+        let code = match &err {
+            ToolError::InvalidInput(_) => code::INVALID_PARAMS,
+            ToolError::Fetch(_) => code::FETCH_ERROR,
+            ToolError::Internal(_) => code::INTERNAL_ERROR,
+        };
+        Self::new(code, err.to_string())
+    }
+}
+
+impl From<servo_fetch::Error> for ResponseError {
+    fn from(err: servo_fetch::Error) -> Self {
+        Self::new(code::FETCH_ERROR, err.to_string())
+    }
+}
+
+impl From<serde_json::Error> for ResponseError {
+    fn from(err: serde_json::Error) -> Self {
+        Self::new(code::INTERNAL_ERROR, err.to_string())
+    }
+}

--- a/crates/servo-fetch-cli/src/rpc/protocol.rs
+++ b/crates/servo-fetch-cli/src/rpc/protocol.rs
@@ -1,0 +1,125 @@
+//! JSON-RPC 2.0 envelope types for the stdio RPC server.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// JSON-RPC request id.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(untagged)]
+pub(crate) enum RequestId {
+    Number(i64),
+    String(String),
+}
+
+/// Inbound request (has `id`) or notification (no `id`).
+#[derive(Debug, Deserialize)]
+pub(crate) struct Incoming {
+    #[serde(default)]
+    pub id: Option<RequestId>,
+    pub method: String,
+    #[serde(default)]
+    pub params: Value,
+}
+
+/// Params of the `$/cancelRequest` notification.
+#[derive(Debug, Deserialize)]
+pub(crate) struct CancelParams {
+    pub id: RequestId,
+}
+
+/// JSON-RPC error object.
+#[derive(Debug, Serialize)]
+pub(crate) struct ResponseError {
+    pub code: i32,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<Value>,
+}
+
+impl ResponseError {
+    pub(crate) fn new(code: i32, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            message: message.into(),
+            data: None,
+        }
+    }
+
+    pub(crate) fn method_not_found(method: &str) -> Self {
+        Self::new(code::METHOD_NOT_FOUND, format!("method not found: {method}"))
+    }
+
+    pub(crate) fn invalid_params(message: impl Into<String>) -> Self {
+        Self::new(code::INVALID_PARAMS, message)
+    }
+
+    pub(crate) fn cancelled() -> Self {
+        Self::new(code::REQUEST_CANCELLED, "request cancelled")
+    }
+
+    pub(crate) fn duplicate_id() -> Self {
+        Self::new(code::INVALID_REQUEST, "duplicate in-flight request id")
+    }
+}
+
+/// Wire protocol version reported by `initialize`.
+pub(crate) const PROTOCOL_VERSION: u32 = 1;
+
+/// Standard JSON-RPC error codes plus LSP's request-cancelled code.
+pub(crate) mod code {
+    pub(crate) const PARSE_ERROR: i32 = -32700;
+    pub(crate) const INVALID_REQUEST: i32 = -32600;
+    pub(crate) const METHOD_NOT_FOUND: i32 = -32601;
+    pub(crate) const INVALID_PARAMS: i32 = -32602;
+    pub(crate) const INTERNAL_ERROR: i32 = -32603;
+    pub(crate) const FETCH_ERROR: i32 = -32000;
+    pub(crate) const REQUEST_CANCELLED: i32 = -32800;
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct Response {
+    pub jsonrpc: &'static str,
+    pub id: RequestId,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<ResponseError>,
+}
+
+impl Response {
+    pub(crate) fn success(id: RequestId, result: Value) -> Self {
+        Self {
+            jsonrpc: "2.0",
+            id,
+            result: Some(result),
+            error: None,
+        }
+    }
+
+    pub(crate) fn failure(id: RequestId, error: ResponseError) -> Self {
+        Self {
+            jsonrpc: "2.0",
+            id,
+            result: None,
+            error: Some(error),
+        }
+    }
+}
+
+/// Server-to-client notification (e.g. `$/progress`).
+#[derive(Debug, Serialize)]
+pub(crate) struct Notification {
+    pub jsonrpc: &'static str,
+    pub method: &'static str,
+    pub params: Value,
+}
+
+impl Notification {
+    pub(crate) fn new(method: &'static str, params: Value) -> Self {
+        Self {
+            jsonrpc: "2.0",
+            method,
+            params,
+        }
+    }
+}

--- a/crates/servo-fetch-cli/src/rpc/transport.rs
+++ b/crates/servo-fetch-cli/src/rpc/transport.rs
@@ -1,0 +1,25 @@
+//! NDJSON framing over stdio — one JSON-RPC message per line.
+
+use tokio::io::{AsyncWriteExt as _, Stdin, Stdout};
+use tokio::sync::mpsc::UnboundedReceiver;
+use tokio_util::codec::{FramedRead, LinesCodec};
+
+/// Reject oversized inbound frames before they exhaust memory.
+const MAX_FRAME_BYTES: usize = 64 * 1024 * 1024;
+
+/// A newline-delimited reader over stdin.
+pub(crate) fn frame_reader(stdin: Stdin) -> FramedRead<Stdin, LinesCodec> {
+    FramedRead::new(stdin, LinesCodec::new_with_max_length(MAX_FRAME_BYTES))
+}
+
+/// Write outbound frames to stdout in order (single writer, no interleaving).
+pub(crate) async fn write_loop(mut stdout: Stdout, mut rx: UnboundedReceiver<String>) {
+    while let Some(line) = rx.recv().await {
+        if stdout.write_all(line.as_bytes()).await.is_err()
+            || stdout.write_all(b"\n").await.is_err()
+            || stdout.flush().await.is_err()
+        {
+            break;
+        }
+    }
+}

--- a/crates/servo-fetch-cli/src/serve/handlers.rs
+++ b/crates/servo-fetch-cli/src/serve/handlers.rs
@@ -12,16 +12,10 @@ use super::params::{
     FetchResponse, Format, HealthResponse, MapRequest, MapResponse, ScreenshotRequest, VersionResponse,
 };
 use crate::tools;
-
-const MAX_TIMEOUT_SECS: u64 = 300;
-const MAX_SETTLE_MS: u64 = 10_000;
-const MAX_SELECTOR_LEN: usize = 1_000;
-const MAX_JS_LEN: usize = 10_000;
-const MAX_JS_OUTPUT_LEN: usize = 1_000_000;
-const MAX_BATCH_URLS: usize = 20;
-const MAX_CRAWL_LIMIT: usize = 500;
-const MAX_CRAWL_DEPTH: usize = 10;
-const MAX_MAP_LIMIT: usize = 100_000;
+use crate::tools::limits::{
+    MAX_BATCH_URLS, MAX_CRAWL_DEPTH, MAX_CRAWL_PAGES, MAX_JS_LEN, MAX_JS_OUTPUT_LEN, MAX_MAP_URLS, MAX_SELECTOR_LEN,
+    MAX_SETTLE_MS, MAX_TIMEOUT_SECS,
+};
 
 pub(super) async fn health() -> AxumJson<HealthResponse> {
     AxumJson(HealthResponse { status: "ok" })
@@ -131,7 +125,7 @@ pub(super) async fn batch_fetch(Json(req): Json<BatchFetchRequest>) -> Result<Ax
 
 pub(super) async fn crawl(Json(req): Json<CrawlRequest>) -> Result<AxumJson<CrawlResponse>, ApiError> {
     let url = tools::validated_url(&req.url)?;
-    let limit = req.limit.unwrap_or(20).clamp(1, MAX_CRAWL_LIMIT);
+    let limit = req.limit.unwrap_or(20).clamp(1, MAX_CRAWL_PAGES);
     let max_depth = req.max_depth.unwrap_or(3).clamp(1, MAX_CRAWL_DEPTH);
     let timeout = req.timeout.unwrap_or(30).clamp(1, MAX_TIMEOUT_SECS);
     let settle_ms = req.settle_ms.unwrap_or(0).min(MAX_SETTLE_MS);
@@ -161,7 +155,7 @@ pub(super) async fn crawl(Json(req): Json<CrawlRequest>) -> Result<AxumJson<Craw
 
 pub(super) async fn map(Json(req): Json<MapRequest>) -> Result<AxumJson<MapResponse>, ApiError> {
     let url = tools::validated_url(&req.url)?;
-    let limit = req.limit.unwrap_or(5000).clamp(1, MAX_MAP_LIMIT);
+    let limit = req.limit.unwrap_or(5000).clamp(1, MAX_MAP_URLS);
 
     let urls = tools::discover_urls(
         &url,

--- a/crates/servo-fetch-cli/src/tools.rs
+++ b/crates/servo-fetch-cli/src/tools.rs
@@ -1,15 +1,16 @@
-//! Shared tool implementations used by both the MCP server and the HTTP API.
+//! Shared tool implementations used by the MCP server, the HTTP API, and the RPC server.
 
 mod common;
 mod crawl;
 mod error;
 mod fetch;
+pub(crate) mod limits;
 mod map;
 mod screenshot;
 
 pub(crate) use common::{extract, paginate, validated_url};
 pub(crate) use crawl::{CrawlOptions, crawl_pages};
 pub(crate) use error::{ToolError, ToolResult};
-pub(crate) use fetch::{batch_fetch_pages, fetch_js, fetch_page};
-pub(crate) use map::discover_urls;
+pub(crate) use fetch::{batch_fetch_pages, fetch_js, fetch_page, fetch_with};
+pub(crate) use map::{discover_urls, map_with};
 pub(crate) use screenshot::take_screenshot;

--- a/crates/servo-fetch-cli/src/tools/crawl.rs
+++ b/crates/servo-fetch-cli/src/tools/crawl.rs
@@ -4,8 +4,7 @@ use std::time::Duration;
 
 use super::common::paginate;
 use super::error::{ToolError, ToolResult};
-
-pub(crate) const MAX_CRAWL_PAGES: usize = 500;
+use super::limits::MAX_CRAWL_PAGES;
 
 pub(crate) struct CrawlOptions<'a> {
     pub url: &'a str,

--- a/crates/servo-fetch-cli/src/tools/fetch.rs
+++ b/crates/servo-fetch-cli/src/tools/fetch.rs
@@ -9,59 +9,43 @@ use tokio::task::spawn_blocking;
 use super::common::{fetch_semaphore, paginate};
 use super::error::{ToolError, ToolResult};
 
-pub(crate) async fn fetch_page(url: &str, timeout: u64, settle_ms: u64) -> ToolResult<Page> {
+/// Run a built fetch on the warm engine, bounded by the global fetch semaphore.
+pub(crate) async fn fetch_with(opts: FetchOptions) -> ToolResult<Page> {
     let _permit = fetch_semaphore()
         .acquire()
         .await
         .map_err(|e| ToolError::internal(format!("fetch semaphore closed: {e}")))?;
-    let url = url.to_string();
-    spawn_blocking(move || {
-        servo_fetch::blocking::fetch(
-            &FetchOptions::new(&url)
-                .timeout(Duration::from_secs(timeout))
-                .settle(Duration::from_millis(settle_ms)),
-        )
-    })
+    spawn_blocking(move || servo_fetch::blocking::fetch(&opts))
+        .await
+        .map_err(|e| ToolError::internal(e.to_string()))?
+        .map_err(|e| ToolError::fetch(format!("{e:#}")))
+}
+
+pub(crate) async fn fetch_page(url: &str, timeout: u64, settle_ms: u64) -> ToolResult<Page> {
+    fetch_with(
+        FetchOptions::new(url)
+            .timeout(Duration::from_secs(timeout))
+            .settle(Duration::from_millis(settle_ms)),
+    )
     .await
-    .map_err(|e| ToolError::internal(e.to_string()))?
-    .map_err(|e| ToolError::fetch(format!("{e:#}")))
 }
 
 pub(crate) async fn fetch_js(url: &str, expression: &str, timeout: u64, settle_ms: u64) -> ToolResult<Page> {
-    let _permit = fetch_semaphore()
-        .acquire()
-        .await
-        .map_err(|e| ToolError::internal(format!("fetch semaphore closed: {e}")))?;
-    let url = url.to_string();
-    let expression = expression.to_string();
-    spawn_blocking(move || {
-        servo_fetch::blocking::fetch(
-            &FetchOptions::javascript(&url, &expression)
-                .timeout(Duration::from_secs(timeout))
-                .settle(Duration::from_millis(settle_ms)),
-        )
-    })
+    fetch_with(
+        FetchOptions::javascript(url, expression)
+            .timeout(Duration::from_secs(timeout))
+            .settle(Duration::from_millis(settle_ms)),
+    )
     .await
-    .map_err(|e| ToolError::internal(e.to_string()))?
-    .map_err(|e| ToolError::fetch(format!("{e:#}")))
 }
 
 pub(crate) async fn fetch_screenshot(url: &str, full_page: bool, timeout: u64, settle_ms: u64) -> ToolResult<Page> {
-    let _permit = fetch_semaphore()
-        .acquire()
-        .await
-        .map_err(|e| ToolError::internal(format!("fetch semaphore closed: {e}")))?;
-    let url = url.to_string();
-    spawn_blocking(move || {
-        servo_fetch::blocking::fetch(
-            &FetchOptions::screenshot(&url, full_page)
-                .timeout(Duration::from_secs(timeout))
-                .settle(Duration::from_millis(settle_ms)),
-        )
-    })
+    fetch_with(
+        FetchOptions::screenshot(url, full_page)
+            .timeout(Duration::from_secs(timeout))
+            .settle(Duration::from_millis(settle_ms)),
+    )
     .await
-    .map_err(|e| ToolError::internal(e.to_string()))?
-    .map_err(|e| ToolError::fetch(format!("{e:#}")))
 }
 
 pub(crate) async fn batch_fetch_pages(

--- a/crates/servo-fetch-cli/src/tools/limits.rs
+++ b/crates/servo-fetch-cli/src/tools/limits.rs
@@ -1,0 +1,12 @@
+//! Shared request limits.
+
+pub(crate) const MAX_TIMEOUT_SECS: u64 = 300;
+pub(crate) const MAX_SETTLE_MS: u64 = 10_000;
+pub(crate) const MAX_SELECTOR_LEN: usize = 1_000;
+pub(crate) const MAX_JS_LEN: usize = 10_000;
+pub(crate) const MAX_JS_OUTPUT_LEN: usize = 1_000_000;
+pub(crate) const MAX_BATCH_URLS: usize = 20;
+pub(crate) const MAX_CRAWL_PAGES: usize = 500;
+pub(crate) const MAX_CRAWL_DEPTH: usize = 10;
+pub(crate) const MAX_CRAWL_CONCURRENCY: usize = 16;
+pub(crate) const MAX_MAP_URLS: usize = 100_000;

--- a/crates/servo-fetch-cli/src/tools/map.rs
+++ b/crates/servo-fetch-cli/src/tools/map.rs
@@ -1,6 +1,16 @@
 //! Map tool helper.
 
+use servo_fetch::{MapOptions, MappedUrl};
+
 use super::error::{ToolError, ToolResult};
+
+/// Run a built map on the engine, returning sitemap entries (URL plus `lastmod`).
+pub(crate) async fn map_with(opts: MapOptions) -> ToolResult<Vec<MappedUrl>> {
+    tokio::task::spawn_blocking(move || servo_fetch::blocking::map(&opts))
+        .await
+        .map_err(|e| ToolError::internal(e.to_string()))?
+        .map_err(|e| ToolError::fetch(format!("{e:#}")))
+}
 
 pub(crate) async fn discover_urls(
     url: &str,
@@ -8,22 +18,13 @@ pub(crate) async fn discover_urls(
     include_glob: &[String],
     exclude_glob: &[String],
 ) -> ToolResult<Vec<String>> {
-    let opts = servo_fetch::MapOptions::new(url).limit(limit);
-    let opts = if include_glob.is_empty() {
-        opts
-    } else {
-        opts.include(&include_glob.iter().map(String::as_str).collect::<Vec<_>>())
-    };
-    let opts = if exclude_glob.is_empty() {
-        opts
-    } else {
-        opts.exclude(&exclude_glob.iter().map(String::as_str).collect::<Vec<_>>())
-    };
-
-    let results = tokio::task::spawn_blocking(move || servo_fetch::blocking::map(&opts))
-        .await
-        .map_err(|e| ToolError::internal(e.to_string()))?
-        .map_err(|e| ToolError::fetch(e.to_string()))?;
-
-    Ok(results.iter().map(|entry| entry.url.clone()).collect())
+    let mut opts = MapOptions::new(url).limit(limit);
+    if !include_glob.is_empty() {
+        opts = opts.include(&include_glob.iter().map(String::as_str).collect::<Vec<_>>());
+    }
+    if !exclude_glob.is_empty() {
+        opts = opts.exclude(&exclude_glob.iter().map(String::as_str).collect::<Vec<_>>());
+    }
+    let entries = map_with(opts).await?;
+    Ok(entries.into_iter().map(|entry| entry.url).collect())
 }

--- a/crates/servo-fetch-cli/tests/rpc.rs
+++ b/crates/servo-fetch-cli/tests/rpc.rs
@@ -1,0 +1,270 @@
+//! Stdio JSON-RPC protocol round-trip tests (engine-free, plus `#[ignore]` engine-backed).
+
+use std::io::{BufRead as _, BufReader, Write as _};
+use std::process::{Command as StdCommand, Stdio};
+use std::time::Duration;
+
+use assert_cmd::Command;
+use serde_json::{Value, json};
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+mod common;
+use common::mock_page;
+
+fn parse_frames(stdout: Vec<u8>) -> Vec<Value> {
+    String::from_utf8(stdout)
+        .unwrap()
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| serde_json::from_str(line).unwrap())
+        .collect()
+}
+
+fn run_rpc(input: &str) -> Vec<Value> {
+    let output = Command::cargo_bin("servo-fetch")
+        .unwrap()
+        .arg("rpc")
+        .write_stdin(input)
+        .output()
+        .unwrap();
+    parse_frames(output.stdout)
+}
+
+/// Run the server with loopback fetches allowed, for `MockServer`-backed engine tests.
+fn run_rpc_loopback(input: &str) -> Vec<Value> {
+    let output = Command::cargo_bin("servo-fetch")
+        .unwrap()
+        .args(["rpc", "--allow-private-addresses"])
+        .write_stdin(input)
+        .output()
+        .unwrap();
+    parse_frames(output.stdout)
+}
+
+#[test]
+fn initialize_returns_server_info() {
+    let out = run_rpc("{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\"}\n");
+    assert_eq!(out.len(), 1, "expected one response, got: {out:?}");
+    assert_eq!(out[0]["id"], 1);
+    assert_eq!(out[0]["result"]["serverInfo"]["name"], "servo-fetch");
+}
+
+#[test]
+fn unknown_method_returns_method_not_found() {
+    let out = run_rpc("{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"nope\"}\n");
+    assert_eq!(out[0]["id"], 2);
+    assert_eq!(out[0]["error"]["code"], -32601);
+}
+
+#[test]
+fn malformed_line_returns_parse_error_with_null_id() {
+    let out = run_rpc("not json\n");
+    assert_eq!(out[0]["error"]["code"], -32700);
+    assert!(out[0]["id"].is_null());
+}
+
+#[test]
+fn exit_notification_stops_the_server() {
+    let out = run_rpc("{\"jsonrpc\":\"2.0\",\"method\":\"exit\"}\n");
+    assert!(out.is_empty(), "exit must produce no response, got: {out:?}");
+}
+
+#[test]
+fn responses_are_correlated_by_id_across_frames() {
+    let out = run_rpc(concat!(
+        "{\"jsonrpc\":\"2.0\",\"id\":10,\"method\":\"initialize\"}\n",
+        "{\"jsonrpc\":\"2.0\",\"id\":11,\"method\":\"initialize\"}\n",
+    ));
+    assert_eq!(out.len(), 2, "expected two responses, got: {out:?}");
+    let ids: Vec<_> = out.iter().map(|m| m["id"].clone()).collect();
+    assert!(
+        ids.contains(&serde_json::json!(10)) && ids.contains(&serde_json::json!(11)),
+        "ids: {ids:?}"
+    );
+}
+
+#[test]
+fn cancel_of_unknown_id_is_ignored() {
+    let out = run_rpc(concat!(
+        "{\"jsonrpc\":\"2.0\",\"method\":\"$/cancelRequest\",\"params\":{\"id\":999}}\n",
+        "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\"}\n",
+    ));
+    assert_eq!(out.len(), 1, "cancel must not respond; initialize must, got: {out:?}");
+    assert_eq!(out[0]["id"], 1);
+}
+
+#[test]
+fn missing_required_param_is_invalid_params() {
+    let out = run_rpc("{\"jsonrpc\":\"2.0\",\"id\":5,\"method\":\"fetch\",\"params\":{}}\n");
+    assert_eq!(out[0]["error"]["code"], -32602);
+}
+
+#[test]
+fn blank_lines_are_ignored() {
+    let out = run_rpc("\n   \n{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\"}\n");
+    assert_eq!(out.len(), 1, "blank lines must be skipped, got: {out:?}");
+    assert_eq!(out[0]["id"], 1);
+}
+
+#[test]
+fn malformed_cancel_is_ignored() {
+    let out = run_rpc(concat!(
+        "{\"jsonrpc\":\"2.0\",\"method\":\"$/cancelRequest\",\"params\":{}}\n",
+        "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\"}\n",
+    ));
+    assert_eq!(out.len(), 1, "malformed cancel must not respond or crash, got: {out:?}");
+    assert_eq!(out[0]["id"], 1);
+}
+
+#[tokio::test]
+#[ignore = "e2e: requires Servo engine"]
+async fn fetch_returns_markdown() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/"))
+        .respond_with(mock_page(
+            "<html><head><title>Test</title></head><body><p>Hello from Servo</p></body></html>",
+        ))
+        .mount(&server)
+        .await;
+
+    let req = json!({"jsonrpc":"2.0","id":1,"method":"fetch","params":{"url":server.uri(),"timeout":30}}).to_string();
+    let out = tokio::task::spawn_blocking(move || run_rpc_loopback(&format!("{req}\n")))
+        .await
+        .unwrap();
+
+    assert_eq!(out.len(), 1, "expected one response, got: {out:?}");
+    let md = out[0]["result"]
+        .as_str()
+        .expect("fetch result should be a markdown string");
+    assert!(md.contains("Hello from Servo"), "got: {md}");
+}
+
+#[tokio::test]
+#[ignore = "e2e: requires Servo engine"]
+async fn crawl_streams_progress_then_returns_stats() {
+    let server = MockServer::start().await;
+    let link = format!(r#"<a href="{}/page2">next</a>"#, server.uri());
+    Mock::given(method("GET"))
+        .and(path("/"))
+        .respond_with(mock_page(format!(
+            "<html><head><title>Root</title></head><body>{link}</body></html>"
+        )))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/page2"))
+        .respond_with(mock_page(
+            "<html><head><title>Page 2</title></head><body>second</body></html>",
+        ))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/robots.txt"))
+        .respond_with(ResponseTemplate::new(404))
+        .mount(&server)
+        .await;
+
+    let req =
+        json!({"jsonrpc":"2.0","id":2,"method":"crawl","params":{"url":server.uri(),"limit":3,"maxDepth":1,"timeout":30}})
+            .to_string();
+    let out = tokio::task::spawn_blocking(move || run_rpc_loopback(&format!("{req}\n")))
+        .await
+        .unwrap();
+
+    let progress: Vec<_> = out.iter().filter(|m| m["method"] == "$/progress").collect();
+    assert!(!progress.is_empty(), "expected $/progress notifications, got: {out:?}");
+    assert!(
+        progress.iter().any(|m| m["params"]["value"]["type"] == "page"),
+        "expected at least one page event, got: {progress:?}"
+    );
+    let response = out.iter().find(|m| m["id"] == 2).expect("final crawl response");
+    assert!(
+        response["result"]["crawled"].as_u64().unwrap_or(0) >= 1,
+        "expected crawled>=1 in CrawlStats, got: {response:?}"
+    );
+}
+
+#[tokio::test]
+#[ignore = "e2e: requires Servo engine"]
+async fn cancel_aborts_in_flight_crawl() {
+    let server = MockServer::start().await;
+    let anchor = format!(r#"<a href="{}/slow">next</a>"#, server.uri());
+    Mock::given(method("GET"))
+        .and(path("/"))
+        .respond_with(mock_page(format!(
+            "<html><head><title>Root</title></head><body>{anchor}</body></html>"
+        )))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/slow"))
+        .respond_with(mock_page("<html><body>slow</body></html>").set_delay(Duration::from_secs(10)))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/robots.txt"))
+        .respond_with(ResponseTemplate::new(404))
+        .mount(&server)
+        .await;
+
+    let uri = server.uri();
+    let code = tokio::task::spawn_blocking(move || {
+        let mut child = StdCommand::new(env!("CARGO_BIN_EXE_servo-fetch"))
+            .args(["rpc", "--allow-private-addresses"])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .unwrap();
+        let mut stdin = child.stdin.take().unwrap();
+        let mut stdout = BufReader::new(child.stdout.take().unwrap());
+
+        let crawl =
+            json!({"jsonrpc":"2.0","id":7,"method":"crawl","params":{"url":uri,"limit":5,"maxDepth":2,"timeout":30}})
+                .to_string();
+        writeln!(stdin, "{crawl}").unwrap();
+        stdin.flush().unwrap();
+
+        // Wait for the root page's progress event, then cancel while /slow is in flight.
+        let mut line = String::new();
+        loop {
+            line.clear();
+            assert!(
+                stdout.read_line(&mut line).unwrap() > 0,
+                "server closed before any progress"
+            );
+            let frame: Value = serde_json::from_str(line.trim()).unwrap();
+            if frame["method"] == "$/progress" {
+                break;
+            }
+        }
+        let cancel = json!({"jsonrpc":"2.0","method":"$/cancelRequest","params":{"id":7}}).to_string();
+        writeln!(stdin, "{cancel}").unwrap();
+        stdin.flush().unwrap();
+        drop(stdin);
+
+        let code = loop {
+            line.clear();
+            if stdout.read_line(&mut line).unwrap() == 0 {
+                break None;
+            }
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            let frame: Value = serde_json::from_str(trimmed).unwrap();
+            if frame["id"] == 7 {
+                break frame["error"]["code"].as_i64();
+            }
+        };
+        let _ = child.kill();
+        let _ = child.wait();
+        code
+    })
+    .await
+    .unwrap();
+
+    assert_eq!(code, Some(-32800), "expected RequestCancelled (-32800)");
+}

--- a/crates/servo-fetch-types/src/request.rs
+++ b/crates/servo-fetch-types/src/request.rs
@@ -1,10 +1,11 @@
-//! Request DTOs.
+//! Request DTOs — the input counterpart to the output wire types, shared by the
+//! servo-fetch servers and language bindings.
 
 use serde::{Deserialize, Serialize};
 
 use crate::Visibility;
 
-/// Output format for a single-page fetch.
+/// Output format for the `fetch` method (all string-valued).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[cfg_attr(feature = "codegen", derive(ts_rs::TS), ts(export, export_to = "index.ts"))]
 #[serde(rename_all = "lowercase")]
@@ -12,24 +13,56 @@ pub enum FetchFormat {
     /// Readability-extracted Markdown.
     #[default]
     Markdown,
-    /// Readability-extracted structured article JSON.
-    Json,
     /// Raw rendered HTML (post-JS execution).
     Html,
     /// Plain text (`document.body.innerText`).
     Text,
 }
 
-/// Parameters for the `fetch` method.
+/// Parameters for the `fetch` method (Markdown/HTML/text — returns a string).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "codegen", derive(ts_rs::TS), ts(export, export_to = "index.ts"))]
 #[serde(rename_all = "camelCase")]
 pub struct FetchRequest {
     /// URL to fetch (http/https only).
     pub url: String,
-    /// Output format.
-    #[serde(default)]
-    pub format: FetchFormat,
+    /// Output format (default: markdown).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "codegen", ts(optional))]
+    pub format: Option<FetchFormat>,
+    /// CSS selector to extract a specific section (Markdown only).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "codegen", ts(optional))]
+    pub selector: Option<String>,
+    /// Page-load timeout in seconds (default: 30).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "codegen", ts(optional, type = "number"))]
+    pub timeout: Option<u64>,
+    /// Extra wait in milliseconds after the load event (default: 0).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "codegen", ts(optional, type = "number"))]
+    pub settle_ms: Option<u64>,
+    /// Override the User-Agent header.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "codegen", ts(optional))]
+    pub user_agent: Option<String>,
+    /// Path to a Netscape-format cookies.txt file.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "codegen", ts(optional))]
+    pub cookies_file: Option<String>,
+    /// Visibility filtering policy (default: moderate).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "codegen", ts(optional))]
+    pub visibility: Option<Visibility>,
+}
+
+/// Parameters for the `extract` method (Readability article JSON).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "codegen", derive(ts_rs::TS), ts(export, export_to = "index.ts"))]
+#[serde(rename_all = "camelCase")]
+pub struct ExtractRequest {
+    /// URL to fetch (http/https only).
+    pub url: String,
     /// CSS selector to extract a specific section.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[cfg_attr(feature = "codegen", ts(optional))]
@@ -54,10 +87,6 @@ pub struct FetchRequest {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[cfg_attr(feature = "codegen", ts(optional))]
     pub visibility: Option<Visibility>,
-    /// Allow loopback/private addresses, relaxing the SSRF guard.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[cfg_attr(feature = "codegen", ts(optional))]
-    pub allow_private_addresses: Option<bool>,
 }
 
 /// Parameters for the `screenshot` method.
@@ -87,10 +116,6 @@ pub struct ScreenshotRequest {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[cfg_attr(feature = "codegen", ts(optional))]
     pub cookies_file: Option<String>,
-    /// Allow loopback/private addresses, relaxing the SSRF guard.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[cfg_attr(feature = "codegen", ts(optional))]
-    pub allow_private_addresses: Option<bool>,
 }
 
 /// Parameters for the `evaluate` method.
@@ -118,10 +143,6 @@ pub struct EvaluateRequest {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[cfg_attr(feature = "codegen", ts(optional))]
     pub cookies_file: Option<String>,
-    /// Allow loopback/private addresses, relaxing the SSRF guard.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[cfg_attr(feature = "codegen", ts(optional))]
-    pub allow_private_addresses: Option<bool>,
 }
 
 /// Parameters for the `extractSchema` method.
@@ -154,10 +175,6 @@ pub struct SchemaExtractRequest {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[cfg_attr(feature = "codegen", ts(optional))]
     pub visibility: Option<Visibility>,
-    /// Allow loopback/private addresses, relaxing the SSRF guard.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[cfg_attr(feature = "codegen", ts(optional))]
-    pub allow_private_addresses: Option<bool>,
 }
 
 /// Parameters for the `crawl` method.
@@ -211,10 +228,6 @@ pub struct CrawlRequest {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[cfg_attr(feature = "codegen", ts(optional))]
     pub cookies_file: Option<String>,
-    /// Allow loopback/private addresses, relaxing the SSRF guard.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[cfg_attr(feature = "codegen", ts(optional))]
-    pub allow_private_addresses: Option<bool>,
 }
 
 /// Parameters for the `map` method.
@@ -248,8 +261,4 @@ pub struct MapRequest {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[cfg_attr(feature = "codegen", ts(optional))]
     pub no_fallback: Option<bool>,
-    /// Allow loopback/private addresses, relaxing the SSRF guard.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[cfg_attr(feature = "codegen", ts(optional))]
-    pub allow_private_addresses: Option<bool>,
 }

--- a/crates/servo-fetch-types/src/wire.rs
+++ b/crates/servo-fetch-types/src/wire.rs
@@ -138,6 +138,22 @@ pub enum CrawlEvent {
     },
 }
 
+/// Terminal summary returned by the `crawl` method once the stream completes.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "codegen", derive(ts_rs::TS), ts(export, export_to = "index.ts"))]
+#[serde(rename_all = "camelCase")]
+pub struct CrawlStats {
+    /// Pages crawled successfully.
+    #[cfg_attr(feature = "codegen", ts(type = "number"))]
+    pub crawled: u64,
+    /// Pages that errored.
+    #[cfg_attr(feature = "codegen", ts(type = "number"))]
+    pub errors: u64,
+    /// Total wall-clock time in milliseconds.
+    #[cfg_attr(feature = "codegen", ts(type = "number"))]
+    pub elapsed_ms: u64,
+}
+
 /// Structured-extraction result for the `--schema` path.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "codegen", derive(ts_rs::TS), ts(export, export_to = "index.ts"))]
@@ -170,4 +186,34 @@ pub struct MappedUrl {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[cfg_attr(feature = "codegen", ts(optional))]
     pub lastmod: Option<String>,
+}
+
+/// Server name and version, reported by `initialize`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "codegen", derive(ts_rs::TS), ts(export, export_to = "index.ts"))]
+#[serde(rename_all = "camelCase")]
+pub struct ServerInfo {
+    /// Server name.
+    pub name: String,
+    /// Server version.
+    pub version: String,
+}
+
+/// Capabilities advertised by the server (none yet; reserved for forward compatibility).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[cfg_attr(feature = "codegen", derive(ts_rs::TS), ts(export, export_to = "index.ts"))]
+#[serde(rename_all = "camelCase")]
+pub struct ServerCapabilities {}
+
+/// Result of the `initialize` handshake.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "codegen", derive(ts_rs::TS), ts(export, export_to = "index.ts"))]
+#[serde(rename_all = "camelCase")]
+pub struct InitializeResult {
+    /// Wire protocol version the server speaks.
+    pub protocol_version: u32,
+    /// Server name and version.
+    pub server_info: ServerInfo,
+    /// Capabilities the server advertises.
+    pub capabilities: ServerCapabilities,
 }


### PR DESCRIPTION
## Summary

Add a hidden `rpc` subcommand that serves JSON-RPC 2.0 over stdio (NDJSON framing) so language bindings can keep the Servo engine warm instead of spawning the CLI per call. Methods: `initialize`, `fetch`, `extract`, `screenshot`, `evaluate`, `extractSchema`, `map`, and streaming `crawl` (`$/progress` + `CrawlStats`); cancellation via `$/cancelRequest`.

## Related issues

follows #301 (request DTOs).

## Test Plan

- `cargo test`: all passed
- Engine-backed `#[ignore]` tests (`cargo test --test rpc -- --include-ignored`): all passed
- Manual end-to-end against the real Servo engine (local HTTP fixtures)

## Checklist

- [x] Ran `cargo +nightly fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
- [x] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed
- [x] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it