### PR TITLE
feat(cli): classify errors with a shared typed error kind

### DIFF
--- a/bindings/node/src/generated/index.ts
+++ b/bindings/node/src/generated/index.ts
@@ -188,6 +188,11 @@ export type ErrorEnvelope = {
 error: string, };
 
 /**
+ * Stable, surface-independent error category for programmatic handling.
+ */
+export type ErrorKind = "invalidUrl" | "timeout" | "addressNotAllowed" | "engine" | "javascript" | "invalidParams" | "methodNotFound" | "parseError" | "requestCancelled" | "duplicateRequest" | "internal" | "other";
+
+/**
  * Parameters for the `evaluate` method.
  */
 export type EvaluateRequest = { 

--- a/crates/servo-fetch-cli/src/commands/fetch.rs
+++ b/crates/servo-fetch-cli/src/commands/fetch.rs
@@ -132,7 +132,7 @@ async fn run_batch(args: &FetchArgs, urls: &[String]) -> Result<()> {
             }
             Err(err) => {
                 failures += 1;
-                tracing::error!(url = %url, "{err:#}");
+                tracing::error!(url = %url, "{err}");
             }
         }
     }

--- a/crates/servo-fetch-cli/src/mcp/tools.rs
+++ b/crates/servo-fetch-cli/src/mcp/tools.rs
@@ -3,6 +3,7 @@
 use base64::Engine as _;
 use rmcp::ErrorData;
 use rmcp::model::{CallToolResult, Content};
+use servo_fetch_types::ErrorKind;
 
 pub(super) use crate::tools::{
     CrawlOptions as CrawlToolOptions, batch_fetch_pages, extract, fetch_js, fetch_page, paginate,
@@ -48,9 +49,11 @@ pub(super) async fn discover_urls(
 impl From<ToolError> for ErrorData {
     fn from(err: ToolError) -> Self {
         let msg = err.to_string();
-        match err {
-            ToolError::InvalidInput(_) => Self::invalid_params(msg, None),
-            ToolError::Fetch(_) | ToolError::Internal(_) => Self::internal_error(msg, None),
+        match err.kind() {
+            ErrorKind::InvalidUrl | ErrorKind::AddressNotAllowed | ErrorKind::InvalidParams => {
+                Self::invalid_params(msg, None)
+            }
+            _ => Self::internal_error(msg, None),
         }
     }
 }

--- a/crates/servo-fetch-cli/src/rpc.rs
+++ b/crates/servo-fetch-cli/src/rpc.rs
@@ -10,8 +10,9 @@ use std::panic::AssertUnwindSafe;
 use std::sync::{Arc, Mutex};
 
 use futures_util::{FutureExt as _, StreamExt as _};
-use protocol::{CancelParams, Incoming, RequestId, Response, ResponseError, code};
+use protocol::{CancelParams, ErrorData, Incoming, RequestId, Response, ResponseError, code};
 use serde_json::Value;
+use servo_fetch_types::ErrorKind;
 use tokio::sync::mpsc::{self, UnboundedSender};
 use tokio_util::codec::LinesCodecError;
 use tokio_util::sync::CancellationToken;
@@ -30,7 +31,11 @@ pub(crate) async fn run() -> anyhow::Result<()> {
             Ok(line) => line,
             Err(LinesCodecError::MaxLineLengthExceeded) => {
                 // FramedRead ends the stream after a decode error, so report and stop.
-                let _ = tx.send(error_line(code::INVALID_REQUEST, "frame exceeds maximum length"));
+                let _ = tx.send(error_line(
+                    code::INVALID_REQUEST,
+                    ErrorKind::ParseError,
+                    "frame exceeds maximum length",
+                ));
                 break;
             }
             Err(LinesCodecError::Io(e)) => {
@@ -44,7 +49,7 @@ pub(crate) async fn run() -> anyhow::Result<()> {
         let incoming: Incoming = match serde_json::from_str(&line) {
             Ok(msg) => msg,
             Err(e) => {
-                let _ = tx.send(error_line(code::PARSE_ERROR, &e.to_string()));
+                let _ = tx.send(error_line(code::PARSE_ERROR, ErrorKind::ParseError, &e.to_string()));
                 continue;
             }
         };
@@ -88,7 +93,7 @@ fn spawn_request(id: RequestId, method: String, params: Value, tx: &UnboundedSen
             () = token.cancelled() => Err(ResponseError::cancelled()),
             result = dispatched => result.unwrap_or_else(|payload| {
                 tracing::error!("rpc handler `{method}` panicked: {}", panic_message(payload.as_ref()));
-                Err(ResponseError::new(code::INTERNAL_ERROR, "handler panicked"))
+                Err(ResponseError::new(code::INTERNAL_ERROR, ErrorKind::Internal, "handler panicked"))
             }),
         };
         // Always deregister and answer exactly once, even on panic/cancel.
@@ -119,11 +124,11 @@ fn panic_message(payload: &(dyn Any + Send)) -> &str {
         .unwrap_or("unknown panic payload")
 }
 
-fn error_line(code: i32, message: &str) -> String {
+fn error_line(code: i32, kind: ErrorKind, message: &str) -> String {
     serde_json::json!({
         "jsonrpc": "2.0",
         "id": Value::Null,
-        "error": { "code": code, "message": message },
+        "error": { "code": code, "message": message, "data": ErrorData { kind } },
     })
     .to_string()
 }

--- a/crates/servo-fetch-cli/src/rpc/dispatch.rs
+++ b/crates/servo-fetch-cli/src/rpc/dispatch.rs
@@ -7,8 +7,8 @@ use serde::de::DeserializeOwned;
 use serde_json::{Value, json};
 use servo_fetch::{FetchOptions, MapOptions, VisibilityPolicy};
 use servo_fetch_types::{
-    CrawlRequest, CrawlStats, EvaluateRequest, ExtractRequest, FetchFormat, FetchRequest, InitializeResult, MapRequest,
-    SchemaExtractRequest, ScreenshotRequest, ServerCapabilities, ServerInfo, Visibility,
+    CrawlRequest, CrawlStats, ErrorKind, EvaluateRequest, ExtractRequest, FetchFormat, FetchRequest, InitializeResult,
+    MapRequest, SchemaExtractRequest, ScreenshotRequest, ServerCapabilities, ServerInfo, Visibility,
 };
 use tokio::sync::mpsc::UnboundedSender;
 
@@ -100,7 +100,7 @@ async fn screenshot(params: Value) -> Result<Value, ResponseError> {
 
     let png = page
         .screenshot_png()
-        .ok_or_else(|| ResponseError::new(code::FETCH_ERROR, "screenshot capture failed"))?;
+        .ok_or_else(|| ResponseError::new(code::INTERNAL_ERROR, ErrorKind::Internal, "screenshot capture failed"))?;
     Ok(json!(base64::engine::general_purpose::STANDARD.encode(png)))
 }
 
@@ -223,7 +223,7 @@ async fn crawl(params: Value, id: &RequestId, tx: &UnboundedSender<String>) -> R
             }
         })
         .await
-        .map_err(|e| ResponseError::new(code::FETCH_ERROR, format!("{e:#}")))?;
+        .map_err(ResponseError::from)?;
     }
 
     let elapsed_ms = u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX);
@@ -264,7 +264,7 @@ fn with_ua_and_cookies(
 }
 
 fn load_cookies(path: &str) -> Result<Vec<servo_fetch::CookieSpec>, ResponseError> {
-    servo_fetch::load_cookies(path).map_err(|e| ResponseError::invalid_params(format!("cookies '{path}': {e:#}")))
+    servo_fetch::load_cookies(path).map_err(|e| ResponseError::invalid_params(format!("cookies '{path}': {e}")))
 }
 
 fn visibility_policy(v: Option<Visibility>) -> VisibilityPolicy {
@@ -302,23 +302,23 @@ fn clamp_usize(value: Option<u64>, default: usize, max: usize) -> usize {
 
 impl From<ToolError> for ResponseError {
     fn from(err: ToolError) -> Self {
-        let code = match &err {
-            ToolError::InvalidInput(_) => code::INVALID_PARAMS,
-            ToolError::Fetch(_) => code::FETCH_ERROR,
-            ToolError::Internal(_) => code::INTERNAL_ERROR,
+        let code = match err.kind() {
+            ErrorKind::InvalidUrl | ErrorKind::AddressNotAllowed | ErrorKind::InvalidParams => code::INVALID_PARAMS,
+            ErrorKind::Internal => code::INTERNAL_ERROR,
+            _ => code::FETCH_ERROR,
         };
-        Self::new(code, err.to_string())
+        Self::new(code, err.kind(), err.to_string())
     }
 }
 
 impl From<servo_fetch::Error> for ResponseError {
     fn from(err: servo_fetch::Error) -> Self {
-        Self::new(code::FETCH_ERROR, err.to_string())
+        Self::from(ToolError::from(err))
     }
 }
 
 impl From<serde_json::Error> for ResponseError {
     fn from(err: serde_json::Error) -> Self {
-        Self::new(code::INTERNAL_ERROR, err.to_string())
+        Self::new(code::INTERNAL_ERROR, ErrorKind::Internal, err.to_string())
     }
 }

--- a/crates/servo-fetch-cli/src/rpc/protocol.rs
+++ b/crates/servo-fetch-cli/src/rpc/protocol.rs
@@ -2,6 +2,7 @@
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use servo_fetch_types::ErrorKind;
 
 /// JSON-RPC request id.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -28,37 +29,55 @@ pub(crate) struct CancelParams {
 }
 
 /// JSON-RPC error object.
+/// Structured payload for JSON-RPC `error.data`.
+#[derive(Debug, Serialize)]
+pub(crate) struct ErrorData {
+    pub kind: ErrorKind,
+}
+
 #[derive(Debug, Serialize)]
 pub(crate) struct ResponseError {
     pub code: i32,
     pub message: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub data: Option<Value>,
+    pub data: Option<ErrorData>,
 }
 
 impl ResponseError {
-    pub(crate) fn new(code: i32, message: impl Into<String>) -> Self {
+    pub(crate) fn new(code: i32, kind: ErrorKind, message: impl Into<String>) -> Self {
         Self {
             code,
             message: message.into(),
-            data: None,
+            data: Some(ErrorData { kind }),
         }
     }
 
     pub(crate) fn method_not_found(method: &str) -> Self {
-        Self::new(code::METHOD_NOT_FOUND, format!("method not found: {method}"))
+        Self::new(
+            code::METHOD_NOT_FOUND,
+            ErrorKind::MethodNotFound,
+            format!("method not found: {method}"),
+        )
     }
 
     pub(crate) fn invalid_params(message: impl Into<String>) -> Self {
-        Self::new(code::INVALID_PARAMS, message)
+        Self::new(code::INVALID_PARAMS, ErrorKind::InvalidParams, message)
     }
 
     pub(crate) fn cancelled() -> Self {
-        Self::new(code::REQUEST_CANCELLED, "request cancelled")
+        Self::new(
+            code::REQUEST_CANCELLED,
+            ErrorKind::RequestCancelled,
+            "request cancelled",
+        )
     }
 
     pub(crate) fn duplicate_id() -> Self {
-        Self::new(code::INVALID_REQUEST, "duplicate in-flight request id")
+        Self::new(
+            code::INVALID_REQUEST,
+            ErrorKind::DuplicateRequest,
+            "duplicate in-flight request id",
+        )
     }
 }
 

--- a/crates/servo-fetch-cli/src/serve/error.rs
+++ b/crates/servo-fetch-cli/src/serve/error.rs
@@ -3,6 +3,7 @@
 use axum::extract::rejection::JsonRejection;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
+use servo_fetch_types::ErrorKind;
 
 use crate::tools::ToolError;
 
@@ -33,10 +34,11 @@ impl From<JsonRejection> for ApiError {
 impl From<ToolError> for ApiError {
     fn from(err: ToolError) -> Self {
         let message = err.to_string();
-        let status = match err {
-            ToolError::InvalidInput(_) => StatusCode::BAD_REQUEST,
-            ToolError::Fetch(_) => StatusCode::BAD_GATEWAY,
-            ToolError::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
+        let status = match err.kind() {
+            ErrorKind::InvalidUrl | ErrorKind::AddressNotAllowed | ErrorKind::InvalidParams => StatusCode::BAD_REQUEST,
+            ErrorKind::Timeout => StatusCode::GATEWAY_TIMEOUT,
+            ErrorKind::Internal => StatusCode::INTERNAL_SERVER_ERROR,
+            _ => StatusCode::BAD_GATEWAY,
         };
         Self { status, message }
     }

--- a/crates/servo-fetch-cli/src/tools/common.rs
+++ b/crates/servo-fetch-cli/src/tools/common.rs
@@ -26,7 +26,7 @@ pub(crate) fn fetch_semaphore() -> &'static Semaphore {
 pub(crate) fn validated_url(url: &str) -> ToolResult<String> {
     servo_fetch::validate_url(url)
         .map(|u| u.to_string())
-        .map_err(|e| ToolError::invalid(format!("{e:#}")))
+        .map_err(ToolError::from)
 }
 
 pub(crate) fn extract(page: &Page, url: &str, json: bool, selector: Option<&str>) -> ToolResult<String> {

--- a/crates/servo-fetch-cli/src/tools/crawl.rs
+++ b/crates/servo-fetch-cli/src/tools/crawl.rs
@@ -51,7 +51,7 @@ pub(crate) async fn crawl_pages(opts: CrawlOptions<'_>) -> ToolResult<Vec<(Strin
             };
             results.push((r.url, text));
         })
-        .map_err(|e| ToolError::fetch(format!("{e:#}")))?;
+        .map_err(ToolError::from)?;
         Ok(results)
     })
     .await

--- a/crates/servo-fetch-cli/src/tools/error.rs
+++ b/crates/servo-fetch-cli/src/tools/error.rs
@@ -1,31 +1,44 @@
 //! Error type for the shared [`crate::tools`] operations.
 
+use servo_fetch_types::ErrorKind;
+
 #[derive(Debug, thiserror::Error)]
-pub(crate) enum ToolError {
-    /// Caller-supplied input is malformed or violates a policy (bad URL, scheme, SSRF block, over-size limits).
-    #[error("{0}")]
-    InvalidInput(String),
-
-    /// Upstream page render or network operation failed.
-    #[error("{0}")]
-    Fetch(String),
-
-    /// Unexpected server-side failure (semaphore poisoning, task join panic, etc.).
-    #[error("{0}")]
-    Internal(String),
+#[error("{message}")]
+pub(crate) struct ToolError {
+    kind: ErrorKind,
+    message: String,
 }
 
 impl ToolError {
-    pub(crate) fn invalid(msg: impl Into<String>) -> Self {
-        Self::InvalidInput(msg.into())
+    pub(crate) fn internal(message: impl Into<String>) -> Self {
+        Self {
+            kind: ErrorKind::Internal,
+            message: message.into(),
+        }
     }
 
-    pub(crate) fn fetch(msg: impl Into<String>) -> Self {
-        Self::Fetch(msg.into())
+    pub(crate) fn kind(&self) -> ErrorKind {
+        self.kind
     }
+}
 
-    pub(crate) fn internal(msg: impl Into<String>) -> Self {
-        Self::Internal(msg.into())
+impl From<servo_fetch::Error> for ToolError {
+    fn from(err: servo_fetch::Error) -> Self {
+        use servo_fetch::Error as E;
+        let kind = match &err {
+            E::InvalidUrl { .. } => ErrorKind::InvalidUrl,
+            E::AddressNotAllowed { .. } => ErrorKind::AddressNotAllowed,
+            E::Cookies { .. } | E::Schema(_) | E::InvalidGlob(_) => ErrorKind::InvalidParams,
+            E::Timeout { .. } => ErrorKind::Timeout,
+            E::JavaScript { .. } => ErrorKind::Javascript,
+            E::Engine { .. } | E::Screenshot { .. } => ErrorKind::Engine,
+            E::Extract(_) | E::Io(_) => ErrorKind::Internal,
+            _ => ErrorKind::Other,
+        };
+        Self {
+            kind,
+            message: err.to_string(),
+        }
     }
 }
 

--- a/crates/servo-fetch-cli/src/tools/fetch.rs
+++ b/crates/servo-fetch-cli/src/tools/fetch.rs
@@ -18,7 +18,7 @@ pub(crate) async fn fetch_with(opts: FetchOptions) -> ToolResult<Page> {
     spawn_blocking(move || servo_fetch::blocking::fetch(&opts))
         .await
         .map_err(|e| ToolError::internal(e.to_string()))?
-        .map_err(|e| ToolError::fetch(format!("{e:#}")))
+        .map_err(ToolError::from)
 }
 
 pub(crate) async fn fetch_page(url: &str, timeout: u64, settle_ms: u64) -> ToolResult<Page> {
@@ -92,7 +92,7 @@ fn fetch_and_render(
             .settle(Duration::from_millis(settle_ms)),
     ) {
         Ok(p) => p,
-        Err(e) => return format!("[error] {e:#}"),
+        Err(e) => return format!("[error] {e}"),
     };
 
     let input = ExtractInput::new(&page.html, url)

--- a/crates/servo-fetch-cli/src/tools/map.rs
+++ b/crates/servo-fetch-cli/src/tools/map.rs
@@ -9,7 +9,7 @@ pub(crate) async fn map_with(opts: MapOptions) -> ToolResult<Vec<MappedUrl>> {
     tokio::task::spawn_blocking(move || servo_fetch::blocking::map(&opts))
         .await
         .map_err(|e| ToolError::internal(e.to_string()))?
-        .map_err(|e| ToolError::fetch(format!("{e:#}")))
+        .map_err(ToolError::from)
 }
 
 pub(crate) async fn discover_urls(

--- a/crates/servo-fetch-cli/tests/rpc.rs
+++ b/crates/servo-fetch-cli/tests/rpc.rs
@@ -55,6 +55,7 @@ fn unknown_method_returns_method_not_found() {
     let out = run_rpc("{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"nope\"}\n");
     assert_eq!(out[0]["id"], 2);
     assert_eq!(out[0]["error"]["code"], -32601);
+    assert_eq!(out[0]["error"]["data"]["kind"], "methodNotFound");
 }
 
 #[test]
@@ -62,6 +63,7 @@ fn malformed_line_returns_parse_error_with_null_id() {
     let out = run_rpc("not json\n");
     assert_eq!(out[0]["error"]["code"], -32700);
     assert!(out[0]["id"].is_null());
+    assert_eq!(out[0]["error"]["data"]["kind"], "parseError");
 }
 
 #[test]
@@ -98,6 +100,15 @@ fn cancel_of_unknown_id_is_ignored() {
 fn missing_required_param_is_invalid_params() {
     let out = run_rpc("{\"jsonrpc\":\"2.0\",\"id\":5,\"method\":\"fetch\",\"params\":{}}\n");
     assert_eq!(out[0]["error"]["code"], -32602);
+    assert_eq!(out[0]["error"]["data"]["kind"], "invalidParams");
+}
+
+#[test]
+fn fetch_blocked_address_reports_typed_kind() {
+    let out =
+        run_rpc("{\"jsonrpc\":\"2.0\",\"id\":6,\"method\":\"fetch\",\"params\":{\"url\":\"http://127.0.0.1/\"}}\n");
+    assert!(out[0].get("error").is_some(), "expected an error, got: {out:?}");
+    assert_eq!(out[0]["error"]["data"]["kind"], "addressNotAllowed", "got: {out:?}");
 }
 
 #[test]

--- a/crates/servo-fetch-types/src/wire.rs
+++ b/crates/servo-fetch-types/src/wire.rs
@@ -217,3 +217,34 @@ pub struct InitializeResult {
     /// Capabilities the server advertises.
     pub capabilities: ServerCapabilities,
 }
+
+/// Stable, surface-independent error category for programmatic handling.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "codegen", derive(ts_rs::TS), ts(export, export_to = "index.ts"))]
+#[serde(rename_all = "camelCase")]
+pub enum ErrorKind {
+    /// The URL is malformed or uses a disallowed scheme.
+    InvalidUrl,
+    /// The page did not finish loading within the timeout.
+    Timeout,
+    /// The URL resolves to a private or reserved address (SSRF block).
+    AddressNotAllowed,
+    /// The browser engine failed to render the page.
+    Engine,
+    /// JavaScript evaluation failed.
+    Javascript,
+    /// A request parameter was missing, malformed, or out of range.
+    InvalidParams,
+    /// The requested method does not exist.
+    MethodNotFound,
+    /// A frame could not be parsed.
+    ParseError,
+    /// The request was cancelled before completing.
+    RequestCancelled,
+    /// A request reused an in-flight request id.
+    DuplicateRequest,
+    /// An unexpected server-side failure.
+    Internal,
+    /// An error that does not map to a known category.
+    Other,
+}


### PR DESCRIPTION
## Summary

Introduce a shared, typed `ErrorKind` (in the wire crate, codegen'd for the JS client) so failures carry a stable, surface-independent category. `ToolError` now holds the kind as a single source (std::io::Error-style `kind()`), with one `From<servo_fetch::Error>` classifier.

## Related issues

Part of the warm-process model; follows #309.

## Test Plan

- `cargo test`: all passed

## Checklist

- [x] Ran `cargo +nightly fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
- [ ] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed
- [x] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it