### PR TITLE
chore(ci): publish to crates.io via release-plz trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,7 @@ jobs:
     environment: release-plz
     permissions:
       contents: read
+      id-token: write
     outputs:
       releases_created: ${{ steps.release-plz.outputs.releases_created }}
       tag: ${{ steps.tag.outputs.tag }}
@@ -222,33 +223,6 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
-  publish-crate:
-    name: Publish to crates.io
-    needs: [release-plz-release, build-release]
-    if: needs.release-plz-release.outputs.tag != ''
-    runs-on: ubuntu-24.04
-    timeout-minutes: 15
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          ref: refs/tags/${{ needs.release-plz-release.outputs.tag }}
-          persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
-        with:
-          toolchain: "1.95.0"
-      - name: Dry-run package
-        run: |
-          cargo package --locked --list -p servo-fetch >/dev/null
-          cargo package --locked --list -p servo-fetch-cli >/dev/null
-      - uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe # v1.0.4
-        id: auth
-      - name: Publish to crates.io
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
-        run: cargo publish --workspace --locked --no-verify
-
   publish-docker:
     name: Publish Docker image
     needs: [release-plz-release, build-release]
@@ -359,7 +333,7 @@ jobs:
 
   publish-release:
     name: Publish release
-    needs: [release-plz-release, build-release, publish-crate, publish-docker, trivy-scan]
+    needs: [release-plz-release, build-release, publish-docker, trivy-scan]
     if: needs.release-plz-release.outputs.tag != ''
     runs-on: ubuntu-24.04
     timeout-minutes: 5

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,6 +1,5 @@
 [workspace]
 changelog_update = false
-publish = false
 git_tag_enable = false
 git_release_enable = false
 release = false

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,5 +1,6 @@
 [workspace]
 changelog_update = false
+publish_no_verify = true
 git_tag_enable = false
 git_release_enable = false
 release = false


### PR DESCRIPTION
## Summary

Publish to crates.io via release-plz's native trusted publishing (OIDC) instead of a dedicated `cargo publish` job.

- Drop the `publish-crate` job (`cargo publish --workspace` + `crates-io-auth-action`)
- Add `id-token: write` to `release-plz-release` so release-plz mints the OIDC token itself
- Remove `publish = false` from `release-plz.toml`

release-plz only publishes *unpublished* crates, so partial-failure re-runs are idempotent (no more "crate already exists" errors). Also removes the long-lived `CARGO_REGISTRY_TOKEN` path and simplifies CI.

## Related issues

N/A

## Test Plan

N/A

## Checklist

- [ ] Ran `cargo +nightly fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
- [ ] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed — n/a, no user-facing change
- [ ] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it