### PR TITLE
fix(cli): make healthcheck probe deterministic

### DIFF
--- a/crates/servo-fetch-cli/src/commands/healthcheck.rs
+++ b/crates/servo-fetch-cli/src/commands/healthcheck.rs
@@ -15,6 +15,7 @@ pub(crate) fn run(args: &HealthcheckArgs) -> Result<()> {
 fn probe(port: u16) -> Result<()> {
     let agent = ureq::Agent::new_with_config(
         ureq::config::Config::builder()
+            .proxy(None)
             .max_redirects(0)
             .timeout_global(Some(TIMEOUT))
             .build(),
@@ -29,39 +30,68 @@ fn probe(port: u16) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use std::io::Write;
+    use std::io::{Read, Write};
     use std::net::TcpListener;
     use std::thread;
 
     use super::*;
 
-    fn spawn_responder(response: &'static [u8]) -> u16 {
+    const MAX_REQUEST_HEADER_BYTES: usize = 16 * 1024;
+
+    fn spawn_responder(response: &'static [u8]) -> (u16, thread::JoinHandle<()>) {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         let port = listener.local_addr().unwrap().port();
-        thread::spawn(move || {
-            if let Ok((mut s, _)) = listener.accept() {
-                let _ = s.write_all(response);
+        let responder = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            stream.set_read_timeout(Some(TIMEOUT)).unwrap();
+            let mut request = Vec::with_capacity(1024);
+            loop {
+                let mut chunk = [0; 1024];
+                let read = stream.read(&mut chunk).unwrap();
+                assert_ne!(read, 0, "client closed before completing request headers");
+                request.extend_from_slice(&chunk[..read]);
+                assert!(
+                    request.len() <= MAX_REQUEST_HEADER_BYTES,
+                    "request headers exceeded test limit"
+                );
+                if request.windows(4).any(|window| window == b"\r\n\r\n") {
+                    break;
+                }
             }
+            let request_line_end = request
+                .windows(2)
+                .position(|window| window == b"\r\n")
+                .expect("request line terminator");
+            assert_eq!(&request[..request_line_end], b"GET /health HTTP/1.1");
+            stream.write_all(response).unwrap();
+            stream.flush().unwrap();
         });
-        port
+        (port, responder)
     }
 
     #[test]
     fn probe_unreachable_port_errors() {
-        assert!(probe(1).is_err());
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        drop(listener);
+        assert!(probe(port).is_err());
     }
 
     #[test]
     fn probe_2xx_succeeds() {
-        let port = spawn_responder(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n");
-        assert!(probe(port).is_ok());
+        let (port, responder) = spawn_responder(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n");
+        let result = probe(port);
+        responder.join().unwrap();
+        assert!(result.is_ok(), "{result:?}");
     }
 
     #[test]
     fn probe_5xx_errors() {
-        let port =
+        let (port, responder) =
             spawn_responder(b"HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\nConnection: close\r\n\r\n");
-        let err = probe(port).unwrap_err();
-        assert!(format!("{err}").contains("503"));
+        let result = probe(port);
+        responder.join().unwrap();
+        let error = result.unwrap_err();
+        assert!(format!("{error}").contains("503"));
     }
 }


### PR DESCRIPTION
## Summary

- Force the local healthcheck probe to bypass environment proxies and connect directly to loopback.
- Make the raw TCP test responder consume a bounded, complete HTTP request before replying, preventing macOS RST/EINVAL flakes.
- Validate `GET /health`, propagate responder failures, and join the server thread deterministically.

## Test Plan

- `cargo test -p servo-fetch-cli --bin servo-fetch commands::healthcheck::tests`
- `cargo test-ci`

## Checklist

- [x] Ran `cargo +nightly fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
- [ ] Documentation updated (not required; no public API or CLI contract changed)
- [x] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it