### PR TITLE
chore(node): migrate biome config to 2.5.0

### DIFF
--- a/bindings/node/biome.jsonc
+++ b/bindings/node/biome.jsonc
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.0/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",
@@ -16,7 +16,7 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true
+      "preset": "recommended"
     }
   },
   "assist": {


### PR DESCRIPTION
## Summary

Migrates the Node bindings' Biome config (`bindings/node/biome.jsonc`) to the 2.5.0 format, following the `@biomejs/biome` 2.5.0 bump in #327.

## Related issues

Follow-up to #327.

## Test Plan

- `biome ci`: all passed

## Checklist

- [ ] Ran `cargo +nightly fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
- [x] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed
- [x] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it