### PR TITLE
fix(runtime): support sync calls from multithread Tokio

### DIFF
--- a/crates/servo-fetch/src/runtime.rs
+++ b/crates/servo-fetch/src/runtime.rs
@@ -1,5 +1,4 @@
-//! Shared tokio runtime for bridging servo-fetch's sync API to the async crawl
-//! implementation.
+//! Tokio bridge for the synchronous crawl and map APIs.
 
 use std::future::Future;
 use std::sync::LazyLock;
@@ -7,7 +6,7 @@ use std::sync::LazyLock;
 use anyhow::{Result, bail};
 use tokio::runtime::{Builder, Handle, Runtime};
 
-/// Process-wide tokio runtime dedicated to servo-fetch's sync↔async bridge.
+/// Fallback runtime for synchronous callers outside a Tokio runtime.
 static RUNTIME: LazyLock<Runtime> = LazyLock::new(|| {
     Builder::new_current_thread()
         .enable_all()
@@ -16,10 +15,13 @@ static RUNTIME: LazyLock<Runtime> = LazyLock::new(|| {
         .expect("failed to build servo-fetch tokio runtime")
 });
 
-/// Run `future` on the shared tokio runtime, blocking the calling thread.
+/// Run `future` to completion while blocking the caller.
 pub(crate) fn block_on<F: Future>(future: F) -> Result<F::Output> {
-    if Handle::try_current().is_ok_and(|h| h.id() == RUNTIME.handle().id()) {
-        bail!("servo-fetch sync API cannot be called from within its own async runtime");
+    if let Ok(handle) = Handle::try_current() {
+        return match handle.runtime_flavor() {
+            tokio::runtime::RuntimeFlavor::MultiThread => Ok(tokio::task::block_in_place(|| handle.block_on(future))),
+            _ => bail!("servo-fetch sync API cannot run on a current-thread async runtime; use the async API"),
+        };
     }
     Ok(RUNTIME.block_on(future))
 }
@@ -38,7 +40,30 @@ mod tests {
     fn rejects_recursive_call() {
         let inner = block_on(async { block_on(async { 1 }) }).unwrap();
         assert!(inner.is_err(), "should refuse recursive calls into its own runtime");
-        assert!(inner.unwrap_err().to_string().contains("own async runtime"));
+        assert!(inner.unwrap_err().to_string().contains("async runtime"));
+    }
+
+    #[test]
+    fn rejects_direct_call_from_foreign_runtime_without_panicking() {
+        let outer = Builder::new_current_thread().enable_all().build().unwrap();
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            outer.block_on(async { block_on(async { 42 }) })
+        }));
+        assert!(result.is_ok(), "blocking bridge must not panic inside a Tokio runtime");
+        let error = result.unwrap().unwrap_err();
+        assert!(error.to_string().contains("current-thread async runtime"));
+    }
+
+    #[test]
+    fn allows_direct_call_from_foreign_multithread_runtime() {
+        let outer = Builder::new_multi_thread()
+            .worker_threads(1)
+            .enable_all()
+            .build()
+            .unwrap();
+        let expected = outer.handle().id();
+        let actual = outer.block_on(async { block_on(async { Handle::current().id() }).unwrap() });
+        assert_eq!(actual, expected);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Reuse the caller's multi-thread tokio runtime via `block_in_place` instead of entering a second runtime.
- Return an actionable error for current-thread runtimes, where nested blocking would panic.
- Cover direct foreign-runtime calls and verify that the caller runtime is retained.

## Related Issues

N/A

## Test Plan

- `cargo clippy -p servo-fetch --lib --tests -- -D warnings`
- `cargo test -p servo-fetch runtime::tests --lib`
- `cargo test-ci`

## Checklist

- [x] Ran `cargo +nightly fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
- [ ] Documentation updated (not required; no public API or CLI contract changed)
- [x] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it