### PR TITLE
fix(build): loosen internal dep version reqs to caret

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,8 +44,8 @@ rustls = { version = "0.23", default-features = false, features = ["aws-lc-rs"] 
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 servo = { version = "0.2.0", default-features = false, features = ["baked-in-resources", "js_jit"] }
-servo-fetch = { path = "crates/servo-fetch", version = "=0.13.0" }
-servo-fetch-types = { path = "crates/servo-fetch-types", version = "=0.13.0" }
+servo-fetch = { path = "crates/servo-fetch", version = "0.13.0" }
+servo-fetch-types = { path = "crates/servo-fetch-types", version = "0.13.0" }
 tempfile = "3"
 thiserror = "2"
 tokio = { version = "1", features = ["rt-multi-thread"] }


### PR DESCRIPTION
## Summary

Loosen the internal `servo-fetch` / `servo-fetch-types` dependency requirements in `[workspace.dependencies]` from exact `=0.13.0` to caret `0.13.0`.

## Related issues

N/A

## Test Plan

- `cargo metadata`: resolves cleanly
- `cargo test`: all passed

## Checklist

- [x] Ran `cargo +nightly fmt`, `cargo clippy`, and `cargo test` locally
- [ ] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed
- [ ] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it