### PR TITLE
fix(pdf): preserve request context during PDF fetch

### DIFF
--- a/crates/servo-fetch/src/cookies.rs
+++ b/crates/servo-fetch/src/cookies.rs
@@ -147,6 +147,39 @@ fn cookie_for(
     Some((url, builder.build()))
 }
 
+pub(crate) fn request_header(target: &Url, specs: &[CookieSpec]) -> Option<http::HeaderValue> {
+    let host = target.host_str()?.to_ascii_lowercase();
+    let request_path = target.path();
+    let secure = target.scheme() == "https";
+    let mut matches = specs
+        .iter()
+        .filter(|spec| {
+            let domain = spec.domain.trim_start_matches('.').to_ascii_lowercase();
+            let domain_matches = if spec.domain.starts_with('.') || spec.include_subdomains {
+                host == domain || host.ends_with(&format!(".{domain}"))
+            } else {
+                host == domain
+            };
+            domain_matches && (!spec.secure || secure) && path_matches(request_path, &spec.path)
+        })
+        .collect::<Vec<_>>();
+    matches.sort_by_key(|spec| std::cmp::Reverse(spec.path.len()));
+    let value = matches
+        .into_iter()
+        .map(|spec| format!("{}={}", spec.name, spec.value))
+        .collect::<Vec<_>>()
+        .join("; ");
+    (!value.is_empty())
+        .then(|| http::HeaderValue::from_str(&value).ok())
+        .flatten()
+}
+
+fn path_matches(request_path: &str, cookie_path: &str) -> bool {
+    request_path == cookie_path
+        || request_path
+            .strip_prefix(cookie_path)
+            .is_some_and(|suffix| cookie_path.ends_with('/') || suffix.starts_with('/'))
+}
 fn has_control(s: &str) -> bool {
     s.bytes().any(|b| b < 0x20 || b == 0x7f)
 }
@@ -253,6 +286,29 @@ mod tests {
     fn missing_file_reports_path() {
         let err = load_cookies("/no/such/cookies.txt").unwrap_err();
         assert!(matches!(err, Error::Cookies { .. }));
+    }
+
+    #[test]
+    fn request_header_applies_cookie_retrieval_rules() {
+        let mut host_only = spec("api.example.com", false);
+        host_only.name = "host".into();
+        let mut domain = spec(".example.com", false);
+        domain.name = "domain".into();
+        domain.include_subdomains = true;
+        domain.path = "/public/deep".into();
+        let mut path = spec("www.example.com", false);
+        path.name = "path".into();
+        path.path = "/admin".into();
+        let mut secure = spec("www.example.com", true);
+        secure.name = "secure".into();
+        let target = Url::parse("http://www.example.com/public/deep/report.pdf").unwrap();
+
+        let header = request_header(&target, &[host_only, domain, path, secure])
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_owned();
+        assert_eq!(header, "domain=v");
     }
 
     #[test]

--- a/crates/servo-fetch/src/cookies.rs
+++ b/crates/servo-fetch/src/cookies.rs
@@ -4,12 +4,15 @@ use std::io::Read;
 use std::path::Path;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use url::Url;
+use url::{Host, Url};
 
 use crate::error::{Error, Result};
 
 const MAX_FILE_BYTES: u64 = 4 << 20;
 const MAX_COOKIES: usize = 3000;
+const MAX_COOKIE_NAME_VALUE_BYTES: usize = 4096;
+const MAX_COOKIE_HEADER_BYTES: usize = 8190;
+const COOKIE_HEADER_PREFIX_BYTES: usize = "Cookie: ".len();
 
 /// A cookie to seed into the jar before navigation.
 #[derive(Clone, PartialEq, Eq)]
@@ -18,6 +21,7 @@ pub struct CookieSpec {
     value: String,
     domain: String,
     path: String,
+    expires: Option<i64>,
     secure: bool,
     http_only: bool,
     include_subdomains: bool,
@@ -30,6 +34,7 @@ impl std::fmt::Debug for CookieSpec {
             .field("value", &"<redacted>")
             .field("domain", &self.domain)
             .field("path", &self.path)
+            .field("expires", &self.expires)
             .field("secure", &self.secure)
             .field("http_only", &self.http_only)
             .field("include_subdomains", &self.include_subdomains)
@@ -60,6 +65,8 @@ enum ParseError {
     FieldCount { line: usize, found: usize },
     #[error("line {line}: illegal character in cookie name or value")]
     IllegalChar { line: usize },
+    #[error("line {line}: cookie name and value exceed {max} bytes")]
+    TooLarge { line: usize, max: usize },
     #[error("too many cookies (max {max})")]
     TooMany { max: usize },
 }
@@ -81,31 +88,112 @@ fn parse_cookies(text: &str) -> std::result::Result<Vec<CookieSpec>, ParseError>
                 found: fields.len(),
             });
         };
-        if has_control(name) || name.contains([';', '=']) || has_control(value) || value.contains(';') {
+        if name.is_empty()
+            || has_control(name)
+            || name.contains([';', '='])
+            || has_control(value)
+            || value.contains(';')
+        {
             return Err(ParseError::IllegalChar { line });
         }
-        if expires
+        if name.len().saturating_add(value.len()) > MAX_COOKIE_NAME_VALUE_BYTES {
+            return Err(ParseError::TooLarge {
+                line,
+                max: MAX_COOKIE_NAME_VALUE_BYTES,
+            });
+        }
+
+        let path = if cpath.starts_with('/') { cpath } else { "/" };
+        let include_subdomains = include_sub.eq_ignore_ascii_case("TRUE");
+        let existing = out
+            .iter()
+            .position(|cookie| same_cookie_key(cookie, name, domain, path));
+        let expires_at = match expires
             .split('.')
             .next()
-            .and_then(|s| s.trim().parse::<i64>().ok())
-            .is_some_and(|e| e > 0 && e <= now)
+            .and_then(|value| value.trim().parse::<i64>().ok())
         {
+            Some(0) => None,
+            Some(expiry) if expiry > 0 => Some(expiry),
+            _ => continue,
+        };
+        if expires_at.is_some_and(|expiry| expiry <= now) {
+            if let Some(index) = existing {
+                out.remove(index);
+            }
             continue;
         }
-        if out.len() >= MAX_COOKIES {
-            return Err(ParseError::TooMany { max: MAX_COOKIES });
-        }
-        out.push(CookieSpec {
+
+        let cookie = CookieSpec {
             name: name.to_owned(),
             value: value.to_owned(),
             domain: domain.to_owned(),
-            path: if cpath.is_empty() { "/" } else { cpath }.to_owned(),
+            path: path.to_owned(),
+            expires: expires_at,
             secure: secure.eq_ignore_ascii_case("TRUE"),
             http_only,
-            include_subdomains: include_sub.eq_ignore_ascii_case("TRUE"),
-        });
+            include_subdomains,
+        };
+        if let Some(index) = existing {
+            out[index] = cookie;
+        } else {
+            if out.len() >= MAX_COOKIES {
+                return Err(ParseError::TooMany { max: MAX_COOKIES });
+            }
+            out.push(cookie);
+        }
     }
     Ok(out)
+}
+
+fn canonical_cookie_host(domain: &str) -> Option<Host<String>> {
+    let domain = domain.strip_prefix('.').unwrap_or(domain);
+    if domain.contains(':') && !domain.starts_with('[') {
+        Host::parse(&format!("[{domain}]")).ok()
+    } else {
+        Host::parse(domain).ok()
+    }
+}
+
+fn same_cookie_key(cookie: &CookieSpec, name: &str, domain: &str, path: &str) -> bool {
+    let domains_equal = match (canonical_cookie_host(&cookie.domain), canonical_cookie_host(domain)) {
+        (Some(left), Some(right)) => left == right,
+        _ => cookie
+            .domain
+            .strip_prefix('.')
+            .unwrap_or(&cookie.domain)
+            .eq_ignore_ascii_case(domain.strip_prefix('.').unwrap_or(domain)),
+    };
+    cookie.name == name && domains_equal && cookie.path == path
+}
+
+fn domain_matches(target: &Url, spec: &CookieSpec) -> bool {
+    match (target.host(), canonical_cookie_host(&spec.domain)) {
+        (Some(Host::Domain(request)), Some(Host::Domain(cookie))) => {
+            request == cookie
+                || (spec.include_subdomains
+                    && request
+                        .strip_suffix(&cookie)
+                        .is_some_and(|prefix| prefix.ends_with('.')))
+        }
+        (Some(Host::Ipv4(request)), Some(Host::Ipv4(cookie))) => request == cookie,
+        (Some(Host::Ipv6(request)), Some(Host::Ipv6(cookie))) => request == cookie,
+        _ => false,
+    }
+}
+
+fn is_secure_context(target: &Url) -> bool {
+    target.scheme() == "https"
+        || match target.host() {
+            Some(Host::Domain(domain)) => domain == "localhost",
+            Some(Host::Ipv4(address)) => address.is_loopback(),
+            Some(Host::Ipv6(address)) => address.is_loopback(),
+            None => false,
+        }
+}
+
+fn cookie_is_expired(cookie: &CookieSpec, now: i64) -> bool {
+    cookie.expires.is_some_and(|expiry| expiry <= now)
 }
 
 /// Seed `specs` into the jar, scoped to `target`'s site and the network policy.
@@ -129,7 +217,11 @@ fn cookie_for(
     spec: &CookieSpec,
     policy: crate::net::NetworkPolicy,
 ) -> Option<(Url, cookie::Cookie<'static>)> {
-    let host = spec.domain.trim_start_matches('.');
+    if cookie_is_expired(spec, now_unix()) {
+        return None;
+    }
+    let host = canonical_cookie_host(&spec.domain)?;
+    let host = host.to_string();
     let scheme = if spec.secure { "https" } else { "http" };
     let url = Url::parse(&format!("{scheme}://{host}{}", spec.path)).ok()?;
     if crate::net::validate_url_with_policy(url.as_str(), policy).is_err() || !crate::scope::is_same_site(target, &url)
@@ -141,34 +233,54 @@ fn cookie_for(
         .path(spec.path.clone())
         .secure(spec.secure)
         .http_only(spec.http_only);
-    if spec.domain.starts_with('.') || spec.include_subdomains {
-        builder = builder.domain(url.host_str().unwrap_or(host).to_owned());
+    if let Some(expires) = spec.expires
+        && let Ok(expires) = cookie::time::OffsetDateTime::from_unix_timestamp(expires)
+    {
+        builder = builder.expires(expires);
+    }
+    if spec.include_subdomains {
+        builder = builder.domain(url.host_str().unwrap_or(&host).to_owned());
     }
     Some((url, builder.build()))
 }
 
 pub(crate) fn request_header(target: &Url, specs: &[CookieSpec]) -> Option<http::HeaderValue> {
-    let host = target.host_str()?.to_ascii_lowercase();
     let request_path = target.path();
-    let secure = target.scheme() == "https";
+    let secure = is_secure_context(target);
+    let now = now_unix();
     let mut matches = specs
         .iter()
         .filter(|spec| {
-            let domain = spec.domain.trim_start_matches('.').to_ascii_lowercase();
-            let domain_matches = if spec.domain.starts_with('.') || spec.include_subdomains {
-                host == domain || host.ends_with(&format!(".{domain}"))
-            } else {
-                host == domain
-            };
-            domain_matches && (!spec.secure || secure) && path_matches(request_path, &spec.path)
+            !cookie_is_expired(spec, now)
+                && domain_matches(target, spec)
+                && (!spec.secure || secure)
+                && path_matches(request_path, &spec.path)
         })
         .collect::<Vec<_>>();
+    // RFC 6265 section 5.4: longer paths first. `sort_by_key` is stable, so
+    // equal-length paths preserve the file order used as creation order.
     matches.sort_by_key(|spec| std::cmp::Reverse(spec.path.len()));
-    let value = matches
-        .into_iter()
-        .map(|spec| format!("{}={}", spec.name, spec.value))
-        .collect::<Vec<_>>()
-        .join("; ");
+
+    let mut value = String::new();
+    for spec in matches {
+        let separator_len = usize::from(!value.is_empty()) * 2;
+        let pair_len = spec.name.len().saturating_add(1).saturating_add(spec.value.len());
+        if COOKIE_HEADER_PREFIX_BYTES
+            .saturating_add(value.len())
+            .saturating_add(separator_len)
+            .saturating_add(pair_len)
+            >= MAX_COOKIE_HEADER_BYTES
+        {
+            tracing::warn!(name = %spec.name, "omitted cookies after reaching outgoing header limit");
+            break;
+        }
+        if !value.is_empty() {
+            value.push_str("; ");
+        }
+        value.push_str(&spec.name);
+        value.push('=');
+        value.push_str(&spec.value);
+    }
     (!value.is_empty())
         .then(|| http::HeaderValue::from_str(&value).ok())
         .flatten()
@@ -194,6 +306,7 @@ fn now_unix() -> i64 {
 
 #[cfg(test)]
 mod tests {
+    use std::fmt::Write as _;
     use std::io::Write as _;
 
     use super::*;
@@ -205,6 +318,7 @@ mod tests {
             value: "v".into(),
             domain: domain.into(),
             path: "/".into(),
+            expires: None,
             secure,
             http_only: false,
             include_subdomains: false,
@@ -231,9 +345,9 @@ mod tests {
 
     #[test]
     fn drops_expired_keeps_session() {
-        // integer- and float-formatted past timestamps are dropped; 0 = session is kept.
+        // Past, negative, and malformed timestamps are dropped; 0 is a session cookie.
         let specs = parse_cookies(
-            "x.com\tFALSE\t/\tFALSE\t100\told\tv\nx.com\tFALSE\t/\tFALSE\t1700000000.5\tfloat\tv\nx.com\tFALSE\t/\tFALSE\t0\tlive\tv\n",
+            "x.com\tFALSE\t/\tFALSE\t100\told\tv\nx.com\tFALSE\t/\tFALSE\t1700000000.5\tfloat\tv\nx.com\tFALSE\t/\tFALSE\t-1\tnegative\tv\nx.com\tFALSE\t/\tFALSE\tinvalid\tmalformed\tv\nx.com\tFALSE\t/\tFALSE\t0\tlive\tv\n",
         )
         .unwrap();
         assert_eq!(specs.len(), 1);
@@ -241,8 +355,54 @@ mod tests {
     }
 
     #[test]
-    fn empty_path_defaults_to_root() {
+    fn duplicate_cookie_replaces_value_and_expiry_deletes() {
+        let replaced = parse_cookies(concat!(
+            ".example.com\tTRUE\t/\tFALSE\t0\tsid\told\n",
+            "example.com\tFALSE\t/\tTRUE\t0\tsid\tnew\n",
+        ))
+        .unwrap();
+        assert_eq!(replaced.len(), 1);
+        assert_eq!(replaced[0].value, "new");
+        assert!(replaced[0].secure);
+        assert!(!replaced[0].include_subdomains);
+
+        let deleted = parse_cookies(concat!(
+            "example.com\tFALSE\t/\tFALSE\t0\tsid\tlive\n",
+            "example.com\tFALSE\t/\tFALSE\t1\tsid\tdeleted\n",
+        ))
+        .unwrap();
+        assert!(deleted.is_empty());
+    }
+
+    #[test]
+    fn expiry_is_preserved_and_rechecked() {
+        let future = now_unix() + 60;
+        let parsed = parse_cookies(&format!("example.com\tFALSE\t/\tFALSE\t{future}\tsid\tlive\n")).unwrap();
+        assert_eq!(parsed[0].expires, Some(future));
+
+        let mut expired = spec("example.com", false);
+        expired.expires = Some(1);
+        let target = Url::parse("https://example.com/report.pdf").unwrap();
+        assert!(request_header(&target, std::slice::from_ref(&expired)).is_none());
+        assert!(cookie_for(&target, &expired, NetworkPolicy::STRICT).is_none());
+    }
+
+    #[test]
+    fn rejects_oversized_cookie() {
+        let input = format!(
+            "example.com\tFALSE\t/\tFALSE\t0\tn\t{}\n",
+            "x".repeat(MAX_COOKIE_NAME_VALUE_BYTES)
+        );
+        assert!(matches!(parse_cookies(&input), Err(ParseError::TooLarge { .. })));
+    }
+
+    #[test]
+    fn invalid_or_empty_path_defaults_to_root() {
         assert_eq!(parse_cookies("x.com\tFALSE\t\tFALSE\t0\tn\tv\n").unwrap()[0].path, "/");
+        assert_eq!(
+            parse_cookies("x.com\tFALSE\taccount\tFALSE\t0\tn\tv\n").unwrap()[0].path,
+            "/"
+        );
     }
 
     #[test]
@@ -252,6 +412,7 @@ mod tests {
 
     #[test]
     fn rejects_illegal_chars() {
+        assert!(parse_cookies("x.com\tFALSE\t/\tFALSE\t0\t\tv\n").is_err());
         assert!(parse_cookies("x.com\tFALSE\t/\tFALSE\t0\tn\ta;b\n").is_err());
         assert!(parse_cookies("x.com\tFALSE\t/\tFALSE\t0\tn=x\tv\n").is_err());
         // '=' is legal in a value (e.g. base64 padding).
@@ -275,6 +436,7 @@ mod tests {
                 value: "v".to_owned(),
                 domain: ".example.com".to_owned(),
                 path: "/".to_owned(),
+                expires: None,
                 secure: false,
                 http_only: false,
                 include_subdomains: true,
@@ -312,6 +474,85 @@ mod tests {
     }
 
     #[test]
+    fn request_header_respects_tailmatch_and_ip_rules() {
+        let target = Url::parse("https://www.example.com/report.pdf").unwrap();
+        let mut cookie = spec(".example.com", false);
+        assert!(request_header(&target, std::slice::from_ref(&cookie)).is_none());
+        cookie.include_subdomains = true;
+        assert_eq!(request_header(&target, &[cookie]).unwrap().to_str().unwrap(), "n=v");
+
+        let target = Url::parse("http://127.0.0.1/report.pdf").unwrap();
+        let mut suffix = spec("0.0.1", false);
+        suffix.include_subdomains = true;
+        assert!(request_header(&target, &[suffix]).is_none());
+        assert_eq!(
+            request_header(&target, &[spec("127.0.0.1", false)])
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            "n=v"
+        );
+    }
+
+    #[test]
+    fn request_header_canonicalizes_idna_and_allows_secure_loopback() {
+        let target = Url::parse("http://xn--bcher-kva.example/report.pdf").unwrap();
+        assert_eq!(
+            request_header(&target, &[spec("bücher.example", false)])
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            "n=v"
+        );
+
+        for url in [
+            "http://localhost/report.pdf",
+            "http://127.0.0.2/report.pdf",
+            "http://[::1]/report.pdf",
+        ] {
+            let target = Url::parse(url).unwrap();
+            let domain = target.host_str().unwrap();
+            assert_eq!(
+                request_header(&target, &[spec(domain, true)])
+                    .unwrap()
+                    .to_str()
+                    .unwrap(),
+                "n=v"
+            );
+        }
+    }
+
+    #[test]
+    fn request_header_orders_stably_and_caps_output() {
+        let mut root = spec("example.com", false);
+        root.name = "root".into();
+        let mut first = spec("example.com", false);
+        first.name = "first".into();
+        first.path = "/account".into();
+        let mut second = spec("example.com", false);
+        second.name = "second".into();
+        second.path = "/account".into();
+        let target = Url::parse("https://example.com/account/report.pdf").unwrap();
+        assert_eq!(
+            request_header(&target, &[root, first, second])
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            "first=v; second=v; root=v"
+        );
+
+        let mut first = spec("example.com", false);
+        first.name = "a".into();
+        first.value = "x".repeat(MAX_COOKIE_NAME_VALUE_BYTES - 1);
+        let mut second = first.clone();
+        second.name = "b".into();
+        let header = request_header(&target, &[first, second]).unwrap();
+        let value = header.to_str().unwrap();
+        assert!(value.starts_with("a=") && !value.contains("; b="));
+        assert!(COOKIE_HEADER_PREFIX_BYTES + value.len() < MAX_COOKIE_HEADER_BYTES);
+    }
+
+    #[test]
     fn debug_redacts_value() {
         let mut c = spec("example.com", false);
         c.value = "SUPERSECRET".into();
@@ -321,7 +562,10 @@ mod tests {
 
     #[test]
     fn rejects_too_many_cookies() {
-        let text = "x.com\tFALSE\t/\tFALSE\t0\tn\tv\n".repeat(MAX_COOKIES + 1);
+        let mut text = String::new();
+        for index in 0..=MAX_COOKIES {
+            writeln!(text, "x.com\tFALSE\t/\tFALSE\t0\tn{index}\tv").unwrap();
+        }
         assert!(matches!(parse_cookies(&text), Err(ParseError::TooMany { .. })));
     }
 
@@ -335,12 +579,18 @@ mod tests {
     #[test]
     fn cookie_for_derives_origin_and_domain_attr() {
         let target = Url::parse("https://example.com/").unwrap();
-        // host-only over https: secure flag picks the https origin, no Domain attribute.
+        // Host-only over https: secure flag picks the https origin, no Domain attribute.
         let (url, c) = cookie_for(&target, &spec("example.com", true), NetworkPolicy::STRICT).unwrap();
         assert_eq!(url.scheme(), "https");
         assert!(c.domain().is_none());
-        // leading dot makes it a domain cookie scoped to the registrable host.
+
+        // The Netscape tailmatch column, not a decorative leading dot, controls
+        // whether the cookie is a domain cookie.
         let (_, c) = cookie_for(&target, &spec(".example.com", false), NetworkPolicy::STRICT).unwrap();
+        assert!(c.domain().is_none());
+        let mut domain = spec(".example.com", false);
+        domain.include_subdomains = true;
+        let (_, c) = cookie_for(&target, &domain, NetworkPolicy::STRICT).unwrap();
         assert_eq!(c.domain(), Some("example.com"));
     }
 
@@ -349,5 +599,9 @@ mod tests {
         let target = Url::parse("http://127.0.0.1/").unwrap();
         assert!(cookie_for(&target, &spec("127.0.0.1", false), NetworkPolicy::STRICT).is_none());
         assert!(cookie_for(&target, &spec("127.0.0.1", false), NetworkPolicy::PERMISSIVE).is_some());
+
+        let target = Url::parse("http://[::1]/").unwrap();
+        let (url, _) = cookie_for(&target, &spec("::1", false), NetworkPolicy::PERMISSIVE).unwrap();
+        assert_eq!(url.host(), Some(Host::Ipv6("::1".parse().unwrap())));
     }
 }

--- a/crates/servo-fetch/src/fetch.rs
+++ b/crates/servo-fetch/src/fetch.rs
@@ -401,31 +401,40 @@ fn pre_fetch(opts: &FetchOptions) -> crate::error::Result<Option<Page>> {
     crate::net::ensure_crypto_provider();
     crate::net::validate_url(&opts.url)?;
 
-    if matches!(opts.mode, FetchMode::Content { .. })
-        && let Some(bytes) = crate::pdf::probe(&opts.url, opts.effective_timeout().as_secs().max(1))
-    {
-        return Ok(Some(pdf_page(&bytes)));
-    }
-
-    Ok(None)
-}
-
-async fn pre_fetch_async(opts: &FetchOptions) -> crate::error::Result<Option<Page>> {
-    crate::net::ensure_crypto_provider();
-    crate::net::validate_url(&opts.url)?;
-
     if matches!(opts.mode, FetchMode::Content { .. }) {
-        let url = opts.url.clone();
-        let timeout_secs = opts.effective_timeout().as_secs().max(1);
-        let probe = tokio::task::spawn_blocking(move || crate::pdf::probe(&url, timeout_secs))
-            .await
-            .map_err(|e| Error::engine(anyhow::anyhow!("pdf probe task panicked: {e}"), Some(opts.url.clone())))?;
-        if let Some(bytes) = probe {
+        let headers = pdf_headers(opts)?;
+        if let Some(bytes) = crate::pdf::probe(
+            &opts.url,
+            opts.effective_timeout().as_secs().max(1),
+            opts.user_agent.as_deref(),
+            &headers,
+        ) {
             return Ok(Some(pdf_page(&bytes)));
         }
     }
 
     Ok(None)
+}
+
+fn pdf_headers(opts: &FetchOptions) -> crate::error::Result<http::HeaderMap> {
+    let mut headers = opts.headers.clone();
+    let target = url::Url::parse(&opts.url).map_err(|error| Error::InvalidUrl {
+        url: opts.url.clone(),
+        reason: error.to_string(),
+    })?;
+    if !headers.contains_key(http::header::COOKIE)
+        && let Some(cookie) = crate::cookies::request_header(&target, &opts.cookies)
+    {
+        headers.insert(http::header::COOKIE, cookie);
+    }
+    Ok(headers)
+}
+
+async fn pre_fetch_async(opts: &FetchOptions) -> crate::error::Result<Option<Page>> {
+    let options = opts.clone();
+    tokio::task::spawn_blocking(move || pre_fetch(&options))
+        .await
+        .map_err(|error| Error::engine(error, Some(opts.url.clone())))?
 }
 
 fn pdf_page(bytes: &[u8]) -> Page {
@@ -671,6 +680,22 @@ mod tests {
     fn fetch_rejects_file_scheme() {
         let result = fetch_blocking(&FetchOptions::new("file:///etc/passwd"));
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn pdf_headers_preserve_explicit_cookie() {
+        use std::io::Write as _;
+
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        writeln!(file, ".example.com\tTRUE\t/\tFALSE\t0\traw\tloser").unwrap();
+        let cookies = crate::load_cookies(file.path()).unwrap();
+        let mut headers = http::HeaderMap::new();
+        headers.insert(http::header::COOKIE, http::HeaderValue::from_static("raw=winner"));
+        let options = FetchOptions::new("https://www.example.com/report.pdf")
+            .cookies(cookies)
+            .headers(headers);
+
+        assert_eq!(pdf_headers(&options).unwrap()[http::header::COOKIE], "raw=winner");
     }
 
     mod page_from_servo {

--- a/crates/servo-fetch/src/pdf.rs
+++ b/crates/servo-fetch/src/pdf.rs
@@ -1,23 +1,22 @@
-//! PDF detection and retrieval, run before Servo so PDF handling never
-//! blocks concurrent `WebView`s in the engine queue.
+//! Bounded PDF retrieval for one-shot fetches.
 
 use std::time::Duration;
 
 use anyhow::{Context as _, Result};
 
 const MAX_PDF_BYTES: u64 = 50 * 1024 * 1024;
-const HEAD_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Return PDF bytes when the resource is a PDF, `None` otherwise.
-pub(crate) fn probe(url: &str, timeout_secs: u64) -> Option<Vec<u8>> {
+pub(crate) fn probe(
+    url: &str,
+    timeout_secs: u64,
+    user_agent: Option<&str>,
+    headers: &http::HeaderMap,
+) -> Option<Vec<u8>> {
     if !looks_like_pdf_url(url) {
         return None;
     }
-    let overall = Duration::from_secs(timeout_secs);
-    if !head_is_pdf(url, HEAD_TIMEOUT.min(overall)) {
-        return None;
-    }
-    fetch_bytes(url, overall).ok()
+    fetch_bytes(url, Duration::from_secs(timeout_secs), user_agent, headers).ok()
 }
 
 fn looks_like_pdf_url(url: &str) -> bool {
@@ -30,21 +29,22 @@ fn looks_like_pdf_url(url: &str) -> bool {
     })
 }
 
-fn head_is_pdf(url: &str, timeout: Duration) -> bool {
-    let Ok(resp) = build_agent(timeout).head(url).call() else {
-        return false;
-    };
-    resp.headers()
+fn fetch_bytes(url: &str, timeout: Duration, user_agent: Option<&str>, headers: &http::HeaderMap) -> Result<Vec<u8>> {
+    let agent = build_agent(timeout, user_agent);
+    let mut request = agent.get(url);
+    for (name, value) in headers {
+        request = request.header(name.clone(), value.clone());
+    }
+    let response = request.call().with_context(|| format!("PDF GET failed for {url}"))?;
+    let is_pdf = response
+        .headers()
         .get("content-type")
-        .and_then(|v| v.to_str().ok())
-        .is_some_and(|ct| ct.to_ascii_lowercase().starts_with("application/pdf"))
-}
-
-fn fetch_bytes(url: &str, timeout: Duration) -> Result<Vec<u8>> {
-    build_agent(timeout)
-        .get(url)
-        .call()
-        .with_context(|| format!("PDF GET failed for {url}"))?
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|value| value.to_ascii_lowercase().starts_with("application/pdf"));
+    if !is_pdf {
+        anyhow::bail!("response is not a PDF");
+    }
+    response
         .into_body()
         .with_config()
         .limit(MAX_PDF_BYTES)
@@ -52,13 +52,14 @@ fn fetch_bytes(url: &str, timeout: Duration) -> Result<Vec<u8>> {
         .context("PDF body read failed")
 }
 
-fn build_agent(timeout: Duration) -> ureq::Agent {
-    ureq::Agent::new_with_config(
-        ureq::config::Config::builder()
-            .max_redirects(0)
-            .timeout_global(Some(timeout))
-            .build(),
-    )
+fn build_agent(timeout: Duration, user_agent: Option<&str>) -> ureq::Agent {
+    let mut config = ureq::config::Config::builder()
+        .max_redirects(0)
+        .timeout_global(Some(timeout));
+    if let Some(user_agent) = user_agent {
+        config = config.user_agent(user_agent);
+    }
+    ureq::Agent::new_with_config(config.build())
 }
 
 #[cfg(test)]
@@ -79,33 +80,39 @@ mod tests {
     #[test]
     fn probe_skips_non_pdf_urls_without_network() {
         // No network traffic because suffix check fails first.
-        assert!(probe("https://example.com/page.html", 1).is_none());
+        assert!(probe("https://example.com/page.html", 1, None, &http::HeaderMap::new()).is_none());
     }
 
     #[test]
     fn probe_returns_none_for_unresolvable_host() {
-        // Suffix matches, HEAD fails quickly.
-        assert!(probe("http://invalid.invalid/foo.pdf", 1).is_none());
+        // Suffix matches, but GET fails quickly.
+        assert!(probe("http://invalid.invalid/foo.pdf", 1, None, &http::HeaderMap::new()).is_none());
     }
 
     mod integration {
-        use wiremock::matchers::{method, path};
+        use wiremock::matchers::{header, method, path};
         use wiremock::{Mock, MockServer, ResponseTemplate};
 
         use crate::pdf::probe;
 
+        async fn run_probe_with(
+            url: String,
+            timeout: u64,
+            user_agent: Option<&'static str>,
+            headers: http::HeaderMap,
+        ) -> Option<Vec<u8>> {
+            tokio::task::spawn_blocking(move || probe(&url, timeout, user_agent, &headers))
+                .await
+                .unwrap()
+        }
+
         async fn run_probe(url: String, timeout: u64) -> Option<Vec<u8>> {
-            tokio::task::spawn_blocking(move || probe(&url, timeout)).await.unwrap()
+            run_probe_with(url, timeout, None, http::HeaderMap::new()).await
         }
 
         #[tokio::test]
-        async fn returns_bytes_when_head_advertises_pdf() {
+        async fn returns_bytes_when_get_is_pdf() {
             let server = MockServer::start().await;
-            Mock::given(method("HEAD"))
-                .and(path("/doc.pdf"))
-                .respond_with(ResponseTemplate::new(200).insert_header("content-type", "application/pdf"))
-                .mount(&server)
-                .await;
             Mock::given(method("GET"))
                 .and(path("/doc.pdf"))
                 .respond_with(ResponseTemplate::new(200).set_body_raw(b"%PDF-1.4 minimal".to_vec(), "application/pdf"))
@@ -117,9 +124,40 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn returns_none_when_head_says_html() {
+        async fn sends_request_context_to_get() {
             let server = MockServer::start().await;
-            Mock::given(method("HEAD"))
+            let required = || {
+                Mock::given(header("user-agent", "TestBot/1.0"))
+                    .and(header("authorization", "Bearer test"))
+                    .and(header("cookie", "sid=seed"))
+                    .and(path("/protected.pdf"))
+            };
+            required()
+                .and(method("GET"))
+                .respond_with(ResponseTemplate::new(200).set_body_raw(b"PDF".to_vec(), "application/pdf"))
+                .mount(&server)
+                .await;
+            let mut headers = http::HeaderMap::new();
+            headers.insert(
+                http::header::AUTHORIZATION,
+                http::HeaderValue::from_static("Bearer test"),
+            );
+            headers.insert(http::header::COOKIE, http::HeaderValue::from_static("sid=seed"));
+
+            let bytes = run_probe_with(
+                format!("{}/protected.pdf", server.uri()),
+                5,
+                Some("TestBot/1.0"),
+                headers,
+            )
+            .await;
+            assert_eq!(bytes.as_deref(), Some(&b"PDF"[..]));
+        }
+
+        #[tokio::test]
+        async fn returns_none_when_get_says_html() {
+            let server = MockServer::start().await;
+            Mock::given(method("GET"))
                 .and(path("/lying.pdf"))
                 .respond_with(ResponseTemplate::new(200).insert_header("content-type", "text/html"))
                 .mount(&server)
@@ -129,9 +167,9 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn returns_none_when_head_lacks_content_type() {
+        async fn returns_none_when_get_lacks_content_type() {
             let server = MockServer::start().await;
-            Mock::given(method("HEAD"))
+            Mock::given(method("GET"))
                 .and(path("/no-ct.pdf"))
                 .respond_with(ResponseTemplate::new(200))
                 .mount(&server)
@@ -141,9 +179,9 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn returns_none_when_head_returns_404() {
+        async fn returns_none_when_get_returns_404() {
             let server = MockServer::start().await;
-            Mock::given(method("HEAD"))
+            Mock::given(method("GET"))
                 .and(path("/missing.pdf"))
                 .respond_with(ResponseTemplate::new(404))
                 .mount(&server)
@@ -155,11 +193,6 @@ mod tests {
         #[tokio::test]
         async fn skips_non_pdf_url_without_any_request() {
             let server = MockServer::start().await;
-            Mock::given(method("HEAD"))
-                .respond_with(ResponseTemplate::new(500))
-                .expect(0)
-                .mount(&server)
-                .await;
             Mock::given(method("GET"))
                 .respond_with(ResponseTemplate::new(500))
                 .expect(0)
@@ -172,16 +205,11 @@ mod tests {
         #[tokio::test]
         async fn accepts_content_type_with_parameter() {
             let server = MockServer::start().await;
-            Mock::given(method("HEAD"))
-                .and(path("/x.pdf"))
-                .respond_with(
-                    ResponseTemplate::new(200).insert_header("content-type", "application/pdf; charset=binary"),
-                )
-                .mount(&server)
-                .await;
             Mock::given(method("GET"))
                 .and(path("/x.pdf"))
-                .respond_with(ResponseTemplate::new(200).set_body_raw(b"PDF".to_vec(), "application/pdf"))
+                .respond_with(
+                    ResponseTemplate::new(200).set_body_raw(b"PDF".to_vec(), "application/pdf; charset=binary"),
+                )
                 .mount(&server)
                 .await;
 
@@ -193,10 +221,9 @@ mod tests {
 
         #[tokio::test]
         async fn does_not_follow_redirects() {
-            // PDF probe is configured with `max_redirects(0)` to avoid SSRF bypass via
-            // redirect to a private IP.
+            // Disable redirects to prevent SSRF bypass.
             let server = MockServer::start().await;
-            Mock::given(method("HEAD"))
+            Mock::given(method("GET"))
                 .and(path("/redirect.pdf"))
                 .respond_with(ResponseTemplate::new(302).insert_header("location", "https://example.com/"))
                 .mount(&server)
@@ -209,14 +236,8 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn head_request_actually_uses_head_method() {
+        async fn probe_uses_single_get_request() {
             let server = MockServer::start().await;
-            Mock::given(method("HEAD"))
-                .and(path("/big.pdf"))
-                .respond_with(ResponseTemplate::new(200).insert_header("content-type", "application/pdf"))
-                .expect(1)
-                .mount(&server)
-                .await;
             Mock::given(method("GET"))
                 .and(path("/big.pdf"))
                 .respond_with(ResponseTemplate::new(200).set_body_raw(b"PDF".to_vec(), "application/pdf"))
@@ -225,7 +246,6 @@ mod tests {
                 .await;
 
             let _ = run_probe(format!("{}/big.pdf", server.uri()), 5).await;
-            // Mock expectations are verified on `MockServer` drop.
         }
     }
 }


### PR DESCRIPTION
## Summary

- Replace the PDF HEAD-then-GET probe with one bounded GET and validate the GET response's Content-Type.
- Forward the request User-Agent, custom headers, and URL-matching cookies; an explicit Cookie header takes precedence.

## Test Plan

- `cargo clippy -p servo-fetch --lib --tests -- -D warnings`
- `cargo test -p servo-fetch pdf::tests --lib`
- `cargo test -p servo-fetch cookies::tests --lib`
- `cargo test -p servo-fetch fetch::tests --lib`
- `cargo test-ci`: all passed

## Checklist

- [x] Ran `cargo +nightly fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
- [ ] Documentation updated (not required; no public API or CLI contract changed)
- [x] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it