### PR TITLE
refactor(engine): route fetches through an EngineMsg dispatch envelope

### DIFF
--- a/crates/servo-fetch/src/bridge.rs
+++ b/crates/servo-fetch/src/bridge.rs
@@ -309,8 +309,16 @@ struct PendingFetch {
     dedicated_ctx: Option<Rc<SoftwareRenderingContext>>,
 }
 
+/// A message handed to the Servo engine thread. Today every message is a
+/// stateless one-shot [`FetchRequest`]; the enum is the dispatch envelope so the
+/// engine thread can grow further message kinds without reworking the channel
+/// plumbing.
+enum EngineMsg {
+    Fetch(FetchRequest),
+}
+
 struct Engine {
-    requests: mpsc::Sender<FetchRequest>,
+    requests: mpsc::Sender<EngineMsg>,
     wake: Arc<WakeFlag>,
     policy: crate::net::NetworkPolicy,
 }
@@ -357,7 +365,7 @@ const PENDING_CAPACITY: usize = 64;
 
 fn ensure_engine() -> &'static Engine {
     ENGINE.get_or_init(|| {
-        let (tx, rx) = mpsc::channel::<FetchRequest>(PENDING_CAPACITY);
+        let (tx, rx) = mpsc::channel::<EngineMsg>(PENDING_CAPACITY);
         let wake = Arc::new(WakeFlag::default());
         let wake_for_thread = wake.clone();
         let policy = pending_policy();
@@ -399,14 +407,17 @@ pub(crate) fn fetch_page(opts: FetchOptions<'_>) -> Result<ServoPage, EngineErro
             let _ = reply_tx.send(r);
         }),
     );
-    engine.requests.try_send(request).map_err(|e| match e {
-        mpsc::error::TrySendError::Full(_) => {
-            anyhow!("Servo engine queue is full ({PENDING_CAPACITY} pending); back off and retry")
-        }
-        mpsc::error::TrySendError::Closed(_) => {
-            anyhow!("Servo engine is not running (it may have crashed on a previous request)")
-        }
-    })?;
+    engine
+        .requests
+        .try_send(EngineMsg::Fetch(request))
+        .map_err(|e| match e {
+            mpsc::error::TrySendError::Full(_) => {
+                anyhow!("Servo engine queue is full ({PENDING_CAPACITY} pending); back off and retry")
+            }
+            mpsc::error::TrySendError::Closed(_) => {
+                anyhow!("Servo engine is not running (it may have crashed on a previous request)")
+            }
+        })?;
     engine.wake.signal();
     reply_rx
         .recv()
@@ -424,7 +435,7 @@ pub(crate) async fn fetch_page_async(opts: FetchOptions<'_>) -> Result<ServoPage
     );
     engine
         .requests
-        .send(request)
+        .send(EngineMsg::Fetch(request))
         .await
         .map_err(|_| anyhow!("Servo engine is not running (it may have crashed on a previous request)"))?;
     engine.wake.signal();
@@ -441,13 +452,13 @@ fn is_apple_gl_driver_noise(line: &str) -> bool {
     clippy::needless_pass_by_value,
     reason = "the thread owns its receiver for its lifetime"
 )]
-fn servo_thread(mut request_rx: mpsc::Receiver<FetchRequest>, wake: Arc<WakeFlag>, policy: crate::net::NetworkPolicy) {
+fn servo_thread(mut request_rx: mpsc::Receiver<EngineMsg>, wake: Arc<WakeFlag>, policy: crate::net::NetworkPolicy) {
     let _filter = crate::sys::StderrFilter::install(is_apple_gl_driver_noise).ok();
 
     let (rc_ctx, servo) = match build_servo(FlagWaker(wake.clone())) {
         Ok(pair) => pair,
         Err(e) => {
-            if let Some(req) = request_rx.blocking_recv() {
+            if let Some(EngineMsg::Fetch(req)) = request_rx.blocking_recv() {
                 (req.reply)(Err(e.context("Servo initialization failed").into()));
             }
             return;
@@ -466,14 +477,14 @@ fn servo_thread(mut request_rx: mpsc::Receiver<FetchRequest>, wake: Arc<WakeFlag
     let mut pending: HashMap<WebViewId, PendingFetch> = HashMap::new();
 
     loop {
-        while let Ok(req) = request_rx.try_recv() {
-            accept_request(&servo, &rc_ctx, &delegate, &ucm, req, &mut pending);
+        while let Ok(msg) = request_rx.try_recv() {
+            accept_message(&servo, &rc_ctx, &delegate, &ucm, msg, &mut pending);
         }
 
         if pending.is_empty() {
-            // Idle: block until a new request nudges us or the channel hangs up.
+            // Idle: block until a new message nudges us or the channel hangs up.
             match request_rx.blocking_recv() {
-                Some(req) => accept_request(&servo, &rc_ctx, &delegate, &ucm, req, &mut pending),
+                Some(msg) => accept_message(&servo, &rc_ctx, &delegate, &ucm, msg, &mut pending),
                 None => return,
             }
             continue;
@@ -500,16 +511,20 @@ fn servo_thread(mut request_rx: mpsc::Receiver<FetchRequest>, wake: Arc<WakeFlag
     }
 }
 
-fn accept_request(
+fn accept_message(
     servo: &servo::Servo,
     rc_ctx: &Rc<SoftwareRenderingContext>,
     delegate: &Rc<SharedDelegate>,
     ucm: &Rc<UserContentManager>,
-    req: FetchRequest,
+    msg: EngineMsg,
     pending: &mut HashMap<WebViewId, PendingFetch>,
 ) {
-    if let Some(p) = start_fetch(servo, rc_ctx, delegate, ucm, req) {
-        pending.insert(p.webview.id(), p);
+    match msg {
+        EngineMsg::Fetch(req) => {
+            if let Some(p) = start_fetch(servo, rc_ctx, delegate, ucm, req) {
+                pending.insert(p.webview.id(), p);
+            }
+        }
     }
 }
 

--- a/crates/servo-fetch/src/bridge.rs
+++ b/crates/servo-fetch/src/bridge.rs
@@ -458,8 +458,10 @@ fn servo_thread(mut request_rx: mpsc::Receiver<EngineMsg>, wake: Arc<WakeFlag>, 
     let (rc_ctx, servo) = match build_servo(FlagWaker(wake.clone())) {
         Ok(pair) => pair,
         Err(e) => {
-            if let Some(EngineMsg::Fetch(req)) = request_rx.blocking_recv() {
-                (req.reply)(Err(e.context("Servo initialization failed").into()));
+            if let Some(msg) = request_rx.blocking_recv() {
+                match msg {
+                    EngineMsg::Fetch(req) => (req.reply)(Err(e.context("Servo initialization failed").into())),
+                }
             }
             return;
         }

--- a/crates/servo-fetch/src/bridge.rs
+++ b/crates/servo-fetch/src/bridge.rs
@@ -309,16 +309,16 @@ struct PendingFetch {
     dedicated_ctx: Option<Rc<SoftwareRenderingContext>>,
 }
 
-/// A message handed to the Servo engine thread. Today every message is a
-/// stateless one-shot [`FetchRequest`]; the enum is the dispatch envelope so the
-/// engine thread can grow further message kinds without reworking the channel
-/// plumbing.
+/// Dispatch envelope for the Servo engine thread; today the only kind is a stateless one-shot [`FetchRequest`].
 enum EngineMsg {
     Fetch(FetchRequest),
 }
 
+type EngineTx = mpsc::Sender<EngineMsg>;
+type EngineRx = mpsc::Receiver<EngineMsg>;
+
 struct Engine {
-    requests: mpsc::Sender<EngineMsg>,
+    requests: EngineTx,
     wake: Arc<WakeFlag>,
     policy: crate::net::NetworkPolicy,
 }
@@ -452,7 +452,7 @@ fn is_apple_gl_driver_noise(line: &str) -> bool {
     clippy::needless_pass_by_value,
     reason = "the thread owns its receiver for its lifetime"
 )]
-fn servo_thread(mut request_rx: mpsc::Receiver<EngineMsg>, wake: Arc<WakeFlag>, policy: crate::net::NetworkPolicy) {
+fn servo_thread(mut request_rx: EngineRx, wake: Arc<WakeFlag>, policy: crate::net::NetworkPolicy) {
     let _filter = crate::sys::StderrFilter::install(is_apple_gl_driver_noise).ok();
 
     let (rc_ctx, servo) = match build_servo(FlagWaker(wake.clone())) {


### PR DESCRIPTION
Per your offer in #339 — splitting out the self-contained engine-thread
refactor so it can land on its own, independent of any WebDriver/actions work.

## What

Wrap the servo-engine channel payload in an `EngineMsg` enum (currently a
single `Fetch` variant) instead of sending `FetchRequest` directly, and rename
the dispatch helper `accept_request` → `accept_message`.

## Why

Gives the engine thread a single typed entry point that can grow further
message kinds without reworking the channel plumbing — the groundwork for a
future multi-step interaction path, but useful on its own as a cleaner seam.

## Scope

Pure internal refactor:
- no behavior change
- no public API change (everything is `pub(crate)`/private)
- no new dependencies
- no feature gates / conditional compilation

## Verification

- `cargo clippy -p servo-fetch --all-targets -- -D warnings` — clean
- `cargo test -p servo-fetch` — unit + doctests pass (e2e ignored as before)
- `cargo +nightly fmt --all -- --check` — clean