### PR TITLE
fix(screenshot): stabilize full-page captures after resize

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6481,6 +6481,7 @@ dependencies = [
  "console",
  "futures-util",
  "humantime",
+ "image",
  "indicatif",
  "libc",
  "postcard",

--- a/crates/servo-fetch-cli/Cargo.toml
+++ b/crates/servo-fetch-cli/Cargo.toml
@@ -62,6 +62,7 @@ url = { workspace = true }
 [dev-dependencies]
 assert_cmd = { workspace = true }
 futures-util = { workspace = true }
+image = { workspace = true }
 postcard = { workspace = true }
 predicates = { workspace = true }
 rmcp = { workspace = true, features = ["client", "transport-child-process"] }

--- a/crates/servo-fetch-cli/tests/cli.rs
+++ b/crates/servo-fetch-cli/tests/cli.rs
@@ -193,6 +193,77 @@ fn format_png_creates_file() {
 
 #[test]
 #[ignore = "e2e: requires Servo engine"]
+fn full_page_screenshot_stabilizes_resize_triggered_content() {
+    block_on(async {
+        let server = MockServer::start().await;
+        let html = r#"<!doctype html>
+<html>
+<head>
+<style>
+  html, body { margin: 0; }
+  .spacer { height: 1200px; }
+  #target { height: 100px; opacity: 0; }
+  #target.revealed { height: 1000px; opacity: 1; }
+  #target img { display: block; width: 120px; height: 120px; margin-top: 800px; }
+  .tail { height: 200px; }
+</style>
+</head>
+<body>
+  <div class="spacer"></div>
+  <div id="target"></div>
+  <div class="tail"></div>
+  <script>
+    const target = document.querySelector('#target');
+    new IntersectionObserver(entries => {
+      if (!entries.some(entry => entry.isIntersecting)) return;
+      target.classList.add('revealed');
+      const image = document.createElement('img');
+      image.src = '/purple.svg';
+      target.appendChild(image);
+    }).observe(target);
+  </script>
+</body>
+</html>"#;
+        Mock::given(method("GET"))
+            .and(path("/"))
+            .respond_with(mock_page(html))
+            .mount(&server)
+            .await;
+        let svg = r##"<svg xmlns="http://www.w3.org/2000/svg" width="120" height="120"><rect width="120" height="120" fill="#9333ea"/></svg>"##;
+        Mock::given(method("GET"))
+            .and(path("/purple.svg"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(svg.as_bytes(), "image/svg+xml"))
+            .mount(&server)
+            .await;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let file = dir.path().join("full-page-io.png");
+        servo_fetch()
+            .args([
+                "--format",
+                "png",
+                "--full-page",
+                "-o",
+                file.to_str().unwrap(),
+                "--allow-private-addresses",
+                TIMEOUT,
+                &server.uri(),
+            ])
+            .assert()
+            .success();
+
+        let screenshot = image::open(&file).expect("decode PNG").to_rgb8();
+        assert!(screenshot.height() >= 2_300, "dynamic page growth was clipped");
+        let purple = screenshot
+            .pixels()
+            .filter(|pixel| pixel.0 == [0x93, 0x33, 0xea])
+            .count();
+        assert!(purple > 5_000, "IntersectionObserver image was not painted");
+    });
+}
+
+#[test]
+#[ignore = "e2e: requires Servo engine"]
 fn crawl_produces_ndjson() {
     block_on(async {
         let s = MockServer::start().await;

--- a/crates/servo-fetch/src/screenshot.rs
+++ b/crates/servo-fetch/src/screenshot.rs
@@ -12,6 +12,11 @@ use servo::{DevicePixel, WebView, WebViewRect};
 use crate::bridge::{eval_js, wait_for_wake};
 use crate::layout;
 
+/// Matches the GPU texture limit on most modern hardware and caps the RGBA framebuffer at ~1 GB.
+const MAX_SCREENSHOT_DIMENSION: u32 = 16_384;
+const MAX_FULL_PAGE_RESIZE_PASSES: usize = 3;
+const SCENE_PROBE_SIZE: PhysicalSize<u32> = PhysicalSize::new(1, 1);
+
 /// Capture a PNG screenshot of the page, temporarily resizing the viewport
 /// to the full content size when `full_page` is set.
 pub(crate) fn capture(
@@ -20,44 +25,79 @@ pub(crate) fn capture(
     full_page: bool,
     deadline: Instant,
 ) -> Option<RgbaImage> {
-    /// 16,384 matches the GPU texture limit on most modern hardware and caps
-    /// the RGBA framebuffer at ~1 GB.
-    const MAX_PIXELS: u32 = 16_384;
-
-    let viewport = PhysicalSize::new(layout::VIEWPORT_WIDTH, layout::VIEWPORT_HEIGHT);
-
     if !full_page {
         return take_screenshot(servo, webview, None, deadline);
     }
 
+    capture_full_page(servo, webview, deadline)
+}
+
+fn capture_full_page(servo: &servo::Servo, webview: &WebView, deadline: Instant) -> Option<RgbaImage> {
+    let viewport = PhysicalSize::new(layout::VIEWPORT_WIDTH, layout::VIEWPORT_HEIGHT);
     let Some(measured) = measure_full_page(servo, webview, deadline) else {
         tracing::warn!("failed to measure full page size; falling back to viewport screenshot");
         return take_screenshot(servo, webview, None, deadline);
     };
-
-    let Some(resized) = resolve_full_page_size(measured, viewport, MAX_PIXELS) else {
-        // Content already fits in the viewport; skip the resize round-trip.
+    let Some(mut capture_size) = resolve_full_page_size(measured, viewport, MAX_SCREENSHOT_DIMENSION) else {
         return take_screenshot(servo, webview, None, deadline);
     };
+    warn_if_clamped(measured, capture_size);
 
-    if resized != measured {
+    let _restore = ViewportRestore {
+        webview,
+        size: viewport,
+    };
+
+    for pass in 0..MAX_FULL_PAGE_RESIZE_PASSES {
+        webview.resize(capture_size);
+        wait_for_scene_update(servo, webview, deadline)?;
+
+        let Some(measured) = measure_full_page(servo, webview, deadline) else {
+            tracing::warn!("failed to remeasure full page after resize; capturing current geometry");
+            break;
+        };
+        let resolved = resolve_full_page_size(measured, viewport, MAX_SCREENSHOT_DIMENSION).unwrap_or(viewport);
+        warn_if_clamped(measured, resolved);
+        let grown = grow_capture_size(capture_size, resolved);
+        if grown == capture_size {
+            break;
+        }
+        if pass + 1 == MAX_FULL_PAGE_RESIZE_PASSES {
+            tracing::warn!(
+                current_w = capture_size.width,
+                current_h = capture_size.height,
+                measured_w = measured.width,
+                measured_h = measured.height,
+                "full-page geometry did not stabilize within the resize limit",
+            );
+            break;
+        }
+        capture_size = grown;
+    }
+
+    take_screenshot(servo, webview, Some(device_rect(capture_size)), deadline)
+}
+
+/// Wait for Servo's rendered scene to catch up with the most recent resize.
+fn wait_for_scene_update(servo: &servo::Servo, webview: &WebView, deadline: Instant) -> Option<()> {
+    take_screenshot(servo, webview, Some(device_rect(SCENE_PROBE_SIZE)), deadline)?;
+    Some(())
+}
+
+fn grow_capture_size(current: PhysicalSize<u32>, measured: PhysicalSize<u32>) -> PhysicalSize<u32> {
+    PhysicalSize::new(current.width.max(measured.width), current.height.max(measured.height))
+}
+
+fn warn_if_clamped(measured: PhysicalSize<u32>, resolved: PhysicalSize<u32>) {
+    if measured.width > MAX_SCREENSHOT_DIMENSION || measured.height > MAX_SCREENSHOT_DIMENSION {
         tracing::warn!(
-            clamped_w = resized.width,
-            clamped_h = resized.height,
+            clamped_w = resolved.width,
+            clamped_h = resolved.height,
             measured_w = measured.width,
             measured_h = measured.height,
             "full-page dimensions clamped",
         );
     }
-
-    // Resize the viewport for capture, restoring it via a guard so the engine
-    // stays usable even if `take_screenshot` panics or times out.
-    let _restore = ViewportRestore {
-        webview,
-        size: viewport,
-    };
-    webview.resize(resized);
-    take_screenshot(servo, webview, Some(device_rect(resized)), deadline)
 }
 
 /// RAII guard that restores the `WebView`'s viewport size on drop.
@@ -130,10 +170,17 @@ fn resolve_full_page_size(
 /// Read the full scrollable content size via JS, saturating at [`u32::MAX`].
 fn measure_full_page(servo: &servo::Servo, webview: &WebView, deadline: Instant) -> Option<PhysicalSize<u32>> {
     const SIZE_JS: &str = r"
-        JSON.stringify({
-            w: Math.max(document.body.scrollWidth, document.documentElement.scrollWidth),
-            h: Math.max(document.body.scrollHeight, document.documentElement.scrollHeight)
-        })
+        (() => {
+            const root = document.documentElement;
+            const body = document.body;
+            const widths = [root.scrollWidth, root.offsetWidth, root.clientWidth];
+            const heights = [root.scrollHeight, root.offsetHeight, root.clientHeight];
+            if (body) {
+                widths.push(body.scrollWidth, body.offsetWidth, body.clientWidth);
+                heights.push(body.scrollHeight, body.offsetHeight, body.clientHeight);
+            }
+            return JSON.stringify({ w: Math.max(...widths), h: Math.max(...heights) });
+        })()
     ";
     #[derive(serde::Deserialize)]
     struct Size {
@@ -142,20 +189,22 @@ fn measure_full_page(servo: &servo::Servo, webview: &WebView, deadline: Instant)
     }
     let raw = eval_js(servo, webview, SIZE_JS, deadline).ok()?;
     let size: Size = serde_json::from_str(&raw).ok()?;
+    Some(PhysicalSize::new(
+        normalize_dimension(size.w),
+        normalize_dimension(size.h),
+    ))
+}
 
-    #[expect(
-        clippy::cast_possible_truncation,
-        clippy::cast_sign_loss,
-        reason = "saturating cast is the intended behavior"
-    )]
-    let width = size.w as u32;
-    #[expect(
-        clippy::cast_possible_truncation,
-        clippy::cast_sign_loss,
-        reason = "saturating cast is the intended behavior"
-    )]
-    let height = size.h as u32;
-    Some(PhysicalSize::new(width, height))
+#[expect(
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    reason = "finite non-negative values intentionally saturate to u32"
+)]
+fn normalize_dimension(value: f64) -> u32 {
+    if !value.is_finite() || value <= 0.0 {
+        return 0;
+    }
+    value.min(f64::from(u32::MAX)) as u32
 }
 
 #[cfg(test)]
@@ -195,6 +244,20 @@ mod tests {
             resolve_full_page_size(size(32_000, 50_000), vp, 16_384),
             Some(size(16_384, 16_384)),
         );
+    }
+
+    #[test]
+    fn grow_capture_size_is_monotonic() {
+        assert_eq!(grow_capture_size(size(1280, 2000), size(1400, 1800)), size(1400, 2000));
+        assert_eq!(grow_capture_size(size(1280, 2000), size(1000, 1000)), size(1280, 2000));
+    }
+
+    #[test]
+    fn normalize_dimension_rejects_invalid_values_and_saturates() {
+        assert_eq!(normalize_dimension(f64::NAN), 0);
+        assert_eq!(normalize_dimension(-1.0), 0);
+        assert_eq!(normalize_dimension(42.9), 42);
+        assert_eq!(normalize_dimension(f64::MAX), u32::MAX);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Full-page screenshots raced against resize-triggered `IntersectionObserver` callbacks: `capture` resized the viewport and took the screenshot immediately, so DOM mutations queued by the resize (revealed content, dynamically inserted images) were missing from the capture, and content growth beyond the initially measured height was clipped.

## Related issues

Closes #392

## Test Plan

- `cargo test -p servo-fetch --lib`
- `cargo test -p servo-fetch-cli --test cli -- --ignored --test-threads=1`

## Checklist

- [x] Ran `cargo +nightly fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
- [ ] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed
- [x] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it