### PR TITLE
fix(deps): bump pyo3 and pythonize to 0.29

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4969,9 +4969,9 @@ checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
 
 [[package]]
 name = "pyo3"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91fd8e38a3b50ed1167fb981cd6fd60147e091784c427b8f7183a7ee32c31c12"
+checksum = "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
 dependencies = [
  "libc",
  "once_cell",
@@ -4983,18 +4983,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e368e7ddfdeb98c9bca7f8383be1648fd84ab466bf2bc015e94008db6d35611e"
+checksum = "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
 dependencies = [
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f29e10af80b1f7ccaf7f69eace800a03ecd13e883acfacc1e5d0988605f651e"
+checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -5002,9 +5002,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df6e520eff47c45997d2fc7dd8214b25dd1310918bbb2642156ef66a67f29813"
+checksum = "9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -5014,22 +5014,21 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4cdc218d835738f81c2338f822078af45b4afdf8b2e33cbb5916f108b813acb"
+checksum = "4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
- "pyo3-build-config",
  "quote",
  "syn",
 ]
 
 [[package]]
 name = "pythonize"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b79f670c9626c8b651c0581011b57b6ba6970bb69faf01a7c4c0cfc81c43f95"
+checksum = "6ec376e1216e0c929a74964ce2020012a1a39f32d80e78aa688721219ea7fb89"
 dependencies = [
  "pyo3",
  "serde",

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -16,8 +16,8 @@ default = []
 extension-module = ["pyo3/extension-module"]
 
 [dependencies]
-pyo3 = { version = "0.28", features = ["abi3-py310"] }
-pythonize = "0.28"
+pyo3 = { version = "0.29", features = ["abi3-py310"] }
+pythonize = "0.29"
 servo-fetch = { workspace = true }
 serde_json = { workspace = true }
 humantime = { workspace = true }

--- a/deny.toml
+++ b/deny.toml
@@ -11,8 +11,6 @@ ignore = [
   "RUSTSEC-2025-0100", # unic-char-property unmaintained
   "RUSTSEC-2025-0141", # ml-dsa timing side-channel
   "RUSTSEC-2025-0144", # rsa marvin attack
-  "RUSTSEC-2026-0176", # pyo3 nth() overflow; fixed in pyo3 0.29, blocked on pythonize 0.29 release
-  "RUSTSEC-2026-0177", # pyo3 PyCFunction Sync bound; fixed in pyo3 0.29, blocked on pythonize 0.29 release
 ]
 
 [licenses]


### PR DESCRIPTION
## Summary

Bumps `pyo3` 0.28 → 0.29 and `pythonize` 0.28 → 0.29 in the Python bindings, and drops the two now-resolved advisory ignores from `deny.toml`.

## Related issues

Resolves RUSTSEC-2026-0176 and RUSTSEC-2026-0177 by upgrading past them, and removes their `ignore` entries in `deny.toml`.

## Test Plan

- `cargo check -p servo-fetch-python`: all passed
- `cargo deny check`: all passed

## Checklist

- [x] Ran `cargo +nightly fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
- [x] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed
- [x] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it