### PR TITLE
fix(ci): ignore RUSTSEC-2026-0206 (rustybuzz unmaintained)

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -12,6 +12,7 @@ ignore = [
   "RUSTSEC-2025-0141", # ml-dsa timing side-channel
   "RUSTSEC-2025-0144", # rsa marvin attack
   "RUSTSEC-2026-0192", # ttf-parser unmaintained
+  "RUSTSEC-2026-0206", # rustybuzz unmaintained
 ]
 
 [licenses]


### PR DESCRIPTION
## Summary

Ignore RUSTSEC-2026-0206 (`rustybuzz` unmaintained) in `deny.toml`.

## Test Plan

- `cargo deny check`: all passed

## Checklist

- [x] Ran `cargo deny check` and `taplo fmt --check` locally
- [ ] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed
- [ ] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it