### PR TITLE
chore(deps): bump rmcp from 1 to 2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5441,9 +5441,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "1.7.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0810a9f717d9828f475fe1f629f4c305c8464b7f496c3a854b58d29e65f4058e"
+checksum = "14db48ee17a9ba61810ab1a9c1beb7d06d8136ae39ac25a1137f10d357af01af"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5473,9 +5473,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.7.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aefac48c364756e97f04c0401ba3231e8607882c7c1d92da0437dc16307904d"
+checksum = "783d787bf21813b285f13019adc49e11af501c658890c1e519f31f937c68b7e3"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ pdf-extract = "0.12"
 predicates = "3"
 psl = "2"
 quick-xml = "0.41"
-rmcp = { version = "1", features = ["server", "transport-io", "transport-streamable-http-server", "macros"] }
+rmcp = { version = "2", features = ["server", "transport-io", "transport-streamable-http-server", "macros"] }
 rustls = { version = "0.23", default-features = false, features = ["aws-lc-rs"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/servo-fetch-cli/src/mcp/server.rs
+++ b/crates/servo-fetch-cli/src/mcp/server.rs
@@ -5,7 +5,7 @@ use std::fmt::Write as _;
 use base64::Engine as _;
 use rmcp::handler::server::router::tool::ToolRouter;
 use rmcp::handler::server::wrapper::Parameters;
-use rmcp::model::{CallToolResult, Content, ProtocolVersion, ServerCapabilities, ServerInfo};
+use rmcp::model::{CallToolResult, ContentBlock, ProtocolVersion, ServerCapabilities, ServerInfo};
 use rmcp::{ErrorData, ServerHandler, tool, tool_handler, tool_router};
 use servo_fetch::FetchOptions;
 use servo_fetch_types::{
@@ -120,7 +120,7 @@ async fn run_fetch(p: FetchRequest) -> Result<CallToolResult, tools::ToolError> 
         to_len(p.start_index, 0),
         to_len(p.max_length, DEFAULT_MAX_LENGTH),
     );
-    Ok(CallToolResult::success(vec![Content::text(content)]))
+    Ok(CallToolResult::success(vec![ContentBlock::text(content)]))
 }
 
 async fn run_screenshot(p: ScreenshotRequest) -> Result<CallToolResult, tools::ToolError> {
@@ -130,7 +130,7 @@ async fn run_screenshot(p: ScreenshotRequest) -> Result<CallToolResult, tools::T
     let png = page
         .screenshot_png()
         .ok_or_else(|| tools::ToolError::internal("screenshot capture failed"))?;
-    Ok(CallToolResult::success(vec![Content::image(
+    Ok(CallToolResult::success(vec![ContentBlock::image(
         base64::engine::general_purpose::STANDARD.encode(png),
         "image/png",
     )]))
@@ -152,7 +152,7 @@ async fn run_execute_js(p: EvaluateRequest) -> Result<CallToolResult, tools::Too
             let _ = writeln!(result, "[{:?}] {}", msg.level, msg.message);
         }
     }
-    Ok(CallToolResult::success(vec![Content::text(
+    Ok(CallToolResult::success(vec![ContentBlock::text(
         servo_fetch::sanitize::sanitize(&result).into_owned(),
     )]))
 }
@@ -181,7 +181,10 @@ async fn run_batch_fetch(p: BatchFetchRequest) -> Result<CallToolResult, tools::
         options: p.options,
     })
     .await;
-    let contents: Vec<Content> = results.into_iter().map(|(_url, text)| Content::text(text)).collect();
+    let contents: Vec<ContentBlock> = results
+        .into_iter()
+        .map(|(_url, text)| ContentBlock::text(text))
+        .collect();
     Ok(CallToolResult::success(contents))
 }
 
@@ -204,7 +207,10 @@ async fn run_crawl(p: CrawlRequest) -> Result<CallToolResult, tools::ToolError> 
         to_len(p.max_length, DEFAULT_MAX_LENGTH),
     )
     .await?;
-    let contents: Vec<Content> = results.into_iter().map(|(_url, text)| Content::text(text)).collect();
+    let contents: Vec<ContentBlock> = results
+        .into_iter()
+        .map(|(_url, text)| ContentBlock::text(text))
+        .collect();
     Ok(CallToolResult::success(contents))
 }
 
@@ -226,7 +232,7 @@ async fn run_map(p: MapRequest) -> Result<CallToolResult, tools::ToolError> {
         .map(|entry| entry.url)
         .collect::<Vec<_>>()
         .join("\n");
-    Ok(CallToolResult::success(vec![Content::text(urls)]))
+    Ok(CallToolResult::success(vec![ContentBlock::text(urls)]))
 }
 
 #[tool_handler]

--- a/crates/servo-fetch-cli/src/mcp/tools.rs
+++ b/crates/servo-fetch-cli/src/mcp/tools.rs
@@ -1,6 +1,6 @@
 //! MCP-specific helpers over the shared [`crate::tools`] business logic.
 
-use rmcp::model::{CallToolResult, Content};
+use rmcp::model::{CallToolResult, ContentBlock};
 
 pub(super) use crate::tools::{
     BatchSpec, CrawlSpec, MapSpec, ToolError, apply_options, batch_fetch_pages, build_map_options, clamp_js_output,
@@ -10,5 +10,5 @@ pub(super) use crate::tools::{
 
 /// Build an `isError` tool result carrying the failure message for the model to react to.
 pub(super) fn tool_error(err: impl std::fmt::Display) -> CallToolResult {
-    CallToolResult::error(vec![Content::text(err.to_string())])
+    CallToolResult::error(vec![ContentBlock::text(err.to_string())])
 }

--- a/crates/servo-fetch-cli/tests/mcp.rs
+++ b/crates/servo-fetch-cli/tests/mcp.rs
@@ -73,7 +73,7 @@ async fn fetch_rejects_private_ip() {
 async fn fetch_rejects_missing_url() {
     let client = connect().await;
     let result = client.call_tool(call_params("fetch", &serde_json::json!({}))).await;
-    assert!(result.is_err());
+    assert_tool_error(result);
 }
 
 #[tokio::test]
@@ -121,7 +121,7 @@ async fn fetch_returns_content() {
         .await
         .unwrap();
     assert!(!result.content.is_empty());
-    let text = &result.content[0].raw.as_text().unwrap().text;
+    let text = &result.content[0].as_text().unwrap().text;
     assert!(text.contains("Hello from Servo"), "got: {text}");
 }
 
@@ -194,7 +194,7 @@ async fn crawl_rejects_private_ip() {
 async fn crawl_rejects_missing_url() {
     let client = connect().await;
     let result = client.call_tool(call_params("crawl", &serde_json::json!({}))).await;
-    assert!(result.is_err());
+    assert_tool_error(result);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Bumps `rmcp` from 1 to 2 (2.2.0) and migrates the MCP server to the 2.x API.

## Related issues

Supersedes #346

## Test Plan

- `cargo test --workspace --locked`: all passed

## Checklist

- [x] Ran `cargo +nightly fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
- [x] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed
- [x] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it