### PR TITLE
fix(cli): capture the a11y tree for the accessibility_tree format

### DIFF
--- a/crates/servo-fetch-cli/src/mcp/server.rs
+++ b/crates/servo-fetch-cli/src/mcp/server.rs
@@ -111,9 +111,10 @@ impl ServoFetchMcp {
 async fn run_fetch(p: FetchRequest) -> Result<CallToolResult, tools::ToolError> {
     let url = tools::validated_url(&p.url)?;
     tools::validate_selector(p.selector.as_deref())?;
-    let opts = FetchOptions::new(&url).visibility(tools::visibility_policy(p.visibility));
+    let format = p.format.unwrap_or_default();
+    let opts = tools::content_options(&url, format, tools::visibility_policy(p.visibility));
     let page = tools::fetch_with(tools::apply_options(opts, p.options)?).await?;
-    let full = tools::render_page(&page, &url, p.format.unwrap_or_default(), p.selector.as_deref())?;
+    let full = tools::render_page(&page, &url, format, p.selector.as_deref())?;
     let content = tools::paginate(
         &servo_fetch::sanitize::sanitize(&full),
         to_len(p.start_index, 0),

--- a/crates/servo-fetch-cli/src/mcp/tools.rs
+++ b/crates/servo-fetch-cli/src/mcp/tools.rs
@@ -4,7 +4,8 @@ use rmcp::model::{CallToolResult, Content};
 
 pub(super) use crate::tools::{
     BatchSpec, CrawlSpec, MapSpec, ToolError, apply_options, batch_fetch_pages, build_map_options, clamp_js_output,
-    crawl_pages, fetch_with, map_with, paginate, render_page, validate_selector, validated_url, visibility_policy,
+    content_options, crawl_pages, fetch_with, map_with, paginate, render_page, validate_selector, validated_url,
+    visibility_policy,
 };
 
 /// Build an `isError` tool result carrying the failure message for the model to react to.

--- a/crates/servo-fetch-cli/src/rpc/dispatch.rs
+++ b/crates/servo-fetch-cli/src/rpc/dispatch.rs
@@ -53,10 +53,11 @@ async fn fetch(params: Value) -> Result<Value, ResponseError> {
     let url = tools::validated_url(&req.url)?;
     tools::validate_selector(req.selector.as_deref())?;
 
-    let opts = FetchOptions::new(&url).visibility(tools::visibility_policy(req.visibility));
+    let format = req.format.unwrap_or_default();
+    let opts = tools::content_options(&url, format, tools::visibility_policy(req.visibility));
     let page = tools::fetch_with(tools::apply_options(opts, req.options)?).await?;
 
-    let full = tools::render_page(&page, &url, req.format.unwrap_or_default(), req.selector.as_deref())?;
+    let full = tools::render_page(&page, &url, format, req.selector.as_deref())?;
     let sanitized = servo_fetch::sanitize::sanitize(&full);
     let content = tools::paginate_opt(&sanitized, req.start_index, req.max_length);
     Ok(json!(content))

--- a/crates/servo-fetch-cli/src/serve/handlers.rs
+++ b/crates/servo-fetch-cli/src/serve/handlers.rs
@@ -30,9 +30,10 @@ pub(super) async fn fetch(Json(req): Json<FetchRequest>) -> Result<AxumJson<Fetc
     let url = tools::validated_url(&req.url)?;
     tools::validate_selector(req.selector.as_deref())?;
 
-    let opts = FetchOptions::new(&url).visibility(tools::visibility_policy(req.visibility));
+    let format = req.format.unwrap_or_default();
+    let opts = tools::content_options(&url, format, tools::visibility_policy(req.visibility));
     let page = tools::fetch_with(tools::apply_options(opts, req.options)?).await?;
-    let full = tools::render_page(&page, &url, req.format.unwrap_or_default(), req.selector.as_deref())?;
+    let full = tools::render_page(&page, &url, format, req.selector.as_deref())?;
     let sanitized = servo_fetch::sanitize::sanitize(&full);
     let content = tools::paginate_opt(&sanitized, req.start_index, req.max_length);
     Ok(AxumJson(FetchResponse { url, content }))

--- a/crates/servo-fetch-cli/src/tools.rs
+++ b/crates/servo-fetch-cli/src/tools.rs
@@ -12,5 +12,5 @@ pub(crate) use crawl::{CrawlSpec, build_crawl_options, crawl_pages};
 pub(crate) use error::ToolError;
 pub(crate) use fetch::{BatchSpec, batch_fetch_pages, fetch_with};
 pub(crate) use map::{MapSpec, build_map_options, map_with};
-pub(crate) use options::{apply_options, validate_selector, validated_url, visibility_policy};
+pub(crate) use options::{apply_options, content_options, validate_selector, validated_url, visibility_policy};
 pub(crate) use render::{clamp_js_output, paginate, paginate_opt, render_page};

--- a/crates/servo-fetch-cli/src/tools/fetch.rs
+++ b/crates/servo-fetch-cli/src/tools/fetch.rs
@@ -8,7 +8,7 @@ use tokio::sync::Semaphore;
 use tokio::task::{JoinSet, spawn_blocking};
 
 use super::error::{ToolError, ToolResult};
-use super::options::apply_options;
+use super::options::{apply_options, content_options};
 use super::render::{paginate, render_page};
 
 const DEFAULT_MAX_CONCURRENT_FETCHES: usize = 4;
@@ -83,7 +83,7 @@ fn render_one(
     visibility: VisibilityPolicy,
     options: RequestOptions,
 ) -> String {
-    let opts = match apply_options(FetchOptions::new(url).visibility(visibility), options) {
+    let opts = match apply_options(content_options(url, format, visibility), options) {
         Ok(opts) => opts,
         Err(e) => return format!("[error] {e}"),
     };

--- a/crates/servo-fetch-cli/src/tools/options.rs
+++ b/crates/servo-fetch-cli/src/tools/options.rs
@@ -4,10 +4,17 @@ use std::collections::BTreeMap;
 use std::time::Duration;
 
 use servo_fetch::{CookieSpec, FetchOptions, HeaderMap, VisibilityPolicy};
-use servo_fetch_types::{RequestOptions, Visibility};
+use servo_fetch_types::{FetchFormat, RequestOptions, Visibility};
 
 use super::error::{ToolError, ToolResult};
 use super::limits::{MAX_SELECTOR_LEN, MAX_SETTLE_MS, MAX_TIMEOUT_SECS};
+
+/// Base options for a content fetch; captures the accessibility tree only when the format needs it.
+pub(crate) fn content_options(url: &str, format: FetchFormat, visibility: VisibilityPolicy) -> FetchOptions {
+    FetchOptions::new(url)
+        .visibility(visibility)
+        .accessibility(matches!(format, FetchFormat::AccessibilityTree))
+}
 
 /// Map the wire visibility policy onto the engine policy (default: moderate).
 pub(crate) fn visibility_policy(v: Option<Visibility>) -> VisibilityPolicy {

--- a/crates/servo-fetch/src/fetch.rs
+++ b/crates/servo-fetch/src/fetch.rs
@@ -213,13 +213,10 @@ impl From<crate::bridge::ConsoleMessage> for ConsoleMessage {
     }
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub(crate) enum FetchMode {
-    #[default]
-    Content,
-    Screenshot {
-        full_page: bool,
-    },
+    Content { include_a11y: bool },
+    Screenshot { full_page: bool },
     JavaScript(String),
 }
 
@@ -253,7 +250,7 @@ impl FetchOptions {
             url: url.into(),
             timeout: None,
             settle: None,
-            mode: FetchMode::Content,
+            mode: FetchMode::Content { include_a11y: false },
             user_agent: None,
             extract_schema: None,
             visibility: None,
@@ -317,6 +314,14 @@ impl FetchOptions {
     /// Custom request headers sent with the navigation request.
     pub fn headers(mut self, headers: http::HeaderMap) -> Self {
         self.headers = headers;
+        self
+    }
+
+    /// Capture the page's accessibility tree (read via [`Page::accessibility_tree`]).
+    pub fn accessibility(mut self, on: bool) -> Self {
+        if let FetchMode::Content { include_a11y } = &mut self.mode {
+            *include_a11y = on;
+        }
         self
     }
 
@@ -392,7 +397,7 @@ fn pre_fetch(opts: &FetchOptions) -> crate::error::Result<Option<Page>> {
     crate::net::ensure_crypto_provider();
     crate::net::validate_url(&opts.url)?;
 
-    if matches!(opts.mode, FetchMode::Content)
+    if matches!(opts.mode, FetchMode::Content { .. })
         && let Some(bytes) = crate::pdf::probe(&opts.url, opts.effective_timeout().as_secs().max(1))
     {
         return Ok(Some(pdf_page(&bytes)));
@@ -405,7 +410,7 @@ async fn pre_fetch_async(opts: &FetchOptions) -> crate::error::Result<Option<Pag
     crate::net::ensure_crypto_provider();
     crate::net::validate_url(&opts.url)?;
 
-    if matches!(opts.mode, FetchMode::Content) {
+    if matches!(opts.mode, FetchMode::Content { .. }) {
         let url = opts.url.clone();
         let timeout_secs = opts.effective_timeout().as_secs().max(1);
         let probe = tokio::task::spawn_blocking(move || crate::pdf::probe(&url, timeout_secs))
@@ -437,7 +442,7 @@ fn build_bridge_options(opts: &FetchOptions) -> crate::bridge::FetchOptions<'_> 
         cookies: &opts.cookies,
         headers: &opts.headers,
         mode: match opts.mode {
-            FetchMode::Content => crate::bridge::FetchMode::Content { include_a11y: false },
+            FetchMode::Content { include_a11y } => crate::bridge::FetchMode::Content { include_a11y },
             FetchMode::Screenshot { full_page } => crate::bridge::FetchMode::Screenshot { full_page },
             FetchMode::JavaScript(ref expr) => crate::bridge::FetchMode::ExecuteJs {
                 expression: expr.clone(),
@@ -476,7 +481,21 @@ mod tests {
         assert_eq!(opts.timeout, None);
         assert_eq!(opts.settle, None);
         assert_eq!(opts.visibility, None);
-        assert!(matches!(opts.mode, FetchMode::Content));
+        assert!(matches!(opts.mode, FetchMode::Content { .. }));
+    }
+
+    #[test]
+    fn accessibility_flag_threads_into_content_mode() {
+        let off = FetchOptions::new("https://example.com");
+        assert!(matches!(
+            build_bridge_options(&off).mode,
+            crate::bridge::FetchMode::Content { include_a11y: false }
+        ));
+        let on = FetchOptions::new("https://example.com").accessibility(true);
+        assert!(matches!(
+            build_bridge_options(&on).mode,
+            crate::bridge::FetchMode::Content { include_a11y: true }
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The `accessibility_tree` fetch format silently returned an empty string because the engine never captured the accessibility tree for a content fetch (`include_a11y` was hardcoded `false`). Add a `FetchOptions::accessibility(bool)` capability (carried in the `Content` mode variant, mirroring the bridge), and have the fetch/batch handlers request it only when the output format is `accessibility_tree` — so the cost is paid only when the tree is needed.

## Test Plan

- `cargo test -p servo-fetch -p servo-fetch-cli`: all passed

## Checklist

- [x] Ran `cargo +nightly fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
- [x] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed
- [x] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it