### PR TITLE
chore(deps): bump spin from 0.9.8 to 0.9.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7643,9 +7643,9 @@ checksum = "b72d540d5c565dbe1f891d7e21ceb21d2649508306782f1066989fccb0b363d3"
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 
 [[package]]
 name = "spki"


### PR DESCRIPTION
## Summary

Updates the transitive `spin` dependency from 0.9.8 to 0.9.9 because 0.9.8 was yanked.

## Related issues

N/A

## Test Plan

Verified on macOS:

- `cargo clippy --profile ci --workspace --locked --all-targets -- -D warnings`: all passed
- `cargo test-ci`: all passed
- `cargo deny check`: all passed

## Checklist

- [x] Ran `cargo +nightly fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
- [ ] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed
- [ ] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it