### PR TITLE
fix(ci): publish release with app token

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -2,7 +2,7 @@ name: Release npm
 
 on:
   release:
-    types: [released]
+    types: [published]
   workflow_dispatch:
     inputs:
       tag:
@@ -24,6 +24,7 @@ jobs:
     name: Publish to npm
     runs-on: ubuntu-24.04
     timeout-minutes: 20
+    if: ${{ github.event_name != 'release' || !github.event.release.prerelease }}
     environment:
       name: release-npm
       url: https://www.npmjs.com/package/servo-fetch

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -337,11 +337,19 @@ jobs:
     if: needs.release-plz-release.outputs.tag != ''
     runs-on: ubuntu-24.04
     timeout-minutes: 5
+    environment: release-plz
     permissions:
-      contents: write
+      contents: read
     env:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       REPO: ${{ github.repository }}
       TAG: ${{ needs.release-plz-release.outputs.tag }}
     steps:
-      - run: gh release edit "$TAG" --repo "$REPO" --draft=false
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token
+        with:
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          permission-contents: write
+      - env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: gh release edit "$TAG" --repo "$REPO" --draft=false


### PR DESCRIPTION
## Summary

`Release npm` never fired for v0.13.1 (npm stayed on 0.13.0 while crates.io / PyPI / GitHub Release published). Root cause: `publish-release` un-drafts the GitHub Release with `GITHUB_TOKEN`, and events triggered by `GITHUB_TOKEN` do not start other workflows — so the `release` event that `release-npm.yml` listens for was never emitted.

## Related issues

N/A

## Test Plan

- `actionlint` and `zizmor`: all passed

## Checklist

- [ ] Ran `cargo +nightly fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
- [ ] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed
- [ ] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it