### PR TITLE
feat(cli)!: return full content by default on serve and rpc fetch

### DIFF
--- a/crates/servo-fetch-cli/README.md
+++ b/crates/servo-fetch-cli/README.md
@@ -404,7 +404,7 @@ Responses include `x-request-id` (auto-generated if the request does not supply 
 | `POST` | `/v1/crawl` | BFS crawl starting from a URL |
 | `POST` | `/v1/map` | Discover URLs via sitemaps (no rendering) |
 
-Request and response shapes mirror the MCP tool parameters documented above.
+Request and response shapes mirror the MCP tool parameters above, except `fetch` returns the full document by default (pass `maxLength`/`startIndex` to paginate).
 
 ### Examples
 

--- a/crates/servo-fetch-cli/src/rpc/dispatch.rs
+++ b/crates/servo-fetch-cli/src/rpc/dispatch.rs
@@ -13,7 +13,7 @@ use servo_fetch_types::{
 use tokio::sync::mpsc::UnboundedSender;
 
 use super::protocol::{Notification, PROTOCOL_VERSION, RequestId, ResponseError, code};
-use crate::tools::limits::{DEFAULT_MAX_LENGTH, MAX_JS_LEN, to_len};
+use crate::tools::limits::MAX_JS_LEN;
 use crate::tools::{self, ToolError};
 
 /// Route a request to its handler (`id`/`tx` drive `crawl` progress streaming).
@@ -57,11 +57,8 @@ async fn fetch(params: Value) -> Result<Value, ResponseError> {
     let page = tools::fetch_with(tools::apply_options(opts, req.options)?).await?;
 
     let full = tools::render_page(&page, &url, req.format.unwrap_or_default(), req.selector.as_deref())?;
-    let content = tools::paginate(
-        &servo_fetch::sanitize::sanitize(&full),
-        to_len(req.start_index, 0),
-        to_len(req.max_length, DEFAULT_MAX_LENGTH),
-    );
+    let sanitized = servo_fetch::sanitize::sanitize(&full);
+    let content = tools::paginate_opt(&sanitized, req.start_index, req.max_length);
     Ok(json!(content))
 }
 

--- a/crates/servo-fetch-cli/src/serve/handlers.rs
+++ b/crates/servo-fetch-cli/src/serve/handlers.rs
@@ -33,11 +33,8 @@ pub(super) async fn fetch(Json(req): Json<FetchRequest>) -> Result<AxumJson<Fetc
     let opts = FetchOptions::new(&url).visibility(tools::visibility_policy(req.visibility));
     let page = tools::fetch_with(tools::apply_options(opts, req.options)?).await?;
     let full = tools::render_page(&page, &url, req.format.unwrap_or_default(), req.selector.as_deref())?;
-    let content = tools::paginate(
-        &servo_fetch::sanitize::sanitize(&full),
-        to_len(req.start_index, 0),
-        to_len(req.max_length, DEFAULT_MAX_LENGTH),
-    );
+    let sanitized = servo_fetch::sanitize::sanitize(&full);
+    let content = tools::paginate_opt(&sanitized, req.start_index, req.max_length);
     Ok(AxumJson(FetchResponse { url, content }))
 }
 

--- a/crates/servo-fetch-cli/src/tools.rs
+++ b/crates/servo-fetch-cli/src/tools.rs
@@ -13,4 +13,4 @@ pub(crate) use error::ToolError;
 pub(crate) use fetch::{BatchSpec, batch_fetch_pages, fetch_with};
 pub(crate) use map::{MapSpec, build_map_options, map_with};
 pub(crate) use options::{apply_options, validate_selector, validated_url, visibility_policy};
-pub(crate) use render::{clamp_js_output, paginate, render_page};
+pub(crate) use render::{clamp_js_output, paginate, paginate_opt, render_page};

--- a/crates/servo-fetch-cli/src/tools/render.rs
+++ b/crates/servo-fetch-cli/src/tools/render.rs
@@ -6,7 +6,7 @@ use servo_fetch::Page;
 use servo_fetch_types::FetchFormat;
 
 use super::error::{ToolError, ToolResult};
-use super::limits::MAX_JS_OUTPUT_LEN;
+use super::limits::{DEFAULT_MAX_LENGTH, MAX_JS_OUTPUT_LEN, to_len};
 
 /// Render a fetched page to its pre-pagination string for the requested format.
 pub(crate) fn render_page<'a>(
@@ -54,6 +54,15 @@ pub(crate) fn paginate(content: &str, start: usize, max_len: usize) -> String {
         format!("{chunk}\n\n<content truncated. total_length={total}, next startIndex={end}>")
     } else {
         chunk.to_string()
+    }
+}
+
+/// Full content unless the caller opts into pagination via `startIndex`/`maxLength`.
+pub(crate) fn paginate_opt(content: &str, start: Option<u64>, max_len: Option<u64>) -> String {
+    if start.is_none() && max_len.is_none() {
+        content.to_string()
+    } else {
+        paginate(content, to_len(start, 0), to_len(max_len, DEFAULT_MAX_LENGTH))
     }
 }
 


### PR DESCRIPTION
## Summary

The JSON-RPC `fetch` method and the HTTP `/v1/fetch` endpoint no longer truncate to 5000 characters by default — they now return the full document. Pagination is opt-in via `maxLength`/`startIndex`. The MCP `fetch` tool keeps the 5000-char default, since truncation is an LLM-context concern.

## Test Plan

- `cargo test -p servo-fetch-cli -p servo-fetch-types`
- Manual: `servo-fetch serve` + `servo-fetch rpc` — confirmed `fetch` without `maxLength` returns full content (no truncation hint), and `maxLength` still paginates

## Checklist

- [x] Ran `cargo +nightly fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
- [x] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed
- [x] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it