### PR TITLE
fix(cli): align mcp/serve crawl default limit with the CLI

### DIFF
--- a/crates/servo-fetch-cli/README.md
+++ b/crates/servo-fetch-cli/README.md
@@ -309,7 +309,7 @@ Streamable HTTP: `servo-fetch mcp --port 8080`
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `url` | string | Starting URL (http/https only) |
-| `limit` | number? | Maximum pages to crawl (default 20, max 500) |
+| `limit` | number? | Maximum pages to crawl (default 50, max 500) |
 | `max_depth` | number? | Maximum link depth from seed (default 3, max 10) |
 | `format` | string? | `markdown` (default) or `json` |
 | `include_glob` | string[]? | URL path patterns to include |

--- a/crates/servo-fetch-cli/src/mcp/params.rs
+++ b/crates/servo-fetch-cli/src/mcp/params.rs
@@ -86,7 +86,7 @@ pub(super) struct BatchFetchParams {
 pub(super) struct CrawlParams {
     #[schemars(description = "Starting URL to crawl (http/https only)")]
     pub url: String,
-    #[schemars(description = "Maximum pages to crawl. Default: 20. Max: 500.")]
+    #[schemars(description = "Maximum pages to crawl. Default: 50. Max: 500.")]
     pub limit: Option<usize>,
     #[schemars(description = "Maximum link depth from seed URL. Default: 3. Max: 10.")]
     pub max_depth: Option<usize>,

--- a/crates/servo-fetch-cli/src/mcp/server.rs
+++ b/crates/servo-fetch-cli/src/mcp/server.rs
@@ -192,7 +192,7 @@ impl ServoFetchMcp {
     )]
     async fn crawl(&self, Parameters(p): Parameters<CrawlParams>) -> Result<CallToolResult, ErrorData> {
         let url = tools::validated_url(&p.url)?;
-        let limit = p.limit.unwrap_or(20).clamp(1, MAX_CRAWL_PAGES);
+        let limit = p.limit.unwrap_or(50).clamp(1, MAX_CRAWL_PAGES);
         let max_depth = p.max_depth.unwrap_or(3).clamp(1, MAX_CRAWL_DEPTH);
         let timeout = p.timeout.unwrap_or(30).clamp(1, MAX_TIMEOUT_SECS);
         let settle_ms = p.settle_ms.unwrap_or(0).min(MAX_SETTLE_MS);

--- a/crates/servo-fetch-cli/src/serve/handlers.rs
+++ b/crates/servo-fetch-cli/src/serve/handlers.rs
@@ -125,7 +125,7 @@ pub(super) async fn batch_fetch(Json(req): Json<BatchFetchRequest>) -> Result<Ax
 
 pub(super) async fn crawl(Json(req): Json<CrawlRequest>) -> Result<AxumJson<CrawlResponse>, ApiError> {
     let url = tools::validated_url(&req.url)?;
-    let limit = req.limit.unwrap_or(20).clamp(1, MAX_CRAWL_PAGES);
+    let limit = req.limit.unwrap_or(50).clamp(1, MAX_CRAWL_PAGES);
     let max_depth = req.max_depth.unwrap_or(3).clamp(1, MAX_CRAWL_DEPTH);
     let timeout = req.timeout.unwrap_or(30).clamp(1, MAX_TIMEOUT_SECS);
     let settle_ms = req.settle_ms.unwrap_or(0).min(MAX_SETTLE_MS);


### PR DESCRIPTION
## Summary

The crawl `limit` default diverged across surfaces: the CLI and the new RPC server default to 50 pages, but the MCP and HTTP (`serve`) handlers defaulted to 20. Align MCP and `serve` to 50 so every surface behaves the same.

## Related issues

Follow-up cleanup noted during the #309 review.

## Test Plan

- `cargo test -p servo-fetch-cli`: all passed

## Checklist

- [x] Ran `cargo +nightly fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
- [x] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed
- [ ] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it