### PR TITLE
docs: surface node.js sdk in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 servo-fetch embeds the [Servo](https://servo.org/) browser engine. It executes JavaScript, computes CSS layout,
 captures screenshots with a software renderer, and extracts clean content — available as a CLI, a Rust library,
-and a Python SDK.
+a Python SDK, and a Node.js SDK.
 
 ```bash
 # CLI
@@ -29,6 +29,12 @@ let md = servo_fetch::markdown("https://example.com").await?;
 # Python
 page = servo_fetch.fetch("https://example.com")
 print(page.markdown)
+```
+
+```ts
+// Node.js
+import { fetch } from "servo-fetch";
+const md = await fetch("https://example.com");
 ```
 
 ## Why servo-fetch
@@ -200,6 +206,12 @@ const md = await fetch("https://example.com");
 for await (const page of crawl("https://docs.example.com", { limit: 50 })) {
   if (page.ok) console.log(page.url, page.title);
 }
+```
+
+Or run the bundled CLI without installing:
+
+```bash
+npx servo-fetch "https://example.com"
 ```
 
 Full API reference → [`bindings/node`](bindings/node/README.md)


### PR DESCRIPTION
## Summary

Surface the Node.js SDK in README so all four bindings are represented equally.

## Related issues

N/A

## Test Plan

N/A

## Checklist

- [ ] Ran `cargo +nightly fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
- [x] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed
- [ ] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it
