### PR TITLE
feat(mcp): report all tool failures as isError results

### DIFF
--- a/crates/servo-fetch-cli/src/mcp/server.rs
+++ b/crates/servo-fetch-cli/src/mcp/server.rs
@@ -39,26 +39,7 @@ impl ServoFetchMcp {
         )
     )]
     async fn fetch(&self, Parameters(p): Parameters<FetchRequest>) -> Result<CallToolResult, ErrorData> {
-        let url = tools::validated_url(&p.url)?;
-        tools::validate_selector(p.selector.as_deref())?;
-        let format = p.format.unwrap_or_default();
-        let start = to_len(p.start_index, 0);
-        let max_len = to_len(p.max_length, DEFAULT_MAX_LENGTH);
-
-        let opts = FetchOptions::new(&url).visibility(tools::visibility_policy(p.visibility));
-        let page = match tools::fetch_with(tools::apply_options(opts, p.options)?).await {
-            Ok(page) => page,
-            Err(e) => return Ok(tools::tool_error(e)),
-        };
-        let full = match tools::render_page(&page, &url, format, p.selector.as_deref()) {
-            Ok(full) => full,
-            Err(e) => return Ok(tools::tool_error(e)),
-        };
-        Ok(CallToolResult::success(vec![Content::text(tools::paginate(
-            &servo_fetch::sanitize::sanitize(&full),
-            start,
-            max_len,
-        ))]))
+        Ok(run_fetch(p).await.unwrap_or_else(tools::tool_error))
     }
 
     #[tool(
@@ -71,20 +52,7 @@ impl ServoFetchMcp {
         )
     )]
     async fn screenshot(&self, Parameters(p): Parameters<ScreenshotRequest>) -> Result<CallToolResult, ErrorData> {
-        let url = tools::validated_url(&p.url)?;
-
-        let opts = FetchOptions::screenshot(&url, p.full_page.unwrap_or(false));
-        let page = match tools::fetch_with(tools::apply_options(opts, p.options)?).await {
-            Ok(page) => page,
-            Err(e) => return Ok(tools::tool_error(e)),
-        };
-        match page.screenshot_png() {
-            Some(png) => Ok(CallToolResult::success(vec![Content::image(
-                base64::engine::general_purpose::STANDARD.encode(png),
-                "image/png",
-            )])),
-            None => Ok(tools::tool_error("screenshot capture failed")),
-        }
+        Ok(run_screenshot(p).await.unwrap_or_else(tools::tool_error))
     }
 
     #[tool(
@@ -97,29 +65,7 @@ impl ServoFetchMcp {
         )
     )]
     async fn execute_js(&self, Parameters(p): Parameters<EvaluateRequest>) -> Result<CallToolResult, ErrorData> {
-        if p.expression.len() > MAX_JS_LEN {
-            return Err(ErrorData::invalid_params(
-                format!("expression exceeds {MAX_JS_LEN} character limit"),
-                None,
-            ));
-        }
-        let url = tools::validated_url(&p.url)?;
-
-        let opts = FetchOptions::javascript(&url, &p.expression);
-        let page = match tools::fetch_with(tools::apply_options(opts, p.options)?).await {
-            Ok(page) => page,
-            Err(e) => return Ok(tools::tool_error(e)),
-        };
-        let mut result = tools::clamp_js_output(page.js_result.unwrap_or_default());
-        if !page.console_messages.is_empty() {
-            result.push_str("\n\n--- console output ---\n");
-            for msg in &page.console_messages {
-                let _ = writeln!(result, "[{:?}] {}", msg.level, msg.message);
-            }
-        }
-        Ok(CallToolResult::success(vec![Content::text(
-            servo_fetch::sanitize::sanitize(&result).into_owned(),
-        )]))
+        Ok(run_execute_js(p).await.unwrap_or_else(tools::tool_error))
     }
 
     #[tool(
@@ -132,34 +78,7 @@ impl ServoFetchMcp {
         )
     )]
     async fn batch_fetch(&self, Parameters(p): Parameters<BatchFetchRequest>) -> Result<CallToolResult, ErrorData> {
-        if p.urls.is_empty() {
-            return Err(ErrorData::invalid_params("urls must not be empty", None));
-        }
-        if p.urls.len() > MAX_BATCH_URLS {
-            return Err(ErrorData::invalid_params(
-                format!("urls exceeds {MAX_BATCH_URLS} URL limit"),
-                None,
-            ));
-        }
-        tools::validate_selector(p.selector.as_deref())?;
-
-        let validated: Vec<String> = p
-            .urls
-            .iter()
-            .map(|u| tools::validated_url(u))
-            .collect::<Result<Vec<_>, _>>()?;
-        let results = tools::batch_fetch_pages(tools::BatchSpec {
-            urls: &validated,
-            format: p.format.unwrap_or_default(),
-            selector: p.selector.as_deref(),
-            max_len: to_len(p.max_length, DEFAULT_MAX_LENGTH),
-            visibility: tools::visibility_policy(p.visibility),
-            options: p.options,
-        })
-        .await;
-
-        let contents: Vec<Content> = results.into_iter().map(|(_url, text)| Content::text(text)).collect();
-        Ok(CallToolResult::success(contents))
+        Ok(run_batch_fetch(p).await.unwrap_or_else(tools::tool_error))
     }
 
     #[tool(
@@ -172,28 +91,7 @@ impl ServoFetchMcp {
         )
     )]
     async fn crawl(&self, Parameters(p): Parameters<CrawlRequest>) -> Result<CallToolResult, ErrorData> {
-        let url = tools::validated_url(&p.url)?;
-        tools::validate_selector(p.selector.as_deref())?;
-
-        let results = tools::crawl_pages(
-            tools::CrawlSpec {
-                url: &url,
-                limit: p.limit,
-                max_depth: p.max_depth,
-                format: p.format.unwrap_or_default(),
-                selector: p.selector.as_deref(),
-                include: p.include.as_deref(),
-                exclude: p.exclude.as_deref(),
-                concurrency: p.concurrency,
-                delay_ms: p.delay_ms,
-                options: p.options,
-            },
-            to_len(p.max_length, DEFAULT_MAX_LENGTH),
-        )
-        .await?;
-
-        let contents: Vec<Content> = results.into_iter().map(|(_url, text)| Content::text(text)).collect();
-        Ok(CallToolResult::success(contents))
+        Ok(run_crawl(p).await.unwrap_or_else(tools::tool_error))
     }
 
     #[tool(
@@ -206,26 +104,128 @@ impl ServoFetchMcp {
         )
     )]
     async fn map(&self, Parameters(p): Parameters<MapRequest>) -> Result<CallToolResult, ErrorData> {
-        let url = tools::validated_url(&p.url)?;
+        Ok(run_map(p).await.unwrap_or_else(tools::tool_error))
+    }
+}
 
-        let opts = tools::build_map_options(tools::MapSpec {
+async fn run_fetch(p: FetchRequest) -> Result<CallToolResult, tools::ToolError> {
+    let url = tools::validated_url(&p.url)?;
+    tools::validate_selector(p.selector.as_deref())?;
+    let opts = FetchOptions::new(&url).visibility(tools::visibility_policy(p.visibility));
+    let page = tools::fetch_with(tools::apply_options(opts, p.options)?).await?;
+    let full = tools::render_page(&page, &url, p.format.unwrap_or_default(), p.selector.as_deref())?;
+    let content = tools::paginate(
+        &servo_fetch::sanitize::sanitize(&full),
+        to_len(p.start_index, 0),
+        to_len(p.max_length, DEFAULT_MAX_LENGTH),
+    );
+    Ok(CallToolResult::success(vec![Content::text(content)]))
+}
+
+async fn run_screenshot(p: ScreenshotRequest) -> Result<CallToolResult, tools::ToolError> {
+    let url = tools::validated_url(&p.url)?;
+    let opts = FetchOptions::screenshot(&url, p.full_page.unwrap_or(false));
+    let page = tools::fetch_with(tools::apply_options(opts, p.options)?).await?;
+    let png = page
+        .screenshot_png()
+        .ok_or_else(|| tools::ToolError::internal("screenshot capture failed"))?;
+    Ok(CallToolResult::success(vec![Content::image(
+        base64::engine::general_purpose::STANDARD.encode(png),
+        "image/png",
+    )]))
+}
+
+async fn run_execute_js(p: EvaluateRequest) -> Result<CallToolResult, tools::ToolError> {
+    if p.expression.len() > MAX_JS_LEN {
+        return Err(tools::ToolError::invalid_params(format!(
+            "expression exceeds {MAX_JS_LEN} character limit"
+        )));
+    }
+    let url = tools::validated_url(&p.url)?;
+    let opts = FetchOptions::javascript(&url, &p.expression);
+    let page = tools::fetch_with(tools::apply_options(opts, p.options)?).await?;
+    let mut result = tools::clamp_js_output(page.js_result.unwrap_or_default());
+    if !page.console_messages.is_empty() {
+        result.push_str("\n\n--- console output ---\n");
+        for msg in &page.console_messages {
+            let _ = writeln!(result, "[{:?}] {}", msg.level, msg.message);
+        }
+    }
+    Ok(CallToolResult::success(vec![Content::text(
+        servo_fetch::sanitize::sanitize(&result).into_owned(),
+    )]))
+}
+
+async fn run_batch_fetch(p: BatchFetchRequest) -> Result<CallToolResult, tools::ToolError> {
+    if p.urls.is_empty() {
+        return Err(tools::ToolError::invalid_params("urls must not be empty"));
+    }
+    if p.urls.len() > MAX_BATCH_URLS {
+        return Err(tools::ToolError::invalid_params(format!(
+            "urls exceeds {MAX_BATCH_URLS} URL limit"
+        )));
+    }
+    tools::validate_selector(p.selector.as_deref())?;
+    let validated: Vec<String> = p
+        .urls
+        .iter()
+        .map(|u| tools::validated_url(u))
+        .collect::<Result<_, _>>()?;
+    let results = tools::batch_fetch_pages(tools::BatchSpec {
+        urls: &validated,
+        format: p.format.unwrap_or_default(),
+        selector: p.selector.as_deref(),
+        max_len: to_len(p.max_length, DEFAULT_MAX_LENGTH),
+        visibility: tools::visibility_policy(p.visibility),
+        options: p.options,
+    })
+    .await;
+    let contents: Vec<Content> = results.into_iter().map(|(_url, text)| Content::text(text)).collect();
+    Ok(CallToolResult::success(contents))
+}
+
+async fn run_crawl(p: CrawlRequest) -> Result<CallToolResult, tools::ToolError> {
+    let url = tools::validated_url(&p.url)?;
+    tools::validate_selector(p.selector.as_deref())?;
+    let results = tools::crawl_pages(
+        tools::CrawlSpec {
             url: &url,
             limit: p.limit,
+            max_depth: p.max_depth,
+            format: p.format.unwrap_or_default(),
+            selector: p.selector.as_deref(),
             include: p.include.as_deref(),
             exclude: p.exclude.as_deref(),
-            no_fallback: p.no_fallback.unwrap_or(false),
-            user_agent: p.user_agent.as_deref(),
-            timeout: p.timeout,
-            headers: p.headers,
-        })?;
-        let text = tools::map_with(opts)
-            .await?
-            .into_iter()
-            .map(|entry| entry.url)
-            .collect::<Vec<_>>()
-            .join("\n");
-        Ok(CallToolResult::success(vec![Content::text(text)]))
-    }
+            concurrency: p.concurrency,
+            delay_ms: p.delay_ms,
+            options: p.options,
+        },
+        to_len(p.max_length, DEFAULT_MAX_LENGTH),
+    )
+    .await?;
+    let contents: Vec<Content> = results.into_iter().map(|(_url, text)| Content::text(text)).collect();
+    Ok(CallToolResult::success(contents))
+}
+
+async fn run_map(p: MapRequest) -> Result<CallToolResult, tools::ToolError> {
+    let url = tools::validated_url(&p.url)?;
+    let opts = tools::build_map_options(tools::MapSpec {
+        url: &url,
+        limit: p.limit,
+        include: p.include.as_deref(),
+        exclude: p.exclude.as_deref(),
+        no_fallback: p.no_fallback.unwrap_or(false),
+        user_agent: p.user_agent.as_deref(),
+        timeout: p.timeout,
+        headers: p.headers,
+    })?;
+    let urls = tools::map_with(opts)
+        .await?
+        .into_iter()
+        .map(|entry| entry.url)
+        .collect::<Vec<_>>()
+        .join("\n");
+    Ok(CallToolResult::success(vec![Content::text(urls)]))
 }
 
 #[tool_handler]

--- a/crates/servo-fetch-cli/src/mcp/tools.rs
+++ b/crates/servo-fetch-cli/src/mcp/tools.rs
@@ -1,35 +1,13 @@
-//! MCP-specific wrappers over the shared [`crate::tools`] business logic.
+//! MCP-specific helpers over the shared [`crate::tools`] business logic.
 
-use rmcp::ErrorData;
 use rmcp::model::{CallToolResult, Content};
-use servo_fetch_types::ErrorKind;
 
-use crate::tools::ToolError;
 pub(super) use crate::tools::{
-    BatchSpec, CrawlSpec, MapSpec, apply_options, batch_fetch_pages, build_map_options, clamp_js_output, fetch_with,
-    map_with, paginate, render_page, validate_selector, visibility_policy,
+    BatchSpec, CrawlSpec, MapSpec, ToolError, apply_options, batch_fetch_pages, build_map_options, clamp_js_output,
+    crawl_pages, fetch_with, map_with, paginate, render_page, validate_selector, validated_url, visibility_policy,
 };
 
-pub(super) fn validated_url(url: &str) -> Result<String, ErrorData> {
-    crate::tools::validated_url(url).map_err(ErrorData::from)
-}
-
-pub(super) fn tool_error(msg: impl std::fmt::Display) -> CallToolResult {
-    CallToolResult::error(vec![Content::text(msg.to_string())])
-}
-
-pub(super) async fn crawl_pages(spec: CrawlSpec<'_>, max_len: usize) -> Result<Vec<(String, String)>, ErrorData> {
-    crate::tools::crawl_pages(spec, max_len).await.map_err(ErrorData::from)
-}
-
-impl From<ToolError> for ErrorData {
-    fn from(err: ToolError) -> Self {
-        let msg = err.to_string();
-        match err.kind() {
-            ErrorKind::InvalidUrl | ErrorKind::AddressNotAllowed | ErrorKind::InvalidParams => {
-                Self::invalid_params(msg, None)
-            }
-            _ => Self::internal_error(msg, None),
-        }
-    }
+/// Build an `isError` tool result carrying the failure message for the model to react to.
+pub(super) fn tool_error(err: impl std::fmt::Display) -> CallToolResult {
+    CallToolResult::error(vec![Content::text(err.to_string())])
 }

--- a/crates/servo-fetch-cli/tests/mcp.rs
+++ b/crates/servo-fetch-cli/tests/mcp.rs
@@ -31,6 +31,11 @@ fn call_params(name: &str, args: &serde_json::Value) -> rmcp::model::CallToolReq
     params
 }
 
+fn assert_tool_error<E: std::fmt::Debug>(result: Result<rmcp::model::CallToolResult, E>) {
+    let result = result.expect("expected an isError tool result, not a protocol error");
+    assert_eq!(result.is_error, Some(true), "expected isError tool result");
+}
+
 #[tokio::test]
 async fn initialize_returns_server_info() {
     let client = connect().await;
@@ -61,7 +66,7 @@ async fn fetch_rejects_private_ip() {
     let result = client
         .call_tool(call_params("fetch", &serde_json::json!({"url": "http://127.0.0.1/"})))
         .await;
-    assert!(result.is_err());
+    assert_tool_error(result);
 }
 
 #[tokio::test]
@@ -80,7 +85,7 @@ async fn screenshot_rejects_private_ip() {
             &serde_json::json!({"url": "http://127.0.0.1/"}),
         ))
         .await;
-    assert!(result.is_err());
+    assert_tool_error(result);
 }
 
 #[tokio::test]
@@ -92,7 +97,7 @@ async fn execute_js_rejects_private_ip() {
             &serde_json::json!({"url": "http://127.0.0.1/", "expression": "1+1"}),
         ))
         .await;
-    assert!(result.is_err());
+    assert_tool_error(result);
 }
 
 #[tokio::test]
@@ -152,7 +157,7 @@ async fn fetch_rejects_metadata_ip_in_pdf_probe() {
             &serde_json::json!({"url": "http://169.254.169.254/latest/meta-data/foo.pdf"}),
         ))
         .await;
-    assert!(result.is_err());
+    assert_tool_error(result);
 }
 
 #[tokio::test]
@@ -161,7 +166,7 @@ async fn batch_fetch_rejects_empty_urls() {
     let result = client
         .call_tool(call_params("batch_fetch", &serde_json::json!({"urls": []})))
         .await;
-    assert!(result.is_err());
+    assert_tool_error(result);
 }
 
 #[tokio::test]
@@ -173,7 +178,7 @@ async fn batch_fetch_rejects_private_ip() {
             &serde_json::json!({"urls": ["http://127.0.0.1/"]}),
         ))
         .await;
-    assert!(result.is_err());
+    assert_tool_error(result);
 }
 
 #[tokio::test]
@@ -182,7 +187,7 @@ async fn crawl_rejects_private_ip() {
     let result = client
         .call_tool(call_params("crawl", &serde_json::json!({"url": "http://127.0.0.1/"})))
         .await;
-    assert!(result.is_err());
+    assert_tool_error(result);
 }
 
 #[tokio::test]
@@ -198,7 +203,7 @@ async fn crawl_rejects_file_scheme() {
     let result = client
         .call_tool(call_params("crawl", &serde_json::json!({"url": "file:///etc/passwd"})))
         .await;
-    assert!(result.is_err());
+    assert_tool_error(result);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Report all MCP tool failures as `isError` results instead of protocol-level errors. Both input-validation failures (bad URL, oversized selector/expression, empty/oversized batch) and execution failures now return a `CallToolResult` with `isError: true`, so the model receives the error as tool output it can read and react to, rather than a hard JSON-RPC error that aborts the call.

## Related issues

Refs #313

## Test Plan

- `cargo test -p servo-fetch-cli -p servo-fetch-types` - all passed

## Checklist

- [x] Ran `cargo +nightly fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
- [x] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed
- [x] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it