### PR TITLE
fix(ci): synchronize release-plz workspace versions

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -19,6 +19,7 @@ git_release_body = """
 
 [[package]]
 name = "servo-fetch-cli"
+version_group = "servo-fetch"
 changelog_update = true
 changelog_path = "CHANGELOG.md"
 changelog_include = ["servo-fetch", "servo-fetch-types", "servo-fetch-python"]
@@ -31,10 +32,13 @@ git_release_draft = true
 
 [[package]]
 name = "servo-fetch"
+version_group = "servo-fetch"
 release = true
 
 [[package]]
 name = "servo-fetch-types"
+version_group = "servo-fetch"
+changelog_include = ["servo-fetch", "servo-fetch-cli", "servo-fetch-python"]
 release = true
 
 [changelog]


### PR DESCRIPTION
## Summary

- Group the publishable workspace crates under one release-plz version group.
- Include core, CLI, and Python changes when deciding whether `servo-fetch-types` must be updated.
- Prevent shared workspace version bumps from leaving internal dependency requirements on the previous minor version.

## Related Issues

https://github.com/konippi/servo-fetch/actions/runs/30976885670/job/92212636638

## Test Plan

- `cargo check --workspace --locked` against the generated release tree
- `taplo check release-plz.toml`
- `cargo test-ci`

## Checklist

- [x] Ran `cargo +nightly fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
- [ ] Documentation updated (not required; no user-facing behavior changed)
- [x] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it