### PR TITLE
feat: add custom request headers support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6307,6 +6307,7 @@ dependencies = [
  "flate2",
  "globset",
  "htmd",
+ "http 1.4.0",
  "humantime",
  "image",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ flate2 = "1"
 futures-util = "0.3"
 globset = "0.4"
 htmd = "0.5"
+http = "1"
 humantime = "2"
 image = { version = "0.25", default-features = false, features = ["png"] }
 libc = "0.2"

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ servo-fetch "https://example.com" --format png -o page.png # PNG screenshot
 servo-fetch "https://example.com" --js "document.title"    # Run JavaScript
 servo-fetch "https://example.com" --schema schema.json     # Schema-driven JSON
 servo-fetch "https://example.com" --cookies cookies.txt    # Send session cookies
+servo-fetch "https://example.com" -H "Authorization: Bearer TOKEN" # Custom request header
 servo-fetch URL1 URL2 URL3                                 # Parallel batch
 servo-fetch "https://example.com" --output page.md         # Save to a single file
 servo-fetch URL1 URL2 --output-dir ./out/                  # Save each URL to its own file

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ servo-fetch "https://example.com" --format png -o page.png # PNG screenshot
 servo-fetch "https://example.com" --js "document.title"    # Run JavaScript
 servo-fetch "https://example.com" --schema schema.json     # Schema-driven JSON
 servo-fetch "https://example.com" --cookies cookies.txt    # Send session cookies
-servo-fetch "https://example.com" -H "Authorization: Bearer TOKEN" # Custom request header
+servo-fetch "https://example.com" -H "X-Api-Key: KEY"      # Custom request header
 servo-fetch URL1 URL2 URL3                                 # Parallel batch
 servo-fetch "https://example.com" --output page.md         # Save to a single file
 servo-fetch URL1 URL2 --output-dir ./out/                  # Save each URL to its own file

--- a/bindings/node/README.md
+++ b/bindings/node/README.md
@@ -83,7 +83,7 @@ npx servo-fetch "https://example.com" --format png -o page.png
 | `map(url, opts?)` | `Promise<MappedUrl[]>` | `map` |
 | `version()` | `Promise<string>` | `--version` |
 
-Single-page calls accept `{ timeout, settle, userAgent, cookiesFile, selector, visibility, signal }`.
+Single-page calls accept `{ timeout, settle, userAgent, cookiesFile, headers, selector, visibility, signal }`; `crawl` and `map` also accept `headers`.
 `SERVO_FETCH_BINARY_PATH` overrides binary resolution.
 
 ## Develop

--- a/bindings/node/src/generated/index.ts
+++ b/bindings/node/src/generated/index.ts
@@ -159,7 +159,11 @@ userAgent?: string,
 /**
  * Path to a Netscape-format cookies.txt file.
  */
-cookiesFile?: string, };
+cookiesFile?: string, 
+/**
+ * Custom request headers.
+ */
+headers?: { [key in string]: string }, };
 
 /**
  * Terminal summary returned by the `crawl` method once the stream completes.
@@ -219,7 +223,11 @@ userAgent?: string,
 /**
  * Path to a Netscape-format cookies.txt file.
  */
-cookiesFile?: string, };
+cookiesFile?: string, 
+/**
+ * Custom request headers.
+ */
+headers?: { [key in string]: string }, };
 
 /**
  * Result of evaluating a JavaScript expression on a page.
@@ -267,6 +275,10 @@ userAgent?: string,
  */
 cookiesFile?: string, 
 /**
+ * Custom request headers.
+ */
+headers?: { [key in string]: string }, 
+/**
  * Visibility filtering policy (default: moderate).
  */
 visibility?: Visibility, };
@@ -308,6 +320,10 @@ userAgent?: string,
  * Path to a Netscape-format cookies.txt file.
  */
 cookiesFile?: string, 
+/**
+ * Custom request headers.
+ */
+headers?: { [key in string]: string }, 
 /**
  * Visibility filtering policy (default: moderate).
  */
@@ -361,7 +377,11 @@ timeout?: number,
 /**
  * Skip the HTML link fallback when no sitemap is found.
  */
-noFallback?: boolean, };
+noFallback?: boolean, 
+/**
+ * Custom request headers.
+ */
+headers?: { [key in string]: string }, };
 
 /**
  * A URL discovered by sitemap mapping.
@@ -404,6 +424,10 @@ userAgent?: string,
  * Path to a Netscape-format cookies.txt file.
  */
 cookiesFile?: string, 
+/**
+ * Custom request headers.
+ */
+headers?: { [key in string]: string }, 
 /**
  * Visibility filtering policy (default: moderate).
  */
@@ -449,7 +473,11 @@ userAgent?: string,
 /**
  * Path to a Netscape-format cookies.txt file.
  */
-cookiesFile?: string, };
+cookiesFile?: string, 
+/**
+ * Custom request headers.
+ */
+headers?: { [key in string]: string }, };
 
 /**
  * Capabilities advertised by the server (none yet; reserved for forward compatibility).

--- a/bindings/node/src/index.ts
+++ b/bindings/node/src/index.ts
@@ -28,6 +28,11 @@ function asArray(value: string | string[] | undefined): string[] {
   return Array.isArray(value) ? value : [value];
 }
 
+function headerArgs(headers: Record<string, string> | undefined): string[] {
+  if (headers == null) return [];
+  return Object.entries(headers).flatMap(([name, value]) => ["-H", `${name}: ${value}`]);
+}
+
 function parseJson<T>(raw: string): T {
   try {
     return JSON.parse(raw) as T;
@@ -44,6 +49,7 @@ function commonArgs(o: FetchOptions): string[] {
   if (o.cookiesFile != null) args.push("--cookies", o.cookiesFile);
   if (o.visibility != null) args.push("--visibility", o.visibility);
   if (o.allowPrivateAddresses) args.push("--allow-private-addresses");
+  args.push(...headerArgs(o.headers));
   return args;
 }
 
@@ -162,6 +168,7 @@ function crawlArgs(url: string, o: CrawlOptions): string[] {
   if (o.cookiesFile != null) args.push("--cookies", o.cookiesFile);
   if (o.selector != null) args.push("--selector", o.selector);
   if (o.allowPrivateAddresses) args.push("--allow-private-addresses");
+  args.push(...headerArgs(o.headers));
   args.push("--", url);
   return args;
 }
@@ -210,6 +217,7 @@ export async function map(url: string, options: MapOptions = {}): Promise<Mapped
   if (options.timeout != null) args.push("-t", String(options.timeout));
   if (options.noFallback) args.push("--no-fallback");
   if (options.allowPrivateAddresses) args.push("--allow-private-addresses");
+  args.push(...headerArgs(options.headers));
   args.push("--", url);
   return parseJson<MappedUrl[]>(await runText(args, { signal: options.signal }));
 }

--- a/bindings/node/src/types.ts
+++ b/bindings/node/src/types.ts
@@ -14,6 +14,8 @@ export interface FetchOptions {
   selector?: string;
   /** Visibility filtering policy. Default: "moderate". */
   visibility?: Visibility;
+  /** Custom request headers sent with the navigation request. */
+  headers?: Record<string, string>;
   /** Allow requests to loopback/private addresses, relaxing the SSRF guard. */
   allowPrivateAddresses?: boolean;
   /** Abort the underlying process. */
@@ -52,6 +54,8 @@ export interface CrawlOptions {
   selector?: string;
   /** Allow requests to loopback/private addresses, relaxing the SSRF guard (for local testing). */
   allowPrivateAddresses?: boolean;
+  /** Custom request headers sent with each page's navigation request. */
+  headers?: Record<string, string>;
   signal?: AbortSignal;
 }
 
@@ -83,5 +87,7 @@ export interface MapOptions {
   noFallback?: boolean;
   /** Allow requests to loopback/private addresses, relaxing the SSRF guard (for local testing). */
   allowPrivateAddresses?: boolean;
+  /** Custom request headers sent with each discovery request. */
+  headers?: Record<string, string>;
   signal?: AbortSignal;
 }

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -67,6 +67,21 @@ pages = client.crawl("https://app.example.com", cookies_file="cookies.txt", max_
 A missing or malformed file raises `servo_fetch.CookieError`. Cookies are scoped
 to the target's site, so out-of-scope entries in the file are ignored.
 
+## Custom Headers
+
+Pass a `dict[str, str]` via `headers` to add request headers (e.g. API tokens).
+Accepted by `fetch`, `Client.fetch` / `Client.crawl` / `Client.map`, and their
+async equivalents:
+
+```python
+import servo_fetch
+
+page = servo_fetch.fetch("https://api.example.com", headers={"Authorization": "Bearer TOKEN"})
+```
+
+Framing headers (`Host`, `Content-Length`, …) are rejected, and `User-Agent` /
+`Cookie` have dedicated options; invalid headers raise `ValueError`.
+
 ## Async
 
 ```python

--- a/bindings/python/python/servo_fetch/_native.pyi
+++ b/bindings/python/python/servo_fetch/_native.pyi
@@ -117,6 +117,7 @@ class Client:
         javascript: str | None = None,
         schema: Schema | None = None,
         cookies_file: str | os.PathLike[str] | None = None,
+        headers: dict[str, str] | None = None,
     ) -> Page: ...
     def crawl(
         self,
@@ -129,6 +130,7 @@ class Client:
         concurrency: int = 1,
         delay_ms: int = 0,
         cookies_file: str | os.PathLike[str] | None = None,
+        headers: dict[str, str] | None = None,
     ) -> list[CrawlResult]: ...
     def crawl_each(
         self,
@@ -143,6 +145,7 @@ class Client:
         delay_ms: int = 0,
         abort: threading.Event | None = None,
         cookies_file: str | os.PathLike[str] | None = None,
+        headers: dict[str, str] | None = None,
     ) -> None: ...
     def map(
         self,
@@ -151,6 +154,7 @@ class Client:
         limit: int = 5000,
         include: str | list[str] | None = None,
         exclude: str | list[str] | None = None,
+        headers: dict[str, str] | None = None,
     ) -> list[MappedUrl]: ...
 
 class ServoFetchError(Exception): ...
@@ -171,4 +175,5 @@ def fetch(
     javascript: str | None = None,
     schema: Schema | None = None,
     cookies_file: str | os.PathLike[str] | None = None,
+    headers: dict[str, str] | None = None,
 ) -> Page: ...

--- a/bindings/python/python/servo_fetch/async_api.py
+++ b/bindings/python/python/servo_fetch/async_api.py
@@ -27,6 +27,7 @@ async def fetch_async(
     javascript: str | None = None,
     schema: Schema | None = None,
     cookies_file: str | os.PathLike[str] | None = None,
+    headers: dict[str, str] | None = None,
 ) -> Page:
     """Asynchronously fetch a single URL."""
     return await asyncio.to_thread(
@@ -39,6 +40,7 @@ async def fetch_async(
         javascript=javascript,
         schema=schema,
         cookies_file=cookies_file,
+        headers=headers,
     )
 
 
@@ -64,6 +66,7 @@ class AsyncClient:
         javascript: str | None = None,
         schema: Schema | None = None,
         cookies_file: str | os.PathLike[str] | None = None,
+        headers: dict[str, str] | None = None,
     ) -> Page:
         return await asyncio.to_thread(
             self._inner.fetch,
@@ -74,6 +77,7 @@ class AsyncClient:
             javascript=javascript,
             schema=schema,
             cookies_file=cookies_file,
+            headers=headers,
         )
 
     async def crawl(
@@ -87,6 +91,7 @@ class AsyncClient:
         concurrency: int = 1,
         delay_ms: int = 0,
         cookies_file: str | os.PathLike[str] | None = None,
+        headers: dict[str, str] | None = None,
     ) -> list[CrawlResult]:
         return await asyncio.to_thread(
             self._inner.crawl,
@@ -98,6 +103,7 @@ class AsyncClient:
             concurrency=concurrency,
             delay_ms=delay_ms,
             cookies_file=cookies_file,
+            headers=headers,
         )
 
     async def crawl_stream(
@@ -111,6 +117,7 @@ class AsyncClient:
         concurrency: int = 1,
         delay_ms: int = 0,
         cookies_file: str | os.PathLike[str] | None = None,
+        headers: dict[str, str] | None = None,
     ) -> AsyncIterator[CrawlResult]:
         """Crawl a site, yielding each page as it completes."""
         loop = asyncio.get_running_loop()
@@ -134,6 +141,7 @@ class AsyncClient:
                     concurrency=concurrency,
                     delay_ms=delay_ms,
                     cookies_file=cookies_file,
+                    headers=headers,
                 )
             finally:
                 fut = asyncio.run_coroutine_threadsafe(queue.put(_SENTINEL), loop)
@@ -156,6 +164,7 @@ class AsyncClient:
         limit: int = 5000,
         include: str | list[str] | None = None,
         exclude: str | list[str] | None = None,
+        headers: dict[str, str] | None = None,
     ) -> list[MappedUrl]:
         return await asyncio.to_thread(
             self._inner.map,
@@ -163,6 +172,7 @@ class AsyncClient:
             limit=limit,
             include=include,
             exclude=exclude,
+            headers=headers,
         )
 
     async def __aenter__(self) -> AsyncClient:

--- a/bindings/python/src/client.rs
+++ b/bindings/python/src/client.rs
@@ -1,5 +1,6 @@
 //! `Client` pyclass: shared defaults + per-call overrides.
 
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -35,7 +36,7 @@ impl Client {
     }
 
     /// Fetch a single URL, merging client defaults with per-call overrides.
-    #[pyo3(signature = (url, *, timeout=None, settle=None, screenshot=false, javascript=None, schema=None, cookies_file=None))]
+    #[pyo3(signature = (url, *, timeout=None, settle=None, screenshot=false, javascript=None, schema=None, cookies_file=None, headers=None))]
     #[allow(clippy::too_many_arguments)]
     fn fetch(
         &self,
@@ -47,6 +48,7 @@ impl Client {
         javascript: Option<String>,
         schema: Option<Bound<'_, Schema>>,
         cookies_file: Option<PathBuf>,
+        headers: Option<HashMap<String, String>>,
     ) -> PyResult<Page> {
         let timeout = timeout.or(Some(self.timeout.as_secs_f64()));
         let settle = settle.or(Some(self.settle.as_secs_f64()));
@@ -59,6 +61,7 @@ impl Client {
             javascript,
             schema,
             cookies_file,
+            headers,
         })?;
         let page = py
             .detach(|| servo_fetch::blocking::fetch(&prepared.opts))
@@ -82,6 +85,7 @@ impl Client {
         concurrency=1,
         delay_ms=0,
         cookies_file=None,
+        headers=None,
     ))]
     #[allow(clippy::too_many_arguments)]
     fn crawl(
@@ -95,6 +99,7 @@ impl Client {
         concurrency: usize,
         delay_ms: u64,
         cookies_file: Option<PathBuf>,
+        headers: Option<HashMap<String, String>>,
     ) -> PyResult<Vec<CrawlResult>> {
         let opts = build_crawl_opts(
             &url,
@@ -108,13 +113,14 @@ impl Client {
             concurrency,
             delay_ms,
             cookies_file,
+            headers,
         )?;
         let results = py.detach(|| servo_fetch::blocking::crawl(&opts)).map_err(map_error)?;
         Ok(results.into_iter().map(CrawlResult::from_core).collect())
     }
 
     /// Crawl a site, invoking `callback(CrawlResult)` as each page completes.
-    #[pyo3(signature = (url, callback, *, max_pages=50, max_depth=3, include=None, exclude=None, concurrency=1, delay_ms=0, abort=None, cookies_file=None))]
+    #[pyo3(signature = (url, callback, *, max_pages=50, max_depth=3, include=None, exclude=None, concurrency=1, delay_ms=0, abort=None, cookies_file=None, headers=None))]
     #[allow(clippy::too_many_arguments)]
     fn crawl_each(
         &self,
@@ -129,6 +135,7 @@ impl Client {
         delay_ms: u64,
         abort: Option<Py<PyAny>>,
         cookies_file: Option<PathBuf>,
+        headers: Option<HashMap<String, String>>,
     ) -> PyResult<()> {
         let opts = build_crawl_opts(
             &url,
@@ -142,6 +149,7 @@ impl Client {
             concurrency,
             delay_ms,
             cookies_file,
+            headers,
         )?;
 
         let stop = AtomicBool::new(false);
@@ -186,7 +194,8 @@ impl Client {
     }
 
     /// Discover URLs on a site via sitemap and link extraction (no rendering).
-    #[pyo3(signature = (url, *, limit=5000, include=None, exclude=None))]
+    #[pyo3(signature = (url, *, limit=5000, include=None, exclude=None, headers=None))]
+    #[allow(clippy::too_many_arguments)]
     fn map(
         &self,
         py: Python<'_>,
@@ -194,6 +203,7 @@ impl Client {
         limit: usize,
         include: Option<&Bound<'_, PyAny>>,
         exclude: Option<&Bound<'_, PyAny>>,
+        headers: Option<HashMap<String, String>>,
     ) -> PyResult<Vec<MappedUrl>> {
         validate::url(&url)?;
         let include = strings_from_any(include)?;
@@ -207,6 +217,9 @@ impl Client {
             .exclude(&exclude_refs);
         if let Some(ua) = self.user_agent.as_deref() {
             opts = opts.user_agent(ua);
+        }
+        if let Some(map) = &headers {
+            opts = opts.headers(servo_fetch::headers::from_pairs(map).map_err(map_error)?);
         }
         let urls = py.detach(|| servo_fetch::blocking::map(&opts)).map_err(map_error)?;
         Ok(urls.into_iter().map(MappedUrl::from_core).collect())
@@ -237,6 +250,7 @@ fn build_crawl_opts(
     concurrency: usize,
     delay_ms: u64,
     cookies_file: Option<PathBuf>,
+    headers: Option<HashMap<String, String>>,
 ) -> PyResult<servo_fetch::CrawlOptions> {
     validate::url(url)?;
     let include = strings_from_any(include)?;
@@ -264,6 +278,9 @@ fn build_crawl_opts(
         if !cookies.is_empty() {
             opts = opts.cookies(cookies);
         }
+    }
+    if let Some(map) = &headers {
+        opts = opts.headers(servo_fetch::headers::from_pairs(map).map_err(map_error)?);
     }
     Ok(opts)
 }

--- a/bindings/python/src/errors.rs
+++ b/bindings/python/src/errors.rs
@@ -61,6 +61,7 @@ pub(crate) fn map_error(err: servo_fetch::Error) -> PyErr {
         servo_fetch::Error::Engine { source, .. } => EngineError::new_err(source.to_string()),
         servo_fetch::Error::Schema(e) => SchemaError::new_err(e.to_string()),
         servo_fetch::Error::Cookies { .. } => CookieError::new_err(err.to_string()),
+        servo_fetch::Error::InvalidHeader(msg) => pyo3::exceptions::PyValueError::new_err(msg.clone()),
         _ => ServoFetchError::new_err(err.to_string()),
     }
 }

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -1,5 +1,6 @@
 //! PyO3 bindings for servo-fetch.
 
+use std::collections::HashMap;
 use std::path::PathBuf;
 
 use pyo3::prelude::*;
@@ -18,7 +19,7 @@ use crate::opts::{BuildOpts, prepare};
 
 /// Fetch, render, and extract a single URL.
 #[pyfunction]
-#[pyo3(signature = (url, *, timeout=None, settle=None, user_agent=None, screenshot=false, javascript=None, schema=None, cookies_file=None))]
+#[pyo3(signature = (url, *, timeout=None, settle=None, user_agent=None, screenshot=false, javascript=None, schema=None, cookies_file=None, headers=None))]
 #[allow(clippy::too_many_arguments)]
 fn fetch(
     py: Python<'_>,
@@ -30,6 +31,7 @@ fn fetch(
     javascript: Option<String>,
     schema: Option<Bound<'_, schema::Schema>>,
     cookies_file: Option<PathBuf>,
+    headers: Option<HashMap<String, String>>,
 ) -> PyResult<page::Page> {
     let prepared = prepare(BuildOpts {
         url,
@@ -40,6 +42,7 @@ fn fetch(
         javascript,
         schema,
         cookies_file,
+        headers,
     })?;
     let servo_page = py
         .detach(|| servo_fetch::blocking::fetch(&prepared.opts))

--- a/bindings/python/src/opts.rs
+++ b/bindings/python/src/opts.rs
@@ -1,5 +1,6 @@
 //! Build [`servo_fetch::FetchOptions`] from Python kwargs.
 
+use std::collections::HashMap;
 use std::path::PathBuf;
 
 use pyo3::prelude::*;
@@ -16,6 +17,7 @@ pub(crate) struct BuildOpts<'py> {
     pub javascript: Option<String>,
     pub schema: Option<Bound<'py, Schema>>,
     pub cookies_file: Option<PathBuf>,
+    pub headers: Option<HashMap<String, String>>,
 }
 
 pub(crate) struct Prepared {
@@ -60,6 +62,9 @@ pub(crate) fn prepare(args: BuildOpts<'_>) -> PyResult<Prepared> {
         if !cookies.is_empty() {
             opts = opts.cookies(cookies);
         }
+    }
+    if let Some(map) = &args.headers {
+        opts = opts.headers(servo_fetch::headers::from_pairs(map).map_err(crate::errors::map_error)?);
     }
 
     Ok(Prepared {

--- a/bindings/python/tests/test_validation.py
+++ b/bindings/python/tests/test_validation.py
@@ -18,6 +18,9 @@ import servo_fetch
         ({"settle": -1.0}, "settle"),
         ({"settle": 61.0}, "settle"),
         ({"javascript": "a" * 1_000_001}, "javascript source length"),
+        ({"headers": {"Host": "evil"}}, "managed by the engine"),
+        ({"headers": {"User-Agent": "x"}}, "custom header"),
+        ({"headers": {"X-A": "a\r\nb"}}, "invalid value"),
     ],
     ids=[
         "timeout_negative",
@@ -28,6 +31,9 @@ import servo_fetch
         "settle_negative",
         "settle_above_max",
         "js_too_long",
+        "header_reserved",
+        "header_user_agent",
+        "header_crlf",
     ],
 )
 def test_fetch_rejects_invalid_kwargs(kwargs: dict, match: str) -> None:

--- a/crates/servo-fetch-cli/README.md
+++ b/crates/servo-fetch-cli/README.md
@@ -165,6 +165,7 @@ Self-contained `/health` probe for any orchestrator that runs a command and insp
 | `--settle <MS>` | Extra wait after load event in ms (default: 0, max: 10000) |
 | `--user-agent <UA>` | Override the User-Agent string |
 | `--cookies <FILE>` | Load session cookies from a Netscape/Mozilla cookies.txt file |
+| `-H, --header <NAME: VALUE>` | Custom request header, repeatable (e.g. `-H "X-Api-Key: secret"`) |
 | `-v, --verbose` | Increase log verbosity (`-v` info, `-vv` debug, `-vvv` trace) |
 | `-q, --quiet` | Suppress all logs except errors |
 
@@ -198,6 +199,7 @@ Self-contained `/health` probe for any orchestrator that runs a command and insp
 | `--delay-ms <MS>` | Minimum dispatch interval in ms (default: 500; 0 disables rate limiting) |
 | `--user-agent <UA>` | Override the User-Agent string |
 | `--cookies <FILE>` | Load session cookies from a Netscape/Mozilla cookies.txt file |
+| `-H, --header <NAME: VALUE>` | Custom request header, repeatable (e.g. `-H "X-Api-Key: secret"`) |
 | `-t, --timeout <SECS>` | Page load timeout in seconds per page (default: 30) |
 | `--settle <MS>` | Extra wait after load event in ms per page (default: 0, max: 10000) |
 
@@ -212,8 +214,13 @@ Self-contained `/health` probe for any orchestrator that runs a command and insp
 | `--exclude <GLOB>` | URL path patterns to exclude |
 | `--format json` | Output as JSON array with lastmod metadata |
 | `--user-agent <UA>` | Override the User-Agent string |
+| `-H, --header <NAME: VALUE>` | Custom request header, repeatable (e.g. `-H "X-Api-Key: secret"`) |
 | `-t, --timeout <SECS>` | HTTP request timeout in seconds (default: 30) |
 | `--no-fallback` | Skip HTML link extraction fallback |
+
+### Custom headers
+
+`-H, --header "Name: Value"` is repeatable and applies to the navigation request (curl-compatible; `Name;` sends an empty value), on `fetch`, `crawl`, and `map`. Framing headers (`Host`, `Content-Length`, `Connection`, `Transfer-Encoding`, …) are rejected; set `User-Agent` via `--user-agent` and cookies via `--cookies`. Avoid sending credentials to URLs that may redirect across origins.
 
 ## Logging
 

--- a/crates/servo-fetch-cli/src/cli.rs
+++ b/crates/servo-fetch-cli/src/cli.rs
@@ -70,6 +70,10 @@ pub(crate) struct FetchArgs {
     #[arg(long, value_name = "FILE")]
     pub cookies: Option<PathBuf>,
 
+    /// Custom request header, repeatable (e.g. -H "X-Api-Key: secret")
+    #[arg(short = 'H', long = "header", value_name = "NAME: VALUE")]
+    pub headers: Vec<String>,
+
     /// Path to a CSS-selector schema file for structured JSON extraction
     #[arg(long, value_name = "FILE", conflicts_with_all = ["js", "selector", "format"])]
     pub schema: Option<PathBuf>,
@@ -227,6 +231,10 @@ pub(crate) struct CrawlArgs {
     #[arg(long, value_name = "FILE")]
     pub cookies: Option<PathBuf>,
 
+    /// Custom request header, repeatable (e.g. -H "X-Api-Key: secret")
+    #[arg(short = 'H', long = "header", value_name = "NAME: VALUE")]
+    pub headers: Vec<String>,
+
     /// Write each crawled page's output to a file in this directory.
     #[arg(long, value_name = "DIR")]
     pub output_dir: Option<PathBuf>,
@@ -264,6 +272,10 @@ pub(crate) struct MapArgs {
     /// Timeout in seconds per HTTP request
     #[arg(short = 't', long, default_value_t = 30, value_parser = value_parser!(u64).range(1..), value_name = "SECS")]
     pub timeout: u64,
+
+    /// Custom request header, repeatable (e.g. -H "X-Api-Key: secret")
+    #[arg(short = 'H', long = "header", value_name = "NAME: VALUE")]
+    pub headers: Vec<String>,
 }
 
 #[derive(Args, Debug)]

--- a/crates/servo-fetch-cli/src/commands/crawl.rs
+++ b/crates/servo-fetch-cli/src/commands/crawl.rs
@@ -19,6 +19,7 @@ pub(crate) fn run(args: &CrawlArgs) -> anyhow::Result<()> {
     if let Some(path) = &args.cookies {
         opts = opts.cookies(servo_fetch::load_cookies(path)?);
     }
+    opts = opts.headers(servo_fetch::headers::parse_lines(&args.headers)?);
 
     let progress = Progress::new();
     let mut completed = 0u64;

--- a/crates/servo-fetch-cli/src/commands/fetch.rs
+++ b/crates/servo-fetch-cli/src/commands/fetch.rs
@@ -85,6 +85,7 @@ async fn run_batch(args: &FetchArgs, urls: &[String]) -> Result<()> {
 
     let schema = args.schema.as_ref().map(|p| load_schema(p)).transpose()?;
     let cookies = args.cookies.as_ref().map(servo_fetch::load_cookies).transpose()?;
+    let headers = servo_fetch::headers::parse_lines(&args.headers)?;
 
     let sem = std::sync::Arc::new(tokio::sync::Semaphore::new(4));
     let (tx, mut rx) = tokio::sync::mpsc::channel::<(String, std::result::Result<Page, servo_fetch::Error>)>(total);
@@ -99,6 +100,7 @@ async fn run_batch(args: &FetchArgs, urls: &[String]) -> Result<()> {
         let schema = schema.clone();
         let visibility = args.visibility.to_policy();
         let cookies = cookies.clone();
+        let headers = headers.clone();
         tokio::task::spawn_blocking(move || {
             let mut opts = FetchOptions::new(&url_str)
                 .timeout(Duration::from_secs(timeout))
@@ -113,6 +115,7 @@ async fn run_batch(args: &FetchArgs, urls: &[String]) -> Result<()> {
             if let Some(c) = cookies {
                 opts = opts.cookies(c);
             }
+            opts = opts.headers(headers);
             let result = servo_fetch::blocking::fetch(&opts);
             let _ = tx.blocking_send((url_str, result));
             drop(permit);
@@ -207,6 +210,7 @@ fn build_fetch_options(args: &FetchArgs, url: &str) -> Result<FetchOptions> {
         Some(ref path) => opts.cookies(servo_fetch::load_cookies(path)?),
         None => opts,
     };
+    let opts = opts.headers(servo_fetch::headers::parse_lines(&args.headers)?);
     Ok(opts)
 }
 

--- a/crates/servo-fetch-cli/src/commands/map.rs
+++ b/crates/servo-fetch-cli/src/commands/map.rs
@@ -19,6 +19,7 @@ pub(crate) fn run(args: &MapArgs) -> anyhow::Result<()> {
     if let Some(ref ua) = args.user_agent {
         opts = opts.user_agent(ua);
     }
+    opts = opts.headers(servo_fetch::headers::parse_lines(&args.headers)?);
 
     let results = servo_fetch::blocking::map(&opts)?;
 

--- a/crates/servo-fetch-cli/src/rpc/dispatch.rs
+++ b/crates/servo-fetch-cli/src/rpc/dispatch.rs
@@ -1,11 +1,12 @@
 //! JSON-RPC method handlers — request DTO in, typed wire result out.
 
+use std::collections::BTreeMap;
 use std::time::{Duration, Instant};
 
 use base64::Engine as _;
 use serde::de::DeserializeOwned;
 use serde_json::{Value, json};
-use servo_fetch::{FetchOptions, MapOptions, VisibilityPolicy};
+use servo_fetch::{FetchOptions, HeaderMap, MapOptions, VisibilityPolicy};
 use servo_fetch_types::{
     CrawlRequest, CrawlStats, ErrorKind, EvaluateRequest, ExtractRequest, FetchFormat, FetchRequest, InitializeResult,
     MapRequest, SchemaExtractRequest, ScreenshotRequest, ServerCapabilities, ServerInfo, Visibility,
@@ -59,7 +60,7 @@ async fn fetch(params: Value) -> Result<Value, ResponseError> {
     let opts = FetchOptions::new(&url)
         .timed(req.timeout, req.settle_ms)
         .visibility(visibility_policy(req.visibility));
-    let page = tools::fetch_with(with_ua_and_cookies(opts, req.user_agent, req.cookies_file)?).await?;
+    let page = tools::fetch_with(with_overrides(opts, req.user_agent, req.cookies_file, req.headers)?).await?;
 
     match req.format.unwrap_or_default() {
         FetchFormat::Html => Ok(json!(page.html)),
@@ -82,7 +83,7 @@ async fn extract(params: Value) -> Result<Value, ResponseError> {
     let opts = FetchOptions::new(&url)
         .timed(req.timeout, req.settle_ms)
         .visibility(visibility_policy(req.visibility));
-    let page = tools::fetch_with(with_ua_and_cookies(opts, req.user_agent, req.cookies_file)?).await?;
+    let page = tools::fetch_with(with_overrides(opts, req.user_agent, req.cookies_file, req.headers)?).await?;
 
     let data = match req.selector.as_deref() {
         Some(s) => page.article_with_selector(&url, s),
@@ -96,7 +97,7 @@ async fn screenshot(params: Value) -> Result<Value, ResponseError> {
     let url = tools::validated_url(&req.url)?;
 
     let opts = FetchOptions::screenshot(&url, req.full_page.unwrap_or(false)).timed(req.timeout, req.settle_ms);
-    let page = tools::fetch_with(with_ua_and_cookies(opts, req.user_agent, req.cookies_file)?).await?;
+    let page = tools::fetch_with(with_overrides(opts, req.user_agent, req.cookies_file, req.headers)?).await?;
 
     let png = page
         .screenshot_png()
@@ -114,7 +115,7 @@ async fn evaluate(params: Value) -> Result<Value, ResponseError> {
     let url = tools::validated_url(&req.url)?;
 
     let opts = FetchOptions::javascript(&url, &req.expression).timed(req.timeout, req.settle_ms);
-    let page = tools::fetch_with(with_ua_and_cookies(opts, req.user_agent, req.cookies_file)?).await?;
+    let page = tools::fetch_with(with_overrides(opts, req.user_agent, req.cookies_file, req.headers)?).await?;
 
     let result = page.js_result.unwrap_or_default();
     Ok(serde_json::to_value(crate::wire::evaluate_result(
@@ -134,7 +135,7 @@ async fn extract_schema(params: Value) -> Result<Value, ResponseError> {
         .timed(req.timeout, req.settle_ms)
         .visibility(visibility_policy(req.visibility))
         .schema(schema);
-    let page = tools::fetch_with(with_ua_and_cookies(opts, req.user_agent, req.cookies_file)?).await?;
+    let page = tools::fetch_with(with_overrides(opts, req.user_agent, req.cookies_file, req.headers)?).await?;
 
     let extracted = page.extracted.unwrap_or(Value::Null);
     Ok(serde_json::to_value(crate::wire::schema_extract(&url, extracted))?)
@@ -161,6 +162,7 @@ async fn map(params: Value) -> Result<Value, ResponseError> {
     if req.no_fallback.unwrap_or(false) {
         opts = opts.no_fallback(true);
     }
+    opts = opts.headers(wire_headers(req.headers)?);
     let entries = tools::map_with(opts).await?;
 
     let mapped: Vec<_> = entries.iter().map(crate::wire::mapped_url).collect();
@@ -198,6 +200,7 @@ async fn crawl(params: Value, id: &RequestId, tx: &UnboundedSender<String>) -> R
     if let Some(path) = req.cookies_file {
         opts = opts.cookies(load_cookies(&path)?);
     }
+    opts = opts.headers(wire_headers(req.headers)?);
 
     // Stream each page as a `$/progress` notification. Buffering is bounded by
     // the crawl `limit`; the run loop cancels by dropping this future.
@@ -249,10 +252,11 @@ fn glob_refs(globs: &[String]) -> Vec<&str> {
     globs.iter().map(String::as_str).collect()
 }
 
-fn with_ua_and_cookies(
+fn with_overrides(
     mut opts: FetchOptions,
     user_agent: Option<String>,
     cookies_file: Option<String>,
+    headers: Option<BTreeMap<String, String>>,
 ) -> Result<FetchOptions, ResponseError> {
     if let Some(ua) = user_agent {
         opts = opts.user_agent(ua);
@@ -260,7 +264,14 @@ fn with_ua_and_cookies(
     if let Some(path) = cookies_file {
         opts = opts.cookies(load_cookies(&path)?);
     }
-    Ok(opts)
+    Ok(opts.headers(wire_headers(headers)?))
+}
+
+fn wire_headers(headers: Option<BTreeMap<String, String>>) -> Result<HeaderMap, ResponseError> {
+    match headers {
+        Some(map) => servo_fetch::headers::from_pairs(&map).map_err(|e| ResponseError::invalid_params(e.to_string())),
+        None => Ok(HeaderMap::new()),
+    }
 }
 
 fn load_cookies(path: &str) -> Result<Vec<servo_fetch::CookieSpec>, ResponseError> {

--- a/crates/servo-fetch-cli/src/tools/error.rs
+++ b/crates/servo-fetch-cli/src/tools/error.rs
@@ -28,7 +28,7 @@ impl From<servo_fetch::Error> for ToolError {
         let kind = match &err {
             E::InvalidUrl { .. } => ErrorKind::InvalidUrl,
             E::AddressNotAllowed { .. } => ErrorKind::AddressNotAllowed,
-            E::Cookies { .. } | E::Schema(_) | E::InvalidGlob(_) => ErrorKind::InvalidParams,
+            E::Cookies { .. } | E::Schema(_) | E::InvalidGlob(_) | E::InvalidHeader(_) => ErrorKind::InvalidParams,
             E::Timeout { .. } => ErrorKind::Timeout,
             E::JavaScript { .. } => ErrorKind::Javascript,
             E::Engine { .. } | E::Screenshot { .. } => ErrorKind::Engine,

--- a/crates/servo-fetch-types/src/request.rs
+++ b/crates/servo-fetch-types/src/request.rs
@@ -1,6 +1,8 @@
 //! Request DTOs — the input counterpart to the output wire types, shared by the
 //! servo-fetch servers and language bindings.
 
+use std::collections::BTreeMap;
+
 use serde::{Deserialize, Serialize};
 
 use crate::Visibility;
@@ -50,6 +52,10 @@ pub struct FetchRequest {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[cfg_attr(feature = "codegen", ts(optional))]
     pub cookies_file: Option<String>,
+    /// Custom request headers.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "codegen", ts(optional))]
+    pub headers: Option<BTreeMap<String, String>>,
     /// Visibility filtering policy (default: moderate).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[cfg_attr(feature = "codegen", ts(optional))]
@@ -83,6 +89,10 @@ pub struct ExtractRequest {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[cfg_attr(feature = "codegen", ts(optional))]
     pub cookies_file: Option<String>,
+    /// Custom request headers.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "codegen", ts(optional))]
+    pub headers: Option<BTreeMap<String, String>>,
     /// Visibility filtering policy (default: moderate).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[cfg_attr(feature = "codegen", ts(optional))]
@@ -116,6 +126,10 @@ pub struct ScreenshotRequest {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[cfg_attr(feature = "codegen", ts(optional))]
     pub cookies_file: Option<String>,
+    /// Custom request headers.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "codegen", ts(optional))]
+    pub headers: Option<BTreeMap<String, String>>,
 }
 
 /// Parameters for the `evaluate` method.
@@ -143,6 +157,10 @@ pub struct EvaluateRequest {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[cfg_attr(feature = "codegen", ts(optional))]
     pub cookies_file: Option<String>,
+    /// Custom request headers.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "codegen", ts(optional))]
+    pub headers: Option<BTreeMap<String, String>>,
 }
 
 /// Parameters for the `extractSchema` method.
@@ -171,6 +189,10 @@ pub struct SchemaExtractRequest {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[cfg_attr(feature = "codegen", ts(optional))]
     pub cookies_file: Option<String>,
+    /// Custom request headers.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "codegen", ts(optional))]
+    pub headers: Option<BTreeMap<String, String>>,
     /// Visibility filtering policy (default: moderate).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[cfg_attr(feature = "codegen", ts(optional))]
@@ -228,6 +250,10 @@ pub struct CrawlRequest {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[cfg_attr(feature = "codegen", ts(optional))]
     pub cookies_file: Option<String>,
+    /// Custom request headers.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "codegen", ts(optional))]
+    pub headers: Option<BTreeMap<String, String>>,
 }
 
 /// Parameters for the `map` method.
@@ -261,4 +287,8 @@ pub struct MapRequest {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[cfg_attr(feature = "codegen", ts(optional))]
     pub no_fallback: Option<bool>,
+    /// Custom request headers.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "codegen", ts(optional))]
+    pub headers: Option<BTreeMap<String, String>>,
 }

--- a/crates/servo-fetch/Cargo.toml
+++ b/crates/servo-fetch/Cargo.toml
@@ -24,6 +24,7 @@ dpi = { workspace = true }
 euclid = { workspace = true }
 globset = { workspace = true }
 htmd = { workspace = true }
+http = { workspace = true }
 image = { workspace = true }
 pdf-extract = { workspace = true }
 psl = { workspace = true }

--- a/crates/servo-fetch/README.md
+++ b/crates/servo-fetch/README.md
@@ -43,6 +43,7 @@ let page = fetch(
         .timeout(Duration::from_secs(60))
         .settle(Duration::from_millis(3000))
         .user_agent("MyBot/1.0")
+        .headers(servo_fetch::headers::from_pairs([("Authorization", "Bearer TOKEN")])?)
         .cookies(load_cookies("cookies.txt")?),
 ).await?;
 println!("{}", page.html);

--- a/crates/servo-fetch/src/bridge.rs
+++ b/crates/servo-fetch/src/bridge.rs
@@ -13,7 +13,8 @@ use image::RgbaImage;
 use serde_json::Value;
 use servo::{
     ConsoleLogLevel, EventLoopWaker, JSValue, LoadStatus, NavigationRequest, Preferences, RenderingContext,
-    ServoBuilder, SoftwareRenderingContext, UserContentManager, WebView, WebViewBuilder, WebViewDelegate, WebViewId,
+    ServoBuilder, SoftwareRenderingContext, UrlRequest, UserContentManager, WebView, WebViewBuilder, WebViewDelegate,
+    WebViewId,
 };
 use tokio::sync::{mpsc, oneshot};
 use url::Url;
@@ -22,6 +23,9 @@ use crate::cookies::CookieSpec;
 use crate::{layout, visibility};
 
 const EXTRACTION_BUDGET: Duration = Duration::from_secs(10);
+
+/// Servo's builder default for a webview created without an initial URL.
+const SHELL_URL: &str = "about:blank";
 
 pub(crate) fn default_user_agent() -> &'static str {
     static UA: OnceLock<String> = OnceLock::new();
@@ -100,6 +104,7 @@ pub(crate) fn wait_for_wake(timeout: Duration) {
 #[derive(Default)]
 struct WebViewState {
     loaded_at: Cell<Option<Instant>>,
+    deferred_load: RefCell<Option<UrlRequest>>,
     a11y_truncated: Cell<bool>,
     a11y_nodes: RefCell<HashMap<servo::accesskit::NodeId, servo::accesskit::Node>>,
     console_messages: RefCell<Vec<ConsoleMessage>>,
@@ -111,8 +116,11 @@ struct SharedDelegate {
 }
 
 impl SharedDelegate {
-    fn register(&self, id: WebViewId) -> Rc<WebViewState> {
-        let state = Rc::new(WebViewState::default());
+    fn register(&self, id: WebViewId, deferred_load: Option<UrlRequest>) -> Rc<WebViewState> {
+        let state = Rc::new(WebViewState {
+            deferred_load: RefCell::new(deferred_load),
+            ..Default::default()
+        });
         self.states.borrow_mut().insert(id, state.clone());
         state
     }
@@ -174,10 +182,15 @@ impl From<ConsoleLogLevel> for ConsoleLevel {
 
 impl WebViewDelegate for SharedDelegate {
     fn notify_load_status_changed(&self, webview: WebView, status: LoadStatus) {
-        if status == LoadStatus::Complete {
-            self.with_state(webview.id(), |s| {
-                s.loaded_at.set(Some(Instant::now()));
-            });
+        if webview.url().is_some_and(|u| u.as_str() == SHELL_URL) {
+            if let Some(request) = self
+                .with_state(webview.id(), |s| s.deferred_load.borrow_mut().take())
+                .flatten()
+            {
+                webview.load_request(request);
+            }
+        } else if status == LoadStatus::Complete {
+            self.with_state(webview.id(), |s| s.loaded_at.set(Some(Instant::now())));
         }
     }
 
@@ -256,6 +269,7 @@ pub(crate) struct FetchOptions<'a> {
     pub mode: FetchMode,
     pub user_agent: Option<&'a str>,
     pub cookies: &'a [CookieSpec],
+    pub headers: &'a http::HeaderMap,
 }
 
 /// What to do once the page has loaded. Variants are mutually exclusive.
@@ -283,6 +297,7 @@ struct FetchRequest {
     mode: FetchMode,
     user_agent: Option<String>,
     cookies: Vec<CookieSpec>,
+    headers: http::HeaderMap,
     reply: ReplyFn,
 }
 
@@ -366,6 +381,7 @@ fn build_request(opts: FetchOptions<'_>, reply: ReplyFn) -> FetchRequest {
         mode: opts.mode,
         user_agent: opts.user_agent.map(String::from),
         cookies: opts.cookies.to_vec(),
+        headers: opts.headers.clone(),
         reply,
     }
 }
@@ -565,17 +581,23 @@ fn start_fetch(
     };
 
     let delegate_dyn: Rc<dyn WebViewDelegate> = delegate.clone();
-    let webview = WebViewBuilder::new(servo, rc_dyn)
-        .url(parsed_url)
+    let builder = WebViewBuilder::new(servo, rc_dyn)
         .delegate(delegate_dyn)
-        .user_content_manager(ucm.clone())
-        .build();
+        .user_content_manager(ucm.clone());
+    let (webview, deferred) = if req.headers.is_empty() {
+        (builder.url(parsed_url).build(), None)
+    } else {
+        (
+            builder.build(),
+            Some(UrlRequest::new(parsed_url).headers(req.headers.clone())),
+        )
+    };
 
     if matches!(req.mode, FetchMode::Content { include_a11y: true }) {
         webview.set_accessibility_active(true);
     }
 
-    let state = delegate.register(webview.id());
+    let state = delegate.register(webview.id(), deferred);
     let deadline = Instant::now() + Duration::from_secs(req.timeout_secs);
     Some(PendingFetch {
         webview,
@@ -948,6 +970,7 @@ mod tests {
             mode: FetchMode::Content { include_a11y: false },
             user_agent: None,
             cookies: Vec::new(),
+            headers: http::HeaderMap::new(),
             reply,
         }
     }
@@ -961,6 +984,7 @@ mod tests {
             mode: FetchMode::Content { include_a11y: false },
             user_agent: Some("test-ua"),
             cookies: &[],
+            headers: &http::HeaderMap::new(),
         };
         let req = build_request(opts, Box::new(|_| {}));
         assert_eq!(req.url, "test://example");

--- a/crates/servo-fetch/src/client.rs
+++ b/crates/servo-fetch/src/client.rs
@@ -20,6 +20,7 @@ pub(crate) struct ClientInner {
     pub(crate) settle: Duration,
     pub(crate) user_agent: Option<String>,
     pub(crate) visibility: VisibilityPolicy,
+    pub(crate) headers: http::HeaderMap,
 }
 
 impl ClientInner {
@@ -30,6 +31,9 @@ impl ClientInner {
         opts.visibility.get_or_insert(self.visibility);
         if let Some(ua) = &self.user_agent {
             opts.user_agent.get_or_insert_with(|| ua.clone());
+        }
+        if opts.headers.is_empty() && !self.headers.is_empty() {
+            opts.headers = self.headers.clone();
         }
         opts
     }
@@ -116,6 +120,7 @@ pub struct ClientBuilder {
     settle: Option<Duration>,
     user_agent: Option<String>,
     visibility: Option<VisibilityPolicy>,
+    headers: http::HeaderMap,
 }
 
 impl ClientBuilder {
@@ -143,6 +148,12 @@ impl ClientBuilder {
         self
     }
 
+    /// Default custom request headers sent with every navigation request.
+    pub fn headers(mut self, headers: http::HeaderMap) -> Self {
+        self.headers = headers;
+        self
+    }
+
     /// Build the [`Client`].
     #[must_use]
     pub fn build(self) -> Client {
@@ -157,6 +168,7 @@ impl ClientBuilder {
             settle: self.settle.unwrap_or_default(),
             user_agent: self.user_agent,
             visibility: self.visibility.unwrap_or_default(),
+            headers: self.headers,
         }
     }
 }

--- a/crates/servo-fetch/src/crawl.rs
+++ b/crates/servo-fetch/src/crawl.rs
@@ -32,6 +32,7 @@ pub struct CrawlOptions {
     pub(crate) concurrency: usize,
     pub(crate) delay: Option<Duration>,
     pub(crate) cookies: Vec<crate::cookies::CookieSpec>,
+    pub(crate) headers: http::HeaderMap,
 }
 
 impl CrawlOptions {
@@ -51,6 +52,7 @@ impl CrawlOptions {
             concurrency: 1,
             delay: Some(Duration::from_millis(500)),
             cookies: Vec::new(),
+            headers: http::HeaderMap::new(),
         }
     }
 
@@ -124,6 +126,12 @@ impl CrawlOptions {
     /// Seed session cookies before crawling, scoped to the seed's site.
     pub fn cookies(mut self, cookies: Vec<crate::cookies::CookieSpec>) -> Self {
         self.cookies = cookies;
+        self
+    }
+
+    /// Custom request headers sent with every page's navigation request.
+    pub fn headers(mut self, headers: http::HeaderMap) -> Self {
+        self.headers = headers;
         self
     }
 }
@@ -224,8 +232,9 @@ where
     let robots = spawn_blocking({
         let seed = plan.seed.clone();
         let user_agent = plan.user_agent.clone();
+        let headers = plan.headers.clone();
         let timeout = Duration::from_secs(plan.timeout_secs);
-        move || crate::robots::RobotsRules::fetch(&seed, user_agent.as_deref(), timeout)
+        move || crate::robots::RobotsRules::fetch(&seed, user_agent.as_deref(), &headers, timeout)
     })
     .await
     .unwrap_or(RobotsPolicy::Unreachable);
@@ -276,6 +285,7 @@ fn build_crawl_plan(opts: &CrawlOptions) -> crate::error::Result<CrawlPlan> {
         concurrency: opts.concurrency,
         delay: opts.delay,
         cookies: opts.cookies.clone(),
+        headers: opts.headers.clone(),
     })
 }
 
@@ -296,6 +306,7 @@ pub(crate) struct CrawlPlan {
     /// Dispatch interval; `None` disables rate limiting.
     pub delay: Option<Duration>,
     pub cookies: Vec<crate::cookies::CookieSpec>,
+    pub headers: http::HeaderMap,
 }
 
 /// Result for a single crawled page.
@@ -454,6 +465,7 @@ fn spawn_fetch(
     let settle = opts.settle_ms;
     let user_agent = opts.user_agent.clone();
     let cookies = opts.cookies.clone();
+    let headers = opts.headers.clone();
     let f = fetcher.clone();
     in_flight.spawn_blocking(move || {
         let result = f
@@ -464,6 +476,7 @@ fn spawn_fetch(
                 mode: bridge::FetchMode::Content { include_a11y: false },
                 user_agent: user_agent.as_deref(),
                 cookies: &cookies,
+                headers: &headers,
             })
             .map_err(|e| crate::error::Error::engine(e, Some(url_str.clone())));
         FetchOutcome {
@@ -687,6 +700,7 @@ mod tests {
             concurrency: 1,
             delay: None,
             cookies: Vec::new(),
+            headers: http::HeaderMap::new(),
         };
         configure(&mut opts);
         let mut results = Vec::new();

--- a/crates/servo-fetch/src/error.rs
+++ b/crates/servo-fetch/src/error.rs
@@ -92,6 +92,10 @@ pub enum Error {
     /// A glob pattern is invalid.
     #[error(transparent)]
     InvalidGlob(#[from] globset::Error),
+
+    /// A custom request header is malformed or not permitted.
+    #[error("{0}")]
+    InvalidHeader(String),
 }
 
 impl Error {
@@ -117,6 +121,11 @@ impl Error {
             url,
             source: source.into(),
         }
+    }
+
+    /// Construct an [`Error::InvalidHeader`].
+    pub(crate) fn invalid_header(message: impl Into<String>) -> Self {
+        Self::InvalidHeader(message.into())
     }
 
     /// Returns `true` if this is a timeout error.

--- a/crates/servo-fetch/src/fetch.rs
+++ b/crates/servo-fetch/src/fetch.rs
@@ -235,6 +235,7 @@ pub struct FetchOptions {
     pub(crate) extract_schema: Option<crate::schema::ExtractSchema>,
     pub(crate) visibility: Option<crate::visibility::VisibilityPolicy>,
     pub(crate) cookies: Vec<crate::cookies::CookieSpec>,
+    pub(crate) headers: http::HeaderMap,
 }
 
 impl FetchOptions {
@@ -257,6 +258,7 @@ impl FetchOptions {
             extract_schema: None,
             visibility: None,
             cookies: Vec::new(),
+            headers: http::HeaderMap::new(),
         }
     }
 
@@ -309,6 +311,12 @@ impl FetchOptions {
     /// Seed session cookies before navigation, scoped to the target's site.
     pub fn cookies(mut self, cookies: Vec<crate::cookies::CookieSpec>) -> Self {
         self.cookies = cookies;
+        self
+    }
+
+    /// Custom request headers sent with the navigation request.
+    pub fn headers(mut self, headers: http::HeaderMap) -> Self {
+        self.headers = headers;
         self
     }
 
@@ -427,6 +435,7 @@ fn build_bridge_options(opts: &FetchOptions) -> crate::bridge::FetchOptions<'_> 
         settle_ms: u64::try_from(opts.effective_settle().as_millis()).unwrap_or(u64::MAX),
         user_agent: opts.user_agent.as_deref(),
         cookies: &opts.cookies,
+        headers: &opts.headers,
         mode: match opts.mode {
             FetchMode::Content => crate::bridge::FetchMode::Content { include_a11y: false },
             FetchMode::Screenshot { full_page } => crate::bridge::FetchMode::Screenshot { full_page },

--- a/crates/servo-fetch/src/headers.rs
+++ b/crates/servo-fetch/src/headers.rs
@@ -1,0 +1,141 @@
+//! Custom request-header parsing and validation, shared by every front-end.
+
+use http::header::{HeaderMap, HeaderName, HeaderValue};
+
+use crate::error::{Error, Result};
+
+/// Hop-by-hop and message-framing headers the engine manages.
+const RESERVED: &[&str] = &[
+    "host",
+    "content-length",
+    "connection",
+    "transfer-encoding",
+    "te",
+    "trailer",
+    "upgrade",
+    "keep-alive",
+];
+
+/// Headers with a dedicated option; steer callers there instead of raw headers.
+fn steer(name: &str) -> Option<&'static str> {
+    match name {
+        "user-agent" => Some("the user-agent option"),
+        "cookie" => Some("the cookies option"),
+        _ => None,
+    }
+}
+
+/// Build a validated [`HeaderMap`] from `name`/`value` pairs (e.g. a JSON object).
+pub fn from_pairs<I, K, V>(pairs: I) -> Result<HeaderMap>
+where
+    I: IntoIterator<Item = (K, V)>,
+    K: AsRef<str>,
+    V: AsRef<str>,
+{
+    let mut headers = HeaderMap::new();
+    for (name, value) in pairs {
+        let (name, value) = validate(name.as_ref(), value.as_ref())?;
+        headers.append(name, value);
+    }
+    Ok(headers)
+}
+
+/// Build a validated [`HeaderMap`] from curl-style `Name: Value` lines
+/// (`Name;` sends an empty value).
+pub fn parse_lines<I, S>(lines: I) -> Result<HeaderMap>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    let mut headers = HeaderMap::new();
+    for line in lines {
+        let (name, value) = split_line(line.as_ref())?;
+        let (name, value) = validate(&name, &value)?;
+        headers.append(name, value);
+    }
+    Ok(headers)
+}
+
+fn validate(name: &str, value: &str) -> Result<(HeaderName, HeaderValue)> {
+    let name = HeaderName::from_bytes(name.trim().as_bytes())
+        .map_err(|_| Error::invalid_header(format!("invalid header name '{}'", name.trim())))?;
+    if let Some(hint) = steer(name.as_str()) {
+        return Err(Error::invalid_header(format!(
+            "header '{name}' cannot be set as a custom header; use {hint} instead"
+        )));
+    }
+    if RESERVED.contains(&name.as_str()) {
+        return Err(Error::invalid_header(format!(
+            "header '{name}' is managed by the engine and cannot be overridden"
+        )));
+    }
+    let value = HeaderValue::from_str(value)
+        .map_err(|_| Error::invalid_header(format!("invalid value for header '{name}'")))?;
+    Ok((name, value))
+}
+
+fn split_line(line: &str) -> Result<(String, String)> {
+    match line.split_once(':') {
+        Some((name, value)) => {
+            let value = value.trim_start();
+            if value.is_empty() {
+                return Err(malformed(line));
+            }
+            Ok((name.to_owned(), value.to_owned()))
+        }
+        None => match line.strip_suffix(';') {
+            Some(name) if !name.is_empty() => Ok((name.to_owned(), String::new())),
+            _ => Err(malformed(line)),
+        },
+    }
+}
+
+fn malformed(line: &str) -> Error {
+    Error::invalid_header(format!(
+        "invalid header '{line}': expected 'Name: Value' (use 'Name;' for an empty value)"
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_and_appends_lines() {
+        let h = parse_lines(["X-A: 1", "X-B: two"]).unwrap();
+        assert_eq!(h.get("x-a").unwrap(), "1", "first header");
+        assert_eq!(h.get("x-b").unwrap(), "two", "second header");
+    }
+
+    #[test]
+    fn empty_value_via_trailing_semicolon() {
+        let h = parse_lines(["X-Empty;"]).unwrap();
+        assert_eq!(h.get("x-empty").unwrap(), "", "semicolon sends empty value");
+    }
+
+    #[test]
+    fn from_pairs_builds_map() {
+        let h = from_pairs([("X-A", "1"), ("X-A", "2")]).unwrap();
+        let values: Vec<_> = h.get_all("x-a").iter().collect();
+        assert_eq!(values.len(), 2, "duplicate names are appended");
+    }
+
+    #[test]
+    fn rejects_crlf_injection() {
+        assert!(parse_lines(["X-A: a\r\nEvil: b"]).is_err(), "CRLF must be rejected");
+        assert!(from_pairs([("X-A", "a\r\nEvil: b")]).is_err(), "CRLF must be rejected");
+    }
+
+    #[test]
+    fn rejects_reserved_and_steered() {
+        assert!(parse_lines(["Host: x"]).is_err(), "framing header rejected");
+        assert!(parse_lines(["User-Agent: x"]).is_err(), "user-agent steered");
+        assert!(parse_lines(["Cookie: a=1"]).is_err(), "cookie steered");
+    }
+
+    #[test]
+    fn rejects_malformed_lines() {
+        assert!(parse_lines(["no-colon"]).is_err(), "missing colon");
+        assert!(parse_lines(["X-Foo:"]).is_err(), "empty value needs 'Name;'");
+    }
+}

--- a/crates/servo-fetch/src/lib.rs
+++ b/crates/servo-fetch/src/lib.rs
@@ -20,6 +20,7 @@
 
 pub mod blocking;
 pub mod extract;
+pub mod headers;
 pub mod sanitize;
 pub mod schema;
 pub mod visibility;
@@ -45,6 +46,7 @@ pub use cookies::{CookieSpec, load_cookies};
 pub use crawl::{CrawlOptions, CrawlPage, CrawlResult, crawl, crawl_each};
 pub use error::{Error, Result};
 pub use fetch::{ConsoleLevel, ConsoleMessage, FetchOptions, Page, extract_json, fetch, markdown, text};
+pub use http::HeaderMap;
 pub use map::{MapOptions, MappedUrl, map};
 pub use net::{NetworkPolicy, validate_url};
 pub use visibility::{VisibilityFlags, VisibilityPolicy};

--- a/crates/servo-fetch/src/map.rs
+++ b/crates/servo-fetch/src/map.rs
@@ -33,6 +33,7 @@ pub struct MapOptions {
     user_agent: Option<String>,
     timeout: u64,
     no_fallback: bool,
+    headers: http::HeaderMap,
 }
 
 impl MapOptions {
@@ -46,6 +47,7 @@ impl MapOptions {
             user_agent: None,
             timeout: 30,
             no_fallback: false,
+            headers: http::HeaderMap::new(),
         }
     }
 
@@ -82,6 +84,12 @@ impl MapOptions {
     /// Skip HTML link fallback if no sitemap is found.
     pub fn no_fallback(mut self, yes: bool) -> Self {
         self.no_fallback = yes;
+        self
+    }
+
+    /// Custom request headers sent with every discovery request.
+    pub fn headers(mut self, headers: http::HeaderMap) -> Self {
+        self.headers = headers;
         self
     }
 }
@@ -125,6 +133,7 @@ pub async fn map(opts: &MapOptions) -> crate::error::Result<Vec<MappedUrl>> {
         user_agent: opts.user_agent.clone(),
         timeout: Duration::from_secs(opts.timeout),
         no_fallback: opts.no_fallback,
+        headers: opts.headers.clone(),
     };
 
     let mut results = Vec::new();
@@ -147,6 +156,7 @@ pub(crate) struct MapConfig {
     pub user_agent: Option<String>,
     pub timeout: Duration,
     pub no_fallback: bool,
+    pub headers: http::HeaderMap,
 }
 
 /// A discovered URL with optional metadata.
@@ -168,8 +178,9 @@ pub(crate) async fn run(opts: &MapConfig, mut on_url: impl FnMut(&MapEntry)) {
     let robots = {
         let seed = opts.seed.clone();
         let user_agent = opts.user_agent.clone();
+        let headers = opts.headers.clone();
         let timeout = opts.timeout;
-        spawn_blocking(move || RobotsRules::fetch(&seed, user_agent.as_deref(), timeout))
+        spawn_blocking(move || RobotsRules::fetch(&seed, user_agent.as_deref(), &headers, timeout))
             .await
             .unwrap_or(RobotsPolicy::Unreachable)
     };
@@ -200,7 +211,8 @@ pub(crate) async fn run(opts: &MapConfig, mut on_url: impl FnMut(&MapEntry)) {
             let agent = agent.clone();
             spawn_blocking({
                 let seed = opts.seed.clone();
-                move || fetch_sitemap(&agent, &sitemap_url, &seed)
+                let headers = opts.headers.clone();
+                move || fetch_sitemap(&agent, &sitemap_url, &seed, &headers)
             })
             .await
             .ok()
@@ -233,7 +245,11 @@ pub(crate) async fn run(opts: &MapConfig, mut on_url: impl FnMut(&MapEntry)) {
         let html = {
             let agent = agent.clone();
             let seed = opts.seed.clone();
-            spawn_blocking(move || fetch_html(&agent, &seed)).await.ok().flatten()
+            let headers = opts.headers.clone();
+            spawn_blocking(move || fetch_html(&agent, &seed, &headers))
+                .await
+                .ok()
+                .flatten()
         };
         if let Some(html) = html {
             for link in extract_links(&html, &opts.seed) {
@@ -273,10 +289,19 @@ fn build_agent(ua: &str, timeout: Duration) -> ureq::Agent {
     )
 }
 
-fn fetch_following_redirects(agent: &ureq::Agent, url: &Url, seed: &Url) -> Option<ureq::http::Response<ureq::Body>> {
+fn fetch_following_redirects(
+    agent: &ureq::Agent,
+    url: &Url,
+    seed: &Url,
+    headers: &http::HeaderMap,
+) -> Option<http::Response<ureq::Body>> {
     let mut current = url.clone();
     for _ in 0..MAP_MAX_REDIRECTS {
-        let resp = agent.get(current.as_str()).call().ok()?;
+        let mut req = agent.get(current.as_str());
+        for (name, value) in headers {
+            req = req.header(name.clone(), value.clone());
+        }
+        let resp = req.call().ok()?;
         let status = resp.status().as_u16();
         if matches!(status, 301 | 302 | 303 | 307 | 308) {
             let location = resp.headers().get("location")?.to_str().ok()?;
@@ -297,8 +322,8 @@ fn fetch_following_redirects(agent: &ureq::Agent, url: &Url, seed: &Url) -> Opti
     None
 }
 
-fn fetch_sitemap(agent: &ureq::Agent, url: &Url, seed: &Url) -> Option<String> {
-    let resp = fetch_following_redirects(agent, url, seed)?;
+fn fetch_sitemap(agent: &ureq::Agent, url: &Url, seed: &Url, headers: &http::HeaderMap) -> Option<String> {
+    let resp = fetch_following_redirects(agent, url, seed, headers)?;
     let content_type = resp
         .headers()
         .get("content-type")
@@ -369,8 +394,8 @@ fn looks_like_html(bytes: &[u8]) -> bool {
         || prefix.get(..HTML.len()).is_some_and(|p| p.eq_ignore_ascii_case(HTML))
 }
 
-fn fetch_html(agent: &ureq::Agent, url: &Url) -> Option<String> {
-    let resp = fetch_following_redirects(agent, url, url)?;
+fn fetch_html(agent: &ureq::Agent, url: &Url, headers: &http::HeaderMap) -> Option<String> {
+    let resp = fetch_following_redirects(agent, url, url, headers)?;
     resp.into_body()
         .with_config()
         .limit(MAP_HTML_MAX_BYTES)
@@ -564,6 +589,7 @@ mod tests {
             user_agent: None,
             timeout: Duration::from_secs(30),
             no_fallback: false,
+            headers: http::HeaderMap::new(),
         }
     }
 
@@ -784,7 +810,9 @@ mod tests {
 
             let agent = build_agent("test/1.0", Duration::from_secs(5));
             let url = Url::parse(&format!("{}/sitemap.xml", server.uri())).unwrap();
-            let body = spawn_blocking(move || fetch_sitemap(&agent, &url, &url)).await.unwrap();
+            let body = spawn_blocking(move || fetch_sitemap(&agent, &url, &url, &http::HeaderMap::new()))
+                .await
+                .unwrap();
 
             let entries = parse_sitemap(&body.unwrap());
             assert_eq!(entries.len(), 1);
@@ -804,7 +832,9 @@ mod tests {
 
             let agent = build_agent("test/1.0", Duration::from_secs(5));
             let url = Url::parse(&format!("{}/sitemap.xml", server.uri())).unwrap();
-            let body = spawn_blocking(move || fetch_sitemap(&agent, &url, &url)).await.unwrap();
+            let body = spawn_blocking(move || fetch_sitemap(&agent, &url, &url, &http::HeaderMap::new()))
+                .await
+                .unwrap();
 
             assert!(body.is_none());
         }
@@ -820,7 +850,9 @@ mod tests {
 
             let agent = build_agent("test/1.0", Duration::from_secs(5));
             let url = Url::parse(&format!("{}/sitemap.xml", server.uri())).unwrap();
-            let body = spawn_blocking(move || fetch_sitemap(&agent, &url, &url)).await.unwrap();
+            let body = spawn_blocking(move || fetch_sitemap(&agent, &url, &url, &http::HeaderMap::new()))
+                .await
+                .unwrap();
 
             assert!(body.is_none());
         }
@@ -846,7 +878,9 @@ mod tests {
 
             let agent = build_agent("test/1.0", Duration::from_secs(5));
             let url = Url::parse(&format!("{}/sitemap.xml.gz", server.uri())).unwrap();
-            let body = spawn_blocking(move || fetch_sitemap(&agent, &url, &url)).await.unwrap();
+            let body = spawn_blocking(move || fetch_sitemap(&agent, &url, &url, &http::HeaderMap::new()))
+                .await
+                .unwrap();
 
             let entries = parse_sitemap(&body.unwrap());
             assert_eq!(entries.len(), 1);
@@ -868,7 +902,7 @@ mod tests {
             let seed = Url::parse(&server.uri()).unwrap();
             let html = spawn_blocking({
                 let seed = seed.clone();
-                move || fetch_html(&agent, &seed)
+                move || fetch_html(&agent, &seed, &http::HeaderMap::new())
             })
             .await
             .unwrap()
@@ -887,6 +921,7 @@ mod tests {
                 user_agent: Some("test-bot".into()),
                 timeout: Duration::from_secs(5),
                 no_fallback: false,
+                headers: http::HeaderMap::new(),
             };
             configure(&mut config);
             let mut entries = Vec::new();

--- a/crates/servo-fetch/src/robots.rs
+++ b/crates/servo-fetch/src/robots.rs
@@ -33,7 +33,12 @@ pub(crate) struct RobotsRules {
 }
 
 impl RobotsRules {
-    pub(crate) fn fetch(seed: &Url, user_agent: Option<&str>, timeout: Duration) -> RobotsPolicy {
+    pub(crate) fn fetch(
+        seed: &Url,
+        user_agent: Option<&str>,
+        headers: &http::HeaderMap,
+        timeout: Duration,
+    ) -> RobotsPolicy {
         let Some(url) = robots_url(seed) else {
             return RobotsPolicy::Unreachable;
         };
@@ -45,7 +50,11 @@ impl RobotsRules {
                 .user_agent(ua)
                 .build(),
         );
-        match agent.get(url.as_str()).call() {
+        let mut req = agent.get(url.as_str());
+        for (name, value) in headers {
+            req = req.header(name.clone(), value.clone());
+        }
+        match req.call() {
             Ok(resp) => resp
                 .into_body()
                 .with_config()
@@ -309,9 +318,11 @@ mod tests {
         }
 
         async fn call(seed: Url, user_agent: Option<&'static str>) -> RobotsPolicy {
-            tokio::task::spawn_blocking(move || RobotsRules::fetch(&seed, user_agent, Duration::from_secs(5)))
-                .await
-                .unwrap()
+            tokio::task::spawn_blocking(move || {
+                RobotsRules::fetch(&seed, user_agent, &http::HeaderMap::new(), Duration::from_secs(5))
+            })
+            .await
+            .unwrap()
         }
 
         #[tokio::test]

--- a/crates/servo-fetch/tests/headers.rs
+++ b/crates/servo-fetch/tests/headers.rs
@@ -1,0 +1,37 @@
+//! Custom request-header integration test.
+
+use servo_fetch::blocking::fetch;
+use servo_fetch::{FetchOptions, HeaderMap, NetworkPolicy};
+use wiremock::matchers::{header, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "e2e: spawns the Servo engine; Linux CI sees SIGSEGV during destructor cleanup"]
+async fn custom_header_reaches_the_target() {
+    servo_fetch::init(NetworkPolicy::PERMISSIVE);
+
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/"))
+        .and(header("x-test-token", "secret-123"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(
+            b"<!DOCTYPE html><html><body><h1>AUTHED</h1></body></html>".as_slice(),
+            "text/html; charset=utf-8",
+        ))
+        .mount(&server)
+        .await;
+    let url = format!("{}/", server.uri());
+
+    let html = tokio::task::spawn_blocking(move || {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-test-token", "secret-123".parse().unwrap());
+        fetch(&FetchOptions::new(&url).headers(headers)).expect("fetch").html
+    })
+    .await
+    .expect("spawn_blocking");
+
+    assert!(
+        html.contains("AUTHED"),
+        "header not delivered or real page not captured:\n{html}"
+    );
+}

--- a/skills/servo-fetch/SKILL.md
+++ b/skills/servo-fetch/SKILL.md
@@ -130,6 +130,7 @@ servo-fetch https://example.com --js "document.title"            # Run JavaScrip
 servo-fetch https://example.com --selector article               # Extract a section by CSS selector
 servo-fetch https://example.com --schema schema.json             # Schema-driven JSON
 servo-fetch https://example.com --cookies cookies.txt            # Send session cookies
+servo-fetch https://example.com -H "Authorization: Bearer TOKEN" # Custom request header (repeatable)
 servo-fetch https://example.com --format html                    # Raw HTML
 servo-fetch https://example.com --format text                    # Plain text
 servo-fetch https://example.com -t 60                            # Custom timeout


### PR DESCRIPTION
## Summary

Add custom HTTP request headers across every surface. A single core policy (`servo_fetch::headers`) validates and builds the header map.

- CLI: repeatable `-H, --header "Name: Value"` (curl-compatible; `Name;` = empty value) on `fetch`, `crawl`, and `map`.
- RPC and wire DTOs: a `headers` object on every page-fetching request.
- Rust lib: `.headers()` on `FetchOptions` / `CrawlOptions` / `MapOptions` / `Client`.
- Python (`headers=` kwarg) and Node (`headers` option) bindings.

## Related issues

Closes #167

## Test Plan

- `cargo test`: all passed
- `cargo test -p servo-fetch --test headers -- --ignored`: all passed

## Checklist

- [x] Ran `cargo +nightly fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
- [x] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed
- [x] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it