### PR TITLE
feat(session): add process-isolated browser sessions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6439,6 +6439,7 @@ dependencies = [
  "anyhow",
  "bitflags 2.13.1",
  "cookie 0.18.1",
+ "crossbeam-channel",
  "cssparser 0.36.0",
  "dom_query",
  "dom_smoothie",
@@ -6466,6 +6467,7 @@ dependencies = [
  "tracing",
  "ureq",
  "url",
+ "windows-sys 0.61.2",
  "wiremock",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ bitflags = "2"
 clap = { version = "4", features = ["derive"] }
 console = "0.16"
 cookie = "0.18"
+crossbeam-channel = "=0.5.15"
 cssparser = "0.36"
 dom_query = "0.28"
 dom_smoothie = "0.18"
@@ -57,6 +58,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "tracing-log"] }
 ureq = { version = "3", default-features = false, features = ["gzip", "rustls-no-provider", "rustls-webpki-roots"] }
 url = "2"
+windows-sys = { version = "=0.61.2", features = ["Win32_Foundation", "Win32_Security", "Win32_System_JobObjects", "Win32_System_Threading"] }
 wiremock = "0.6"
 
 [workspace.lints.rust]

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ const md = await fetch("https://example.com");
 - **Layout- and visibility-aware extraction** — strips navbars, sidebars, footers by rendered position, plus cookie banners, modals, and CSS-hidden content (`opacity:0`, `aria-hidden`, sr-only)
 - **Schema-driven JSON** — declarative CSS-selector schema pulls structured data
 - **Parallel batch fetch** — multiple URLs fetched concurrently
+- **Isolated browser sessions** — one-use worker process per session keeps cookies and storage fully separated
 - **Site crawling** — BFS link traversal with robots.txt, same-site scope, and rate limiting
 - **URL discovery** — sitemap-based URL mapping without rendering (fast, lightweight)
 - **Screenshots without GPU** — software renderer captures PNG/full-page screenshots anywhere

--- a/crates/servo-fetch-cli/Cargo.toml
+++ b/crates/servo-fetch-cli/Cargo.toml
@@ -33,6 +33,10 @@ path = "tests/parallel.rs"
 name = "rpc"
 path = "tests/rpc.rs"
 
+[[test]]
+name = "session"
+path = "tests/session.rs"
+
 [dependencies]
 anyhow = { workspace = true }
 axum = { workspace = true }

--- a/crates/servo-fetch-cli/src/main.rs
+++ b/crates/servo-fetch-cli/src/main.rs
@@ -25,6 +25,10 @@ fn main() -> ! {
         let code = exit::exit_code(servo_fetch::run_worker_stdio().map_err(anyhow::Error::from));
         exit::flush_and_exit(code);
     }
+    if let Err(error) = configure_worker_command() {
+        let result: anyhow::Result<()> = Err(error);
+        exit::flush_and_exit(exit::exit_code(result));
+    }
 
     let args = Cli::parse();
     logging::init(logging::Verbosity::from_flags(args.verbose, args.quiet));
@@ -37,6 +41,14 @@ fn is_internal_worker() -> bool {
     let mut args = std::env::args_os();
     let _ = args.next();
     args.next().is_some_and(|arg| arg == "__worker") && args.next().is_none()
+}
+
+fn configure_worker_command() -> anyhow::Result<()> {
+    let program = std::env::var_os("SERVO_FETCH_WORKER")
+        .map(std::path::PathBuf::from)
+        .map_or_else(std::env::current_exe, Ok)?;
+    servo_fetch::set_default_worker_command(servo_fetch::WorkerCommand::new(program).arg("__worker"))
+        .map_err(anyhow::Error::from)
 }
 
 fn dispatch(args: &Cli) -> anyhow::Result<()> {

--- a/crates/servo-fetch-cli/tests/cli.rs
+++ b/crates/servo-fetch-cli/tests/cli.rs
@@ -3,6 +3,13 @@
 use std::fs;
 use std::future::Future;
 use std::str::from_utf8;
+#[cfg(unix)]
+use std::{
+    io::Read as _,
+    os::fd::{AsRawFd as _, FromRawFd as _, OwnedFd},
+    process::Stdio,
+    time::{Duration, Instant},
+};
 
 use assert_cmd::Command;
 use predicates::prelude::*;
@@ -93,6 +100,52 @@ fn internal_worker_dispatches_before_clap_and_logging() {
     let info: WorkerProtocolInfo = postcard::from_bytes(&output.stdout[4..]).unwrap();
     assert_eq!(info.magic, *b"SFETCHW\0");
     assert_eq!(info.package_version, env!("CARGO_PKG_VERSION"));
+}
+
+#[cfg(unix)]
+#[test]
+#[allow(unsafe_code)]
+fn internal_worker_exits_when_parent_lifeline_closes() {
+    let mut descriptors = [-1; 2];
+    assert_eq!(unsafe { libc::pipe(descriptors.as_mut_ptr()) }, 0);
+    let read_end = unsafe { OwnedFd::from_raw_fd(descriptors[0]) };
+    let write_end = unsafe { OwnedFd::from_raw_fd(descriptors[1]) };
+    let flags = unsafe { libc::fcntl(write_end.as_raw_fd(), libc::F_GETFD) };
+    assert!(flags >= 0);
+    assert_eq!(
+        unsafe { libc::fcntl(write_end.as_raw_fd(), libc::F_SETFD, flags | libc::FD_CLOEXEC) },
+        0
+    );
+
+    let mut child = std::process::Command::new(env!("CARGO_BIN_EXE_servo-fetch"))
+        .arg("__worker")
+        .env(
+            "SERVO_FETCH_INTERNAL_PARENT_LIFELINE_FD",
+            read_end.as_raw_fd().to_string(),
+        )
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    drop(read_end);
+    let _stdin = child.stdin.take().unwrap();
+    let mut stdout = child.stdout.take().unwrap();
+    let mut prefix = [0; 4];
+    stdout.read_exact(&mut prefix).unwrap();
+    let mut info = vec![0; usize::try_from(u32::from_be_bytes(prefix)).unwrap()];
+    stdout.read_exact(&mut info).unwrap();
+    drop(write_end);
+
+    let deadline = Instant::now() + Duration::from_secs(3);
+    loop {
+        if let Some(status) = child.try_wait().unwrap() {
+            assert!(status.success());
+            break;
+        }
+        assert!(Instant::now() < deadline, "worker survived parent lifeline closure");
+        std::thread::sleep(Duration::from_millis(10));
+    }
 }
 
 const TIMEOUT: &str = "--timeout=30";

--- a/crates/servo-fetch-cli/tests/session.rs
+++ b/crates/servo-fetch-cli/tests/session.rs
@@ -1,0 +1,103 @@
+//! Strong logical browser-session isolation, capacity, and cancellation E2E tests.
+
+use std::sync::Once;
+use std::time::Duration;
+
+use servo_fetch::{
+    BrowserSessionConfig, FetchOptions, NetworkPolicy, SessionBroker, SessionBrokerConfig, WorkerCommand,
+};
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+static INIT: Once = Once::new();
+
+fn broker(max_sessions: usize, queue_capacity: usize) -> SessionBroker {
+    INIT.call_once(|| servo_fetch::init(NetworkPolicy::PERMISSIVE));
+    let config = SessionBrokerConfig::default()
+        .max_sessions(max_sessions)
+        .queue_capacity(queue_capacity)
+        .prewarm(0)
+        .acquire_timeout(Duration::from_secs(2))
+        .worker_command(WorkerCommand::new(env!("CARGO_BIN_EXE_servo-fetch")).arg("__worker"));
+    SessionBroker::new(config).expect("broker starts")
+}
+
+async fn page(server: &MockServer, path_name: &str, delay: Option<Duration>) {
+    let mut response = ResponseTemplate::new(200).set_body_raw(
+        b"<!doctype html><html><body>session test</body></html>".to_vec(),
+        "text/html; charset=utf-8",
+    );
+    if let Some(delay) = delay {
+        response = response.set_delay(delay);
+    }
+    Mock::given(method("GET"))
+        .and(path(path_name))
+        .respond_with(response)
+        .mount(server)
+        .await;
+}
+
+#[tokio::test]
+#[ignore = "e2e: requires Servo engine"]
+async fn logical_sessions_isolate_cookie_state() {
+    let server = MockServer::start().await;
+    page(&server, "/", None).await;
+    let broker = broker(2, 2);
+
+    let mut first = broker.session(BrowserSessionConfig::new()).await.unwrap();
+    let url = format!("{}/", server.uri());
+    let set = first
+        .fetch(&FetchOptions::javascript(
+            &url,
+            "window.isolationMarker = 'page-only'; document.cookie = 'isolation_marker=first; path=/'; document.cookie",
+        ))
+        .await
+        .unwrap();
+    assert!(set.js_result.unwrap_or_default().contains("isolation_marker=first"));
+
+    let persisted = first
+        .fetch(&FetchOptions::javascript(
+            &url,
+            "typeof window.isolationMarker + '|' + document.cookie",
+        ))
+        .await
+        .unwrap();
+    let persisted = persisted.js_result.unwrap_or_default();
+    assert!(persisted.starts_with("undefined|"));
+    assert!(persisted.contains("isolation_marker=first"));
+    first.close().await.unwrap();
+
+    let mut second = broker.session(BrowserSessionConfig::new()).await.unwrap();
+    let isolated = second
+        .fetch(&FetchOptions::javascript(&url, "document.cookie"))
+        .await
+        .unwrap();
+    assert!(!isolated.js_result.unwrap_or_default().contains("isolation_marker"));
+    second.close().await.unwrap();
+}
+
+#[tokio::test]
+#[ignore = "e2e: requires Servo engine"]
+async fn cancelling_fetch_kills_worker_and_releases_capacity() {
+    let server = MockServer::start().await;
+    page(&server, "/slow", Some(Duration::from_secs(10))).await;
+    let broker = broker(1, 1);
+    let url = format!("{}/slow", server.uri());
+    let task_broker = broker.clone();
+
+    let task = tokio::spawn(async move {
+        let mut session = task_broker.session(BrowserSessionConfig::new()).await.unwrap();
+        session
+            .fetch(&FetchOptions::new(&url).timeout(Duration::from_secs(30)))
+            .await
+    });
+    tokio::time::sleep(Duration::from_millis(300)).await;
+    task.abort();
+    let _ = task.await;
+
+    let replacement = tokio::time::timeout(Duration::from_secs(5), broker.session(BrowserSessionConfig::new()))
+        .await
+        .expect("cancelled worker should release its broker permit")
+        .expect("replacement session starts");
+    replacement.close().await.unwrap();
+}

--- a/crates/servo-fetch/Cargo.toml
+++ b/crates/servo-fetch/Cargo.toml
@@ -17,6 +17,7 @@ servo = { workspace = true }
 anyhow = { workspace = true }
 bitflags = { workspace = true }
 cookie = { workspace = true }
+crossbeam-channel = { workspace = true }
 cssparser = { workspace = true }
 dom_query = { workspace = true }
 dom_smoothie = { workspace = true }
@@ -32,6 +33,7 @@ psl = { workspace = true }
 rustls = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+tempfile = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
@@ -49,9 +51,9 @@ os_pipe = "1"
 
 [target.'cfg(windows)'.dependencies]
 servo = { workspace = true, features = ["no-wgl"] }
+windows-sys = { workspace = true }
 
 [dev-dependencies]
-tempfile = { workspace = true }
 tokio = { workspace = true, features = ["macros", "test-util"] }
 wiremock = { workspace = true }
 

--- a/crates/servo-fetch/README.md
+++ b/crates/servo-fetch/README.md
@@ -17,6 +17,7 @@ Looking for the CLI? See [`servo-fetch-cli`](https://crates.io/crates/servo-fetc
 - **PDF auto-detection** — URLs returning PDF are automatically extracted as text
 - **Typed errors** — `Error::Timeout`, `Error::InvalidUrl`, etc. for match-based retry logic
 - **SSRF protection** — blocks private IPs, reserved ranges, and metadata endpoints
+- **Isolated browser sessions** — one-use worker process per session keeps cookies and storage fully separated
 
 ## Quick Start
 
@@ -113,6 +114,26 @@ An empty `selector` (`""`) reads from the matched element itself — useful
 inside `nested_list` to grab each item's own text or attribute. For
 programmatic construction, see [`ExtractSchema::builder()`].
 
+### Isolated browser sessions
+
+Each `BrowserSession` runs in its own one-use OS process, so cookies, storage,
+and caches never leak between sessions. Requires a worker command (the
+`servo-fetch` CLI configures itself automatically; library embedders point it
+at their own binary that calls `run_worker_stdio()` early in `main`):
+
+```rust,no_run
+use servo_fetch::{BrowserSessionConfig, FetchOptions, SessionBroker, SessionBrokerConfig, WorkerCommand};
+
+# async fn example() -> Result<(), servo_fetch::Error> {
+servo_fetch::set_default_worker_command(WorkerCommand::new("/path/to/my-app").arg("__worker"))?;
+let broker = SessionBroker::new(SessionBrokerConfig::default())?;
+let session = broker.session(BrowserSessionConfig::new()).await?;
+let page = session.fetch(&FetchOptions::new("https://example.com")).await?;
+// Dropping the session tears down its worker process and deletes its storage.
+# Ok(())
+# }
+```
+
 ### Error handling
 
 ```rust
@@ -156,6 +177,8 @@ let page = client.fetch("https://example.com")?;
 | Variable | Description |
 | -------- | ----------- |
 | `SERVO_FETCH_USER_AGENT` | Default User-Agent string (overridden by `.user_agent()`) |
+| `SERVO_FETCH_WORKER` | Worker executable for isolated sessions (defaults to the current executable) |
+| `SERVO_FETCH_PREWARM` | Number of session worker processes to start eagerly (default 0) |
 
 ## API Overview
 
@@ -171,6 +194,7 @@ Every function is available in both async (top-level) and sync (`blocking::*`) f
 | `crawl_each(opts, cb)` | Streaming results via callback |
 | `map(opts)` | `Vec<MappedUrl>` (URL discovery) |
 | `Client` / `ClientBuilder` | Reusable client with defaults |
+| `SessionBroker` / `BrowserSession` | Process-isolated browser sessions |
 
 See [docs.rs](https://docs.rs/servo-fetch) for the full API reference and [`examples/`](examples/) for complete runnable programs.
 

--- a/crates/servo-fetch/README.md
+++ b/crates/servo-fetch/README.md
@@ -114,26 +114,6 @@ An empty `selector` (`""`) reads from the matched element itself — useful
 inside `nested_list` to grab each item's own text or attribute. For
 programmatic construction, see [`ExtractSchema::builder()`].
 
-### Isolated browser sessions
-
-Each `BrowserSession` runs in its own one-use OS process, so cookies, storage,
-and caches never leak between sessions. Requires a worker command (the
-`servo-fetch` CLI configures itself automatically; library embedders point it
-at their own binary that calls `run_worker_stdio()` early in `main`):
-
-```rust,no_run
-use servo_fetch::{BrowserSessionConfig, FetchOptions, SessionBroker, SessionBrokerConfig, WorkerCommand};
-
-# async fn example() -> Result<(), servo_fetch::Error> {
-servo_fetch::set_default_worker_command(WorkerCommand::new("/path/to/my-app").arg("__worker"))?;
-let broker = SessionBroker::new(SessionBrokerConfig::default())?;
-let session = broker.session(BrowserSessionConfig::new()).await?;
-let page = session.fetch(&FetchOptions::new("https://example.com")).await?;
-// Dropping the session tears down its worker process and deletes its storage.
-# Ok(())
-# }
-```
-
 ### Error handling
 
 ```rust

--- a/crates/servo-fetch/src/cookies.rs
+++ b/crates/servo-fetch/src/cookies.rs
@@ -39,6 +39,22 @@ pub(crate) struct CookieWire {
     include_subdomains: bool,
 }
 impl CookieWire {
+    pub(crate) fn from_specs(specs: &[CookieSpec]) -> Vec<Self> {
+        specs
+            .iter()
+            .map(|spec| Self {
+                name: spec.name.clone(),
+                value: spec.value.clone(),
+                domain: spec.domain.clone(),
+                path: spec.path.clone(),
+                secure: spec.secure,
+                http_only: spec.http_only,
+                include_subdomains: spec.include_subdomains,
+                expires: spec.expires,
+            })
+            .collect()
+    }
+
     pub(crate) fn into_specs(wires: Vec<Self>) -> std::result::Result<Vec<CookieSpec>, &'static str> {
         if wires.len() > MAX_COOKIES {
             return Err("too many cookies in worker request");

--- a/crates/servo-fetch/src/crawl.rs
+++ b/crates/servo-fetch/src/crawl.rs
@@ -58,6 +58,18 @@ impl CrawlOptions {
         }
     }
 
+    /// Validate the seed URL and include/exclude glob syntax without starting a browser worker.
+    pub(crate) fn validate(&self) -> crate::error::Result<()> {
+        net::validate_url(&self.url)?;
+        if !self.include.is_empty() {
+            crate::scope::build_globset(&self.include)?;
+        }
+        if !self.exclude.is_empty() {
+            crate::scope::build_globset(&self.exclude)?;
+        }
+        Ok(())
+    }
+
     /// Maximum number of pages to crawl (default: 50).
     pub fn limit(mut self, n: usize) -> Self {
         self.limit = n;

--- a/crates/servo-fetch/src/error.rs
+++ b/crates/servo-fetch/src/error.rs
@@ -108,6 +108,46 @@ pub enum Error {
         max: usize,
     },
 
+    /// Browser-session acquisition or an in-flight operation was cancelled.
+    #[error("browser session operation was cancelled")]
+    SessionCancelled,
+
+    /// The worker did not produce the next protocol frame before its deadline.
+    #[error("browser worker {operation} timed out after {timeout:?}")]
+    WorkerProtocolTimeout {
+        /// Protocol operation being awaited.
+        operation: &'static str,
+        /// Configured protocol deadline.
+        timeout: Duration,
+    },
+
+    /// Browser-session broker configuration is invalid.
+    #[error("invalid browser session configuration: {reason}")]
+    InvalidSessionConfig {
+        /// Validation failure description.
+        reason: String,
+    },
+
+    /// No isolated worker could be acquired before the configured deadline.
+    #[error("browser session acquisition timed out after {}s", timeout.as_secs())]
+    SessionAcquireTimeout {
+        /// The configured acquisition timeout.
+        timeout: Duration,
+    },
+
+    /// An operation cannot preserve the documented browser-session semantics.
+    #[error("{operation} is not supported in BrowserSession: {reason}")]
+    UnsupportedSessionOperation {
+        /// Operation that was rejected.
+        operation: &'static str,
+        /// Why it cannot preserve session semantics.
+        reason: &'static str,
+    },
+
+    /// The bounded browser-session queue is full.
+    #[error("browser session broker is at capacity")]
+    SessionBrokerFull,
+
     /// The isolated worker protocol could not continue.
     #[error("isolated browser worker unavailable: {source}")]
     WorkerUnavailable {

--- a/crates/servo-fetch/src/headers.rs
+++ b/crates/servo-fetch/src/headers.rs
@@ -58,6 +58,17 @@ where
 
 const MAX_WIRE_HEADERS: usize = 128;
 const MAX_WIRE_HEADER_BYTES: usize = 64 * 1024;
+/// Validate a header map against the same limits as the worker wire format.
+pub(crate) fn validate_map(headers: &HeaderMap) -> Result<()> {
+    from_wire_pairs(
+        headers
+            .iter()
+            .map(|(name, value)| (name.as_str().to_owned(), value.as_bytes().to_vec()))
+            .collect(),
+    )
+    .map(drop)
+}
+
 pub(crate) fn from_wire_pairs(headers: Vec<(String, Vec<u8>)>) -> Result<HeaderMap> {
     if headers.len() > MAX_WIRE_HEADERS {
         return Err(Error::invalid_header("too many custom headers in worker request"));

--- a/crates/servo-fetch/src/lib.rs
+++ b/crates/servo-fetch/src/lib.rs
@@ -1,5 +1,4 @@
 //! Fetch, render, and extract web content as Markdown, JSON, or screenshots with an embedded Servo browser engine.
-//! No Chromium and no external services; optional [`BrowserSession`]s isolate browser state in one-use worker processes.
 //!
 //! ## Async usage
 //!

--- a/crates/servo-fetch/src/lib.rs
+++ b/crates/servo-fetch/src/lib.rs
@@ -1,5 +1,5 @@
 //! Fetch, render, and extract web content as Markdown, JSON, or screenshots with an embedded Servo browser engine.
-//! No Chromium, no containers, no external processes.
+//! No Chromium and no external services; optional [`BrowserSession`]s isolate browser state in one-use worker processes.
 //!
 //! ## Async usage
 //!
@@ -39,6 +39,7 @@ pub(crate) mod robots;
 pub(crate) mod runtime;
 pub(crate) mod scope;
 pub(crate) mod screenshot;
+pub(crate) mod session;
 pub(crate) mod sys;
 mod worker;
 
@@ -50,6 +51,10 @@ pub use fetch::{ConsoleLevel, ConsoleMessage, FetchOptions, Page, extract_json, 
 pub use http::HeaderMap;
 pub use map::{MapOptions, MappedUrl, map};
 pub use net::{NetworkPolicy, validate_url};
+pub use session::{
+    BrowserSession, BrowserSessionConfig, SessionBroker, SessionBrokerConfig, SessionCancellation, WorkerCommand,
+    configure_default_broker, set_default_worker_command,
+};
 pub use visibility::{VisibilityFlags, VisibilityPolicy};
 #[doc(hidden)]
 pub use worker::run_worker_stdio;

--- a/crates/servo-fetch/src/pdf.rs
+++ b/crates/servo-fetch/src/pdf.rs
@@ -19,7 +19,7 @@ pub(crate) fn probe(
     fetch_bytes(url, Duration::from_secs(timeout_secs), user_agent, headers).ok()
 }
 
-fn looks_like_pdf_url(url: &str) -> bool {
+pub(crate) fn looks_like_pdf_url(url: &str) -> bool {
     let Ok(parsed) = url::Url::parse(url) else {
         return false;
     };

--- a/crates/servo-fetch/src/session.rs
+++ b/crates/servo-fetch/src/session.rs
@@ -1,0 +1,847 @@
+//! Strong browser-state isolation using one one-use OS process per logical session.
+
+mod supervisor;
+
+use std::ffi::OsString;
+use std::path::PathBuf;
+use std::sync::{Arc, LazyLock, Mutex, OnceLock};
+use std::time::Duration;
+
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+
+use self::supervisor::{
+    ForcePort, SupervisorCommand, SupervisorHandle, receive_response, recv_async, recv_optional_async, response_channel,
+};
+use crate::cookies::{CookieSpec, CookieWire};
+use crate::error::{Error, Result};
+use crate::fetch::{FetchMode, FetchOptions, Page};
+use crate::worker::protocol::InitializeSession;
+use crate::worker::wire::{CrawlWire, FetchWire, MAX_WIRE_CRAWL_CONCURRENCY, MAX_WIRE_DURATION};
+use crate::worker::worker_error;
+use crate::{CrawlOptions, CrawlResult, NetworkPolicy};
+const MAX_SESSIONS: usize = 64;
+const MAX_QUEUE_CAPACITY: usize = 1024;
+const MAX_ACQUIRE_TIMEOUT: Duration = Duration::from_secs(3600);
+
+#[cfg(test)]
+mod tests;
+
+static DEFAULT_WORKER_COMMAND: OnceLock<WorkerCommand> = OnceLock::new();
+static DEFAULT_BROKER_CONFIG: OnceLock<SessionBrokerConfig> = OnceLock::new();
+static DEFAULT_BROKER: OnceLock<SessionBroker> = OnceLock::new();
+static DEFAULT_BROKER_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+/// Executable and arguments used to start an isolated worker.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkerCommand {
+    program: PathBuf,
+    args: Vec<OsString>,
+}
+
+impl WorkerCommand {
+    /// Construct a command that enters [`run_worker_stdio`] before using Servo.
+    pub fn new(program: impl Into<PathBuf>) -> Self {
+        Self {
+            program: program.into(),
+            args: Vec::new(),
+        }
+    }
+
+    /// Append one worker argument.
+    #[must_use]
+    pub fn arg(mut self, arg: impl Into<OsString>) -> Self {
+        self.args.push(arg.into());
+        self
+    }
+
+    /// Append worker arguments.
+    #[must_use]
+    pub fn args(mut self, args: impl IntoIterator<Item = impl Into<OsString>>) -> Self {
+        self.args.extend(args.into_iter().map(Into::into));
+        self
+    }
+
+    fn unconfigured() -> Self {
+        Self::new(PathBuf::new())
+    }
+
+    fn validate(&self) -> Result<()> {
+        if self.program.as_os_str().is_empty() {
+            return Err(invalid_config("worker command is not configured"));
+        }
+        if !self.program.is_absolute() {
+            return Err(invalid_config("worker executable path must be absolute"));
+        }
+        Ok(())
+    }
+
+    fn resolved() -> Result<Self> {
+        DEFAULT_WORKER_COMMAND.get().cloned().ok_or_else(|| {
+            invalid_config("worker command is not configured; call set_default_worker_command or set worker_command")
+        })
+    }
+}
+
+fn invalid_config(reason: impl Into<String>) -> Error {
+    Error::InvalidSessionConfig { reason: reason.into() }
+}
+
+/// Set the worker command before default broker initialization; PATH lookup is intentionally disabled.
+pub fn set_default_worker_command(command: WorkerCommand) -> Result<()> {
+    command.validate()?;
+    let _guard = DEFAULT_BROKER_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    if DEFAULT_BROKER.get().is_some() || DEFAULT_BROKER_CONFIG.get().is_some() {
+        return Err(worker_error(
+            "default session broker is already configured or initialized",
+        ));
+    }
+    DEFAULT_WORKER_COMMAND
+        .set(command)
+        .map_err(|_| worker_error("default worker command is already configured"))
+}
+
+/// Configure the process-wide broker before its first use.
+pub fn configure_default_broker(mut config: SessionBrokerConfig) -> Result<()> {
+    if config.worker_command.program.as_os_str().is_empty() {
+        config.worker_command = WorkerCommand::resolved()?;
+    }
+    config.validate()?;
+    let _guard = DEFAULT_BROKER_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    if DEFAULT_BROKER.get().is_some() {
+        return Err(worker_error("default session broker is already initialized"));
+    }
+    DEFAULT_BROKER_CONFIG
+        .set(config)
+        .map_err(|_| worker_error("default session broker is already configured"))
+}
+
+/// Capacity and startup policy for a [`SessionBroker`].
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct SessionBrokerConfig {
+    /// Maximum simultaneously-live logical sessions.
+    pub(crate) max_sessions: usize,
+    /// Maximum number of callers allowed to wait for capacity.
+    pub(crate) queue_capacity: usize,
+    /// Maximum wait for session capacity.
+    pub(crate) acquire_timeout: Duration,
+    /// Number of clean, uninitialized workers created eagerly.
+    pub(crate) prewarm: usize,
+    /// Worker executable configuration.
+    pub(crate) worker_command: WorkerCommand,
+}
+
+impl SessionBrokerConfig {
+    /// Set the maximum number of simultaneously-live sessions.
+    #[must_use]
+    pub fn max_sessions(mut self, max_sessions: usize) -> Self {
+        self.max_sessions = max_sessions;
+        self
+    }
+
+    /// Set the maximum number of callers waiting for capacity.
+    #[must_use]
+    pub fn queue_capacity(mut self, queue_capacity: usize) -> Self {
+        self.queue_capacity = queue_capacity;
+        self
+    }
+
+    /// Set the maximum wait for session capacity.
+    #[must_use]
+    pub fn acquire_timeout(mut self, acquire_timeout: Duration) -> Self {
+        self.acquire_timeout = acquire_timeout;
+        self
+    }
+
+    /// Set the number of clean workers created eagerly.
+    #[must_use]
+    pub fn prewarm(mut self, prewarm: usize) -> Self {
+        self.prewarm = prewarm;
+        self
+    }
+
+    /// Set the executable used for isolated workers.
+    #[must_use]
+    pub fn worker_command(mut self, worker_command: WorkerCommand) -> Self {
+        self.worker_command = worker_command;
+        self
+    }
+
+    fn validate(&self) -> Result<()> {
+        if self.max_sessions == 0 || self.max_sessions > MAX_SESSIONS {
+            return Err(invalid_config("max_sessions must be between 1 and 64"));
+        }
+        if self.queue_capacity > MAX_QUEUE_CAPACITY {
+            return Err(invalid_config("queue_capacity must not exceed 1024"));
+        }
+        if self.prewarm > self.max_sessions {
+            return Err(invalid_config("prewarm must not exceed max_sessions"));
+        }
+        if self.acquire_timeout.is_zero() || self.acquire_timeout > MAX_ACQUIRE_TIMEOUT {
+            return Err(invalid_config(
+                "acquire_timeout must be greater than zero and at most 3600s",
+            ));
+        }
+        self.worker_command.validate()
+    }
+}
+
+impl Default for SessionBrokerConfig {
+    fn default() -> Self {
+        let cpu_default = std::thread::available_parallelism().map_or(2, usize::from).clamp(1, 4);
+        let max_sessions = env_usize("SERVO_FETCH_MAX_WORKERS")
+            .unwrap_or(cpu_default)
+            .clamp(1, MAX_SESSIONS);
+        let queue_capacity = env_usize("SERVO_FETCH_SESSION_QUEUE")
+            .unwrap_or_else(|| max_sessions.saturating_mul(2))
+            .min(MAX_QUEUE_CAPACITY);
+        let prewarm = env_usize("SERVO_FETCH_PREWARM").unwrap_or(0).min(max_sessions);
+        let acquire_timeout = Duration::from_secs(
+            env_usize("SERVO_FETCH_ACQUIRE_TIMEOUT_SECS")
+                .and_then(|value| u64::try_from(value).ok())
+                .unwrap_or(30)
+                .clamp(1, MAX_ACQUIRE_TIMEOUT.as_secs()),
+        );
+        Self {
+            max_sessions,
+            queue_capacity,
+            acquire_timeout,
+            prewarm,
+            worker_command: WorkerCommand::unconfigured(),
+        }
+    }
+}
+
+fn env_usize(name: &str) -> Option<usize> {
+    std::env::var(name).ok()?.parse().ok()
+}
+
+/// Immutable state applied once when a logical browser session starts.
+#[derive(Debug, Clone, Default)]
+#[non_exhaustive]
+pub struct BrowserSessionConfig {
+    /// Session-wide User-Agent.
+    pub(crate) user_agent: Option<String>,
+    /// Cookies seeded once before the first navigation.
+    pub(crate) cookies: Vec<CookieSpec>,
+    /// URL used to validate and scope session cookies.
+    pub(crate) cookie_scope: Option<String>,
+}
+
+impl BrowserSessionConfig {
+    /// Create an empty session configuration.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set the immutable session User-Agent.
+    #[must_use]
+    pub fn user_agent(mut self, user_agent: impl Into<String>) -> Self {
+        self.user_agent = Some(crate::net::sanitize_user_agent(user_agent.into()));
+        self
+    }
+
+    /// Seed cookies once, scoped to `url`.
+    #[must_use]
+    pub fn cookies(mut self, url: impl Into<String>, cookies: Vec<CookieSpec>) -> Self {
+        self.cookie_scope = Some(url.into());
+        self.cookies = cookies;
+        self
+    }
+}
+
+/// Cancellation handle for one browser-session acquisition and its session.
+#[derive(Debug, Clone, Default)]
+pub struct SessionCancellation {
+    inner: Arc<CancellationState>,
+}
+
+#[derive(Debug, Default)]
+struct CancellationState {
+    state: Mutex<CancellationStateInner>,
+    notified: tokio::sync::Notify,
+}
+
+#[derive(Debug, Default)]
+struct CancellationStateInner {
+    cancelled: bool,
+    force_port: Option<ForcePort>,
+}
+
+impl SessionCancellation {
+    /// Create an active cancellation handle.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Cancel acquisition and force-close its worker if one has been attached.
+    ///
+    /// A handle tracks at most one live acquisition; reusing it across
+    /// concurrent acquisitions only force-closes the most recently attached one.
+    pub fn cancel(&self) {
+        let force_port = {
+            let mut state = self
+                .inner
+                .state
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            state.cancelled = true;
+            state.force_port.clone()
+        };
+        if let Some(force_port) = force_port {
+            force_port.force();
+        }
+        self.inner.notified.notify_waiters();
+    }
+
+    /// Return whether cancellation has been requested.
+    #[must_use]
+    pub fn is_cancelled(&self) -> bool {
+        self.inner
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .cancelled
+    }
+
+    fn attach(&self, force_port: &ForcePort) -> bool {
+        let cancelled = {
+            let mut state = self
+                .inner
+                .state
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            state.force_port = Some(force_port.clone());
+            state.cancelled
+        };
+        if cancelled {
+            force_port.force();
+        }
+        !cancelled
+    }
+
+    async fn cancelled(&self) {
+        loop {
+            let notified = self.inner.notified.notified();
+            tokio::pin!(notified);
+            notified.as_mut().enable();
+            if self.is_cancelled() {
+                return;
+            }
+            notified.await;
+        }
+    }
+}
+
+/// Bounded owner of clean workers and live logical-session permits.
+#[derive(Debug, Clone)]
+pub struct SessionBroker {
+    inner: Arc<BrokerInner>,
+}
+
+#[derive(Debug)]
+struct BrokerInner {
+    config: SessionBrokerConfig,
+    permits: Arc<Semaphore>,
+    queue_slots: Arc<Semaphore>,
+    prewarmed: Mutex<Vec<SupervisorHandle>>,
+}
+
+impl SessionBroker {
+    /// Construct a broker and eagerly start only the configured clean workers.
+    pub fn new(mut config: SessionBrokerConfig) -> Result<Self> {
+        if config.worker_command.program.as_os_str().is_empty() {
+            config.worker_command = WorkerCommand::resolved()?;
+        }
+        config.validate()?;
+        let permits = Arc::new(Semaphore::new(config.max_sessions));
+        let mut prewarmed = Vec::with_capacity(config.prewarm);
+        for _ in 0..config.prewarm {
+            let permit = permits
+                .clone()
+                .try_acquire_owned()
+                .map_err(|_| worker_error("failed to reserve prewarm permit"))?;
+            prewarmed.push(SupervisorHandle::spawn(config.worker_command.clone(), permit, None)?);
+        }
+        Ok(Self {
+            inner: Arc::new(BrokerInner {
+                permits,
+                queue_slots: Arc::new(Semaphore::new(config.queue_capacity)),
+                prewarmed: Mutex::new(prewarmed),
+                config,
+            }),
+        })
+    }
+
+    /// Acquire a fresh isolated browser session.
+    pub async fn session(&self, config: BrowserSessionConfig) -> Result<BrowserSession> {
+        self.session_with_cancellation(config, &SessionCancellation::new())
+            .await
+    }
+
+    /// Acquire a session linked to a cancellation handle created before this call.
+    pub async fn session_with_cancellation(
+        &self,
+        config: BrowserSessionConfig,
+        cancellation: &SessionCancellation,
+    ) -> Result<BrowserSession> {
+        validate_session_config(&config)?;
+        if cancellation.is_cancelled() {
+            return Err(cancelled_error());
+        }
+        let clean = self.take_prewarmed();
+        let permit = if clean.is_none() {
+            Some(self.acquire_permit(cancellation).await?)
+        } else {
+            None
+        };
+        let mut acquisition = AcquisitionGuard::new(cancellation.clone());
+        let broker = self.clone();
+        let cancellation = cancellation.clone();
+        let result =
+            tokio::task::spawn_blocking(move || broker.start_session_blocking(config, &cancellation, clean, permit))
+                .await;
+        // The guard only exists to abort detached startup work when this future
+        // is dropped mid-flight; once the join completes, ordinary failures must
+        // not poison the caller's cancellation handle.
+        acquisition.disarm();
+        result.map_err(|error| worker_error(format!("worker startup task failed: {error}")))?
+    }
+
+    /// Blocking counterpart of [`Self::session`].
+    pub fn session_blocking(&self, config: BrowserSessionConfig) -> Result<BrowserSession> {
+        self.session_blocking_with_cancellation(config, &SessionCancellation::new())
+    }
+
+    /// Blocking counterpart of [`Self::session_with_cancellation`].
+    pub fn session_blocking_with_cancellation(
+        &self,
+        config: BrowserSessionConfig,
+        cancellation: &SessionCancellation,
+    ) -> Result<BrowserSession> {
+        crate::runtime::block_on(self.session_with_cancellation(config, cancellation))
+            .map_err(|error| worker_error(error.to_string()))?
+    }
+
+    fn take_prewarmed(&self) -> Option<SupervisorHandle> {
+        self.inner
+            .prewarmed
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .pop()
+    }
+
+    async fn acquire_permit(&self, cancellation: &SessionCancellation) -> Result<OwnedSemaphorePermit> {
+        if let Ok(permit) = self.inner.permits.clone().try_acquire_owned() {
+            return Ok(permit);
+        }
+        let queue_slot = self
+            .inner
+            .queue_slots
+            .clone()
+            .try_acquire_owned()
+            .map_err(|_| Error::SessionBrokerFull)?;
+        let acquire = self.inner.permits.clone().acquire_owned();
+        let timeout = self.inner.config.acquire_timeout;
+        let result = tokio::select! {
+            biased;
+            () = cancellation.cancelled() => Err(cancelled_error()),
+            result = tokio::time::timeout(timeout, acquire) => match result {
+                Ok(Ok(permit)) => Ok(permit),
+                Ok(Err(_)) => Err(worker_error("session broker closed")),
+                Err(_) => Err(Error::SessionAcquireTimeout { timeout }),
+            },
+        };
+        drop(queue_slot);
+        result
+    }
+
+    fn start_session_blocking(
+        &self,
+        config: BrowserSessionConfig,
+        cancellation: &SessionCancellation,
+        clean: Option<SupervisorHandle>,
+        permit: Option<OwnedSemaphorePermit>,
+    ) -> Result<BrowserSession> {
+        if cancellation.is_cancelled() {
+            return Err(cancelled_error());
+        }
+        let mut supervisor = match clean {
+            Some(supervisor) => supervisor,
+            None => SupervisorHandle::spawn(
+                self.inner.config.worker_command.clone(),
+                permit.expect("non-prewarmed startup owns a permit"),
+                Some(cancellation),
+            )?,
+        };
+        if !cancellation.attach(&supervisor.force_port) {
+            return Err(cancelled_error());
+        }
+        let user_agent = config.user_agent.clone();
+        let initialization = InitializeSession {
+            permissive_network: crate::bridge::engine_policy() == NetworkPolicy::PERMISSIVE,
+            user_agent: config.user_agent,
+            cookies: CookieWire::from_specs(&config.cookies),
+            cookie_scope: config.cookie_scope,
+            config_dir: supervisor.config_dir.clone(),
+            temporary_storage: true,
+        };
+        supervisor.initialize_session(initialization)?;
+        Ok(BrowserSession {
+            supervisor: Some(supervisor),
+            user_agent,
+        })
+    }
+}
+
+fn validate_session_config(config: &BrowserSessionConfig) -> Result<()> {
+    if !config.cookies.is_empty() && config.cookie_scope.is_none() {
+        return Err(worker_error(
+            "cookie_scope is required when session cookies are configured",
+        ));
+    }
+    if let Some(scope) = config.cookie_scope.as_deref() {
+        crate::net::validate_url(scope)?;
+    }
+    Ok(())
+}
+
+struct AcquisitionGuard {
+    cancellation: SessionCancellation,
+    armed: bool,
+}
+
+impl AcquisitionGuard {
+    fn new(cancellation: SessionCancellation) -> Self {
+        Self {
+            cancellation,
+            armed: true,
+        }
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for AcquisitionGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            self.cancellation.cancel();
+        }
+    }
+}
+
+/// An isolated context with session-scoped site data and fresh `WebView`s; configure a compatible [`WorkerCommand`] before construction.
+#[derive(Debug)]
+pub struct BrowserSession {
+    supervisor: Option<SupervisorHandle>,
+    user_agent: Option<String>,
+}
+
+impl BrowserSession {
+    /// Force-close this session without waiting. Further operations fail.
+    pub fn cancel(&mut self) {
+        if let Some(mut supervisor) = self.supervisor.take() {
+            supervisor.force();
+        }
+    }
+
+    /// Gracefully close this session, force-killing the worker if it does not exit.
+    pub async fn close(mut self) -> Result<()> {
+        let Some(mut supervisor) = self.supervisor.take() else {
+            return Ok(());
+        };
+        let receive = supervisor.begin_close()?;
+        recv_async(receive, "session close").await?;
+        supervisor.disarm();
+        Ok(())
+    }
+
+    /// Blocking counterpart of [`Self::close`].
+    pub fn close_blocking(mut self) -> Result<()> {
+        let Some(mut supervisor) = self.supervisor.take() else {
+            return Ok(());
+        };
+        let result = supervisor.close_blocking();
+        supervisor.disarm();
+        result
+    }
+
+    /// Force-close this session and wait for supervisor-owned cleanup to finish.
+    pub async fn force_close(mut self) -> Result<()> {
+        let Some(mut supervisor) = self.supervisor.take() else {
+            return Ok(());
+        };
+        let terminal = supervisor.begin_force()?;
+        recv_async(terminal, "forced session close").await?;
+        supervisor.disarm();
+        Ok(())
+    }
+
+    /// Create a session from the process-wide default broker.
+    pub async fn new(config: BrowserSessionConfig) -> Result<Self> {
+        default_broker()?.session(config).await
+    }
+
+    /// Create a session linked to a pre-existing cancellation handle.
+    pub async fn new_with_cancellation(
+        config: BrowserSessionConfig,
+        cancellation: &SessionCancellation,
+    ) -> Result<Self> {
+        default_broker()?.session_with_cancellation(config, cancellation).await
+    }
+
+    /// Create a blocking session from the process-wide default broker.
+    pub fn new_blocking(config: BrowserSessionConfig) -> Result<Self> {
+        default_broker()?.session_blocking(config)
+    }
+
+    /// Create a blocking session linked to a pre-existing cancellation handle.
+    pub fn new_blocking_with_cancellation(
+        config: BrowserSessionConfig,
+        cancellation: &SessionCancellation,
+    ) -> Result<Self> {
+        default_broker()?.session_blocking_with_cancellation(config, cancellation)
+    }
+
+    /// Fetch in this logical session. Per-request UA/cookies are rejected.
+    pub async fn fetch(&mut self, opts: &FetchOptions) -> Result<Page> {
+        validate_session_fetch(opts)?;
+        crate::net::validate_url(&opts.url)?;
+        let (reply, receive) = response_channel();
+        let command = SupervisorCommand::Fetch {
+            request: FetchWire::from_options(opts),
+            reply,
+        };
+        let force_port = self.supervisor_mut()?.force_port.clone();
+        self.supervisor_mut()?.send(command)?;
+        let mut guard = OperationGuard::new(force_port);
+        let response = recv_async(receive, "isolated fetch").await;
+        guard.disarm();
+        let (wire, screenshot) = self.finish_operation(response)?;
+        self.finish_operation(wire.into_page(screenshot))
+    }
+
+    /// Blocking fetch in this logical session.
+    pub fn fetch_blocking(&mut self, opts: &FetchOptions) -> Result<Page> {
+        validate_session_fetch(opts)?;
+        crate::net::validate_url(&opts.url)?;
+        let (reply, receive) = response_channel();
+        self.supervisor_mut()?.send(SupervisorCommand::Fetch {
+            request: FetchWire::from_options(opts),
+            reply,
+        })?;
+        let response = receive_response(&receive, "isolated fetch");
+        let (wire, screenshot) = self.finish_operation(response)?;
+        self.finish_operation(wire.into_page(screenshot))
+    }
+
+    /// Crawl in this logical session.
+    pub async fn crawl(&mut self, opts: &CrawlOptions) -> Result<Vec<CrawlResult>> {
+        let mut results = Vec::new();
+        self.crawl_each(opts, |result| results.push(result)).await?;
+        Ok(results)
+    }
+
+    /// Stream crawl results while preserving async cancellation semantics.
+    pub async fn crawl_each<F>(&mut self, opts: &CrawlOptions, mut on_page: F) -> Result<()>
+    where
+        F: FnMut(CrawlResult),
+    {
+        validate_session_crawl(opts)?;
+        crate::net::validate_url(&opts.url)?;
+        let mut request = opts.clone();
+        request.robots_user_agent.clone_from(&self.user_agent);
+        let (events, receive_events) = crossbeam_channel::bounded(1);
+        let (reply, receive) = response_channel();
+        let force_port = self.supervisor_mut()?.force_port.clone();
+        self.supervisor_mut()?.send(SupervisorCommand::Crawl {
+            request: CrawlWire::from_options(&request),
+            events,
+            reply,
+        })?;
+        let mut guard = OperationGuard::new(force_port);
+        while let Some(result) = recv_optional_async(receive_events.clone()).await? {
+            let callback = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| on_page(result)));
+            if let Err(payload) = callback {
+                drop(guard);
+                std::panic::resume_unwind(payload);
+            }
+        }
+        let response = recv_async(receive, "isolated crawl").await;
+        guard.disarm();
+        self.finish_operation(response)
+    }
+
+    /// Blocking crawl in this logical session.
+    pub fn crawl_blocking(&mut self, opts: &CrawlOptions) -> Result<Vec<CrawlResult>> {
+        let mut results = Vec::new();
+        self.crawl_each_blocking(opts, |result| results.push(result))?;
+        Ok(results)
+    }
+
+    /// Stream a crawl from this logical session over bounded worker frames.
+    pub fn crawl_each_blocking<F>(&mut self, opts: &CrawlOptions, mut on_page: F) -> Result<()>
+    where
+        F: FnMut(CrawlResult),
+    {
+        validate_session_crawl(opts)?;
+        crate::net::validate_url(&opts.url)?;
+        let mut request = opts.clone();
+        request.robots_user_agent.clone_from(&self.user_agent);
+        let (events, receive_events) = crossbeam_channel::bounded(1);
+        let (reply, receive) = response_channel();
+        let force_port = self.supervisor_mut()?.force_port.clone();
+        self.supervisor_mut()?.send(SupervisorCommand::Crawl {
+            request: CrawlWire::from_options(&request),
+            events,
+            reply,
+        })?;
+        while let Ok(result) = receive_events.recv() {
+            let callback = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| on_page(result)));
+            if let Err(payload) = callback {
+                force_port.force();
+                std::panic::resume_unwind(payload);
+            }
+        }
+        let response = receive_response(&receive, "isolated crawl");
+        self.finish_operation(response)
+    }
+
+    fn finish_operation<T>(&mut self, result: Result<T>) -> Result<T> {
+        if result.as_ref().is_err_and(is_terminal_session_error)
+            && let Some(mut supervisor) = self.supervisor.take()
+        {
+            supervisor.disarm();
+        }
+        result
+    }
+
+    fn supervisor_mut(&mut self) -> Result<&mut SupervisorHandle> {
+        self.supervisor
+            .as_mut()
+            .ok_or_else(|| worker_error("browser session is closed"))
+    }
+}
+
+struct OperationGuard {
+    force_port: ForcePort,
+    armed: bool,
+}
+
+impl OperationGuard {
+    fn new(force_port: ForcePort) -> Self {
+        Self {
+            force_port,
+            armed: true,
+        }
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for OperationGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            self.force_port.force();
+        }
+    }
+}
+
+fn default_broker() -> Result<&'static SessionBroker> {
+    if let Some(broker) = DEFAULT_BROKER.get() {
+        return Ok(broker);
+    }
+    let _guard = DEFAULT_BROKER_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    if let Some(broker) = DEFAULT_BROKER.get() {
+        return Ok(broker);
+    }
+    let config = match DEFAULT_BROKER_CONFIG.get() {
+        Some(config) => config.clone(),
+        None => SessionBrokerConfig::default().worker_command(WorkerCommand::resolved()?),
+    };
+    let broker = SessionBroker::new(config)?;
+    DEFAULT_BROKER
+        .set(broker)
+        .map_err(|_| worker_error("default session broker initialized concurrently"))?;
+    DEFAULT_BROKER
+        .get()
+        .ok_or_else(|| worker_error("default session broker initialization failed"))
+}
+
+fn validate_session_fetch(opts: &FetchOptions) -> Result<()> {
+    validate_immutable_settings(opts.user_agent.as_ref(), &opts.cookies, &opts.headers)?;
+    validate_operation_duration("fetch timeout", opts.effective_timeout())?;
+    validate_operation_duration("fetch settle", opts.effective_settle())?;
+    if matches!(opts.mode, FetchMode::Content { .. }) && crate::pdf::looks_like_pdf_url(&opts.url) {
+        return Err(Error::UnsupportedSessionOperation {
+            operation: "PDF extraction",
+            reason: "session-aware PDF networking is unavailable; use the one-shot fetch API",
+        });
+    }
+    Ok(())
+}
+
+fn validate_session_crawl(opts: &CrawlOptions) -> Result<()> {
+    validate_immutable_settings(opts.user_agent.as_ref(), &opts.cookies, &opts.headers)?;
+    validate_operation_duration("crawl timeout", opts.timeout)?;
+    validate_operation_duration("crawl settle", opts.settle)?;
+    if let Some(delay) = opts.delay {
+        validate_operation_duration("crawl delay", delay)?;
+    }
+    if !(1..=MAX_WIRE_CRAWL_CONCURRENCY).contains(&opts.concurrency) {
+        return Err(worker_error(format!(
+            "crawl concurrency must be between 1 and {MAX_WIRE_CRAWL_CONCURRENCY}"
+        )));
+    }
+    opts.validate()
+}
+
+fn validate_operation_duration(field: &str, duration: Duration) -> Result<()> {
+    if duration > MAX_WIRE_DURATION {
+        return Err(worker_error(format!(
+            "{field} exceeds the maximum of {} seconds",
+            MAX_WIRE_DURATION.as_secs()
+        )));
+    }
+    Ok(())
+}
+
+fn validate_immutable_settings(
+    user_agent: Option<&String>,
+    cookies: &[CookieSpec],
+    headers: &http::HeaderMap,
+) -> Result<()> {
+    if user_agent.is_some()
+        || !cookies.is_empty()
+        || headers.contains_key(http::header::USER_AGENT)
+        || headers.contains_key(http::header::COOKIE)
+    {
+        return Err(worker_error(
+            "User-Agent and cookies are immutable session settings; use BrowserSessionConfig",
+        ));
+    }
+    crate::headers::validate_map(headers)
+}
+
+fn cancelled_error() -> Error {
+    Error::SessionCancelled
+}
+
+fn is_terminal_session_error(error: &Error) -> bool {
+    matches!(
+        error,
+        Error::SessionCancelled | Error::WorkerProtocolTimeout { .. } | Error::WorkerUnavailable { .. }
+    )
+}

--- a/crates/servo-fetch/src/session.rs
+++ b/crates/servo-fetch/src/session.rs
@@ -656,7 +656,6 @@ impl BrowserSession {
         F: FnMut(CrawlResult),
     {
         validate_session_crawl(opts)?;
-        crate::net::validate_url(&opts.url)?;
         let mut request = opts.clone();
         request.robots_user_agent.clone_from(&self.user_agent);
         let (events, receive_events) = crossbeam_channel::bounded(1);
@@ -693,7 +692,6 @@ impl BrowserSession {
         F: FnMut(CrawlResult),
     {
         validate_session_crawl(opts)?;
-        crate::net::validate_url(&opts.url)?;
         let mut request = opts.clone();
         request.robots_user_agent.clone_from(&self.user_agent);
         let (events, receive_events) = crossbeam_channel::bounded(1);

--- a/crates/servo-fetch/src/session.rs
+++ b/crates/servo-fetch/src/session.rs
@@ -39,7 +39,7 @@ pub struct WorkerCommand {
 }
 
 impl WorkerCommand {
-    /// Construct a command that enters [`run_worker_stdio`] before using Servo.
+    /// Construct a command that enters [`run_worker_stdio`](crate::run_worker_stdio) before using Servo.
     pub fn new(program: impl Into<PathBuf>) -> Self {
         Self {
             program: program.into(),

--- a/crates/servo-fetch/src/session/supervisor.rs
+++ b/crates/servo-fetch/src/session/supervisor.rs
@@ -43,7 +43,7 @@ const BOOTSTRAP_TIMEOUT: Duration = Duration::from_secs(10);
 const REAP_GRACE: Duration = Duration::from_secs(2);
 const READER_SHUTDOWN_GRACE: Duration = Duration::from_secs(2);
 #[derive(Debug, Clone, Copy)]
-pub(super) enum Lifecycle {
+enum Lifecycle {
     Force,
 }
 
@@ -436,13 +436,9 @@ struct WorkerProcess {
 }
 
 impl WorkerProcess {
-    pub(super) fn spawn(
-        command: &WorkerCommand,
-        permit: OwnedSemaphorePermit,
-        lifecycle: Receiver<Lifecycle>,
-    ) -> Result<Self> {
+    fn spawn(command: &WorkerCommand, permit: OwnedSemaphorePermit, lifecycle: Receiver<Lifecycle>) -> Result<Self> {
         command.validate()?;
-        let mut owner = SupervisorOwner::new(permit)?;
+        let owner = SupervisorOwner::new(permit)?;
         #[cfg(unix)]
         let (lifeline_read, lifeline_write) = create_parent_lifeline()?;
         let mut process = Command::new(&command.program);
@@ -456,10 +452,7 @@ impl WorkerProcess {
         let child = process.spawn();
         let mut child = match child {
             Ok(child) => child,
-            Err(error) => {
-                owner.release();
-                return Err(worker_error(error));
-            }
+            Err(error) => return Err(worker_error(error)),
         };
         #[cfg(unix)]
         drop(lifeline_read);
@@ -469,7 +462,6 @@ impl WorkerProcess {
             Err(error) => {
                 let _ = child.kill();
                 let _ = child.wait();
-                owner.release();
                 return Err(error);
             }
         };
@@ -477,12 +469,10 @@ impl WorkerProcess {
         let process_tree = Arc::new(ProcessTree::attach(&child));
         let Some(stdin) = child.stdin.take() else {
             force_reap(&mut child, &process_tree);
-            owner.release();
             return Err(worker_error("worker stdin unavailable"));
         };
         let Some(stdout) = child.stdout.take() else {
             force_reap(&mut child, &process_tree);
-            owner.release();
             return Err(worker_error("worker stdout unavailable"));
         };
         let (frames_tx, frames) = crossbeam_channel::bounded(1);
@@ -515,7 +505,6 @@ impl WorkerProcess {
             Ok(reader) => reader,
             Err(error) => {
                 force_reap(&mut child, &process_tree);
-                owner.release();
                 return Err(worker_error(error));
             }
         };
@@ -534,7 +523,7 @@ impl WorkerProcess {
         })
     }
 
-    pub(super) fn config_dir(&self) -> PathBuf {
+    fn config_dir(&self) -> PathBuf {
         self.owner.config_dir()
     }
 
@@ -559,7 +548,7 @@ impl WorkerProcess {
         Ok(())
     }
 
-    pub(super) fn initialize_session(&mut self, initialization: InitializeSession) -> Result<()> {
+    fn initialize_session(&mut self, initialization: InitializeSession) -> Result<()> {
         let id = self.write_request(WorkerRequest::Initialize(initialization))?;
         match self.recv_response(id, BOOTSTRAP_TIMEOUT, "session initialization")? {
             WorkerResponse::SessionInitialized => Ok(()),

--- a/crates/servo-fetch/src/session/supervisor.rs
+++ b/crates/servo-fetch/src/session/supervisor.rs
@@ -1,0 +1,870 @@
+//! Worker process ownership, lifecycle supervision, and resource cleanup.
+
+use std::io::{BufReader, BufWriter};
+#[cfg(unix)]
+use std::os::fd::{AsRawFd as _, FromRawFd as _, OwnedFd};
+#[cfg(unix)]
+use std::os::unix::process::CommandExt as _;
+#[cfg(windows)]
+use std::os::windows::io::AsRawHandle as _;
+use std::path::PathBuf;
+use std::process::{Child, ChildStdin, Command, Stdio};
+use std::sync::{Arc, OnceLock};
+use std::time::{Duration, Instant};
+
+use crossbeam_channel::{Receiver, Sender};
+use tokio::sync::OwnedSemaphorePermit;
+#[cfg(windows)]
+use windows_sys::Win32::Foundation::{CloseHandle, HANDLE};
+#[cfg(windows)]
+use windows_sys::Win32::System::JobObjects::{
+    AssignProcessToJobObject, CreateJobObjectW, JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+    JOBOBJECT_EXTENDED_LIMIT_INFORMATION, JobObjectExtendedLimitInformation, SetInformationJobObject,
+    TerminateJobObject,
+};
+
+use super::{SessionCancellation, WorkerCommand, cancelled_error, is_terminal_session_error};
+use crate::CrawlResult;
+use crate::error::{Error, Result};
+use crate::worker::protocol::{
+    InitializeSession, PACKAGE_VERSION, RequestFrame, ResponseFrame, WorkerProtocolInfo, WorkerRequest, WorkerResponse,
+    decode_frame, read_bounded_frame, validate_response, write_bounded_frame,
+};
+use crate::worker::wire::{
+    CrawlWire, FetchWire, MAX_SCREENSHOT_BYTES, PageWire, crawl_wire_absolute_watchdog, crawl_wire_watchdog,
+    fetch_wire_watchdog,
+};
+use crate::worker::{
+    MAX_WORKER_BLOB_CHUNK_BYTES, MAX_WORKER_FRAME_BYTES, MAX_WORKER_PROTOCOL_INFO_BYTES,
+    MAX_WORKER_REQUEST_FRAME_BYTES, PARENT_LIFELINE_FD_ENV, WORKER_PROTOCOL_MAGIC, worker_error,
+};
+
+const BOOTSTRAP_TIMEOUT: Duration = Duration::from_secs(10);
+const REAP_GRACE: Duration = Duration::from_secs(2);
+const READER_SHUTDOWN_GRACE: Duration = Duration::from_secs(2);
+#[derive(Debug, Clone, Copy)]
+pub(super) enum Lifecycle {
+    Force,
+}
+
+type ProcessTreeSlot = Arc<OnceLock<Arc<ProcessTree>>>;
+
+/// Force-close port that both notifies the supervisor and kills the worker
+/// process tree directly, so cancellation cannot be blocked by a supervisor
+/// thread stuck on pipe I/O.
+#[derive(Debug, Clone)]
+pub(super) struct ForcePort {
+    lifecycle: Sender<Lifecycle>,
+    process_tree: ProcessTreeSlot,
+}
+
+impl ForcePort {
+    pub(super) fn force(&self) {
+        // try_send coalesces repeated cancels: one pending Force is sufficient.
+        let _ = self.lifecycle.try_send(Lifecycle::Force);
+        if let Some(tree) = self.process_tree.get() {
+            tree.terminate_now();
+        }
+    }
+}
+
+pub(super) type ResponseSender<T> = Sender<Result<T>>;
+pub(super) type ResponseReceiver<T> = Receiver<Result<T>>;
+
+pub(super) fn frame_wait_duration(idle_timeout: Duration, remaining: Duration) -> Option<Duration> {
+    (!remaining.is_zero()).then(|| idle_timeout.min(remaining))
+}
+
+pub(super) fn response_channel<T>() -> (ResponseSender<T>, ResponseReceiver<T>) {
+    crossbeam_channel::bounded(1)
+}
+
+#[cfg(unix)]
+#[allow(unsafe_code)]
+pub(super) fn create_parent_lifeline() -> Result<(OwnedFd, OwnedFd)> {
+    let (child_end, parent_end) = std::os::unix::net::UnixStream::pair().map_err(worker_error)?;
+    let duplicate = |descriptor: OwnedFd| -> Result<OwnedFd> {
+        // F_DUPFD_CLOEXEC atomically creates a descriptor outside the standard streams.
+        // SAFETY: descriptor is valid and the returned descriptor has independent ownership.
+        let duplicated = unsafe { libc::fcntl(descriptor.as_raw_fd(), libc::F_DUPFD_CLOEXEC, 3) };
+        if duplicated < 0 {
+            return Err(worker_error(std::io::Error::last_os_error()));
+        }
+        // SAFETY: fcntl returned a new descriptor whose ownership is transferred here.
+        Ok(unsafe { OwnedFd::from_raw_fd(duplicated) })
+    };
+    Ok((duplicate(child_end.into())?, duplicate(parent_end.into())?))
+}
+
+#[cfg(unix)]
+#[allow(unsafe_code)]
+fn inherit_parent_lifeline(process: &mut Command, lifeline_fd: i32) {
+    process
+        .process_group(0)
+        .env(PARENT_LIFELINE_FD_ENV, lifeline_fd.to_string());
+    // SAFETY: fcntl is async-signal-safe and only clears CLOEXEC on the dedicated
+    // descriptor after fork, so concurrent process spawns cannot inherit it.
+    unsafe {
+        process.pre_exec(move || {
+            let flags = libc::fcntl(lifeline_fd, libc::F_GETFD);
+            if flags < 0 || libc::fcntl(lifeline_fd, libc::F_SETFD, flags & !libc::FD_CLOEXEC) < 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+}
+
+pub(super) enum SupervisorCommand {
+    Initialize {
+        request: InitializeSession,
+        reply: ResponseSender<()>,
+    },
+    Fetch {
+        request: FetchWire,
+        reply: ResponseSender<(PageWire, Option<Vec<u8>>)>,
+    },
+    Crawl {
+        request: CrawlWire,
+        events: Sender<CrawlResult>,
+        reply: ResponseSender<()>,
+    },
+    Shutdown {
+        reply: ResponseSender<()>,
+    },
+}
+
+pub(super) struct SupervisorHandle {
+    commands: Sender<SupervisorCommand>,
+    pub(super) force_port: ForcePort,
+    terminal: Option<ResponseReceiver<()>>,
+    pub(super) config_dir: PathBuf,
+    armed: bool,
+}
+
+impl std::fmt::Debug for SupervisorHandle {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("SupervisorHandle")
+            .field("config_dir", &self.config_dir)
+            .field("armed", &self.armed)
+            .finish_non_exhaustive()
+    }
+}
+
+impl SupervisorHandle {
+    pub(super) fn spawn(
+        command: WorkerCommand,
+        permit: OwnedSemaphorePermit,
+        cancellation: Option<&SessionCancellation>,
+    ) -> Result<Self> {
+        let (commands, command_rx) = crossbeam_channel::bounded(1);
+        let (lifecycle, lifecycle_rx) = crossbeam_channel::bounded(1);
+        let (bootstrap_result, bootstrap_result_rx) = response_channel();
+        let (terminal, terminal_rx) = response_channel();
+        let force_port = ForcePort {
+            lifecycle,
+            process_tree: ProcessTreeSlot::default(),
+        };
+        if cancellation.is_some_and(|cancel| !cancel.attach(&force_port)) {
+            return Err(cancelled_error());
+        }
+        let tree_slot = force_port.process_tree.clone();
+        std::thread::Builder::new()
+            .name("servo-fetch-supervisor".into())
+            .spawn(move || {
+                supervisor_thread(command, permit, command_rx, lifecycle_rx, tree_slot, bootstrap_result);
+                let _ = terminal.send(Ok(()));
+            })
+            .map_err(worker_error)?;
+        let config_dir = receive_response(&bootstrap_result_rx, "worker protocol bootstrap")?;
+        Ok(Self {
+            commands,
+            force_port,
+            terminal: Some(terminal_rx),
+            config_dir,
+            armed: true,
+        })
+    }
+
+    pub(super) fn send(&self, command: SupervisorCommand) -> Result<()> {
+        self.commands
+            .send(command)
+            .map_err(|_| worker_error("worker supervisor stopped"))
+    }
+
+    pub(super) fn initialize_session(&mut self, request: InitializeSession) -> Result<()> {
+        let (reply, receive) = response_channel();
+        self.send(SupervisorCommand::Initialize { request, reply })?;
+        receive_response(&receive, "worker session initialization")
+    }
+
+    pub(super) fn begin_close(&mut self) -> Result<ResponseReceiver<()>> {
+        let (reply, receive) = response_channel();
+        self.send(SupervisorCommand::Shutdown { reply })?;
+        Ok(receive)
+    }
+
+    pub(super) fn close_blocking(&mut self) -> Result<()> {
+        let receive = self.begin_close()?;
+        receive_response(&receive, "session close")
+    }
+
+    pub(super) fn begin_force(&mut self) -> Result<ResponseReceiver<()>> {
+        self.force();
+        self.terminal
+            .take()
+            .ok_or_else(|| worker_error("supervisor terminal receiver unavailable"))
+    }
+
+    pub(super) fn force(&mut self) {
+        if self.armed {
+            self.force_port.force();
+            self.armed = false;
+        }
+    }
+
+    pub(super) fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for SupervisorHandle {
+    fn drop(&mut self) {
+        // Drop only enqueues force-close; the supervisor owns teardown.
+        self.force();
+    }
+}
+
+pub(super) async fn recv_optional_async<T: Send + 'static>(receive: Receiver<T>) -> Result<Option<T>> {
+    tokio::task::spawn_blocking(move || receive.recv().ok())
+        .await
+        .map_err(|error| worker_error(format!("crawl event task failed: {error}")))
+}
+
+pub(super) async fn recv_async<T: Send + 'static>(receive: ResponseReceiver<T>, context: &'static str) -> Result<T> {
+    tokio::task::spawn_blocking(move || receive_response(&receive, context))
+        .await
+        .map_err(|error| worker_error(format!("{context} task failed: {error}")))?
+}
+
+pub(super) fn receive_response<T>(receive: &ResponseReceiver<T>, context: &str) -> Result<T> {
+    receive
+        .recv()
+        .map_err(|_| worker_error(format!("{context} response channel closed")))?
+}
+
+pub(super) struct SupervisorOwner {
+    temp_dir: Option<tempfile::TempDir>,
+    permit: Option<OwnedSemaphorePermit>,
+}
+
+impl SupervisorOwner {
+    pub(super) fn new(permit: OwnedSemaphorePermit) -> Result<Self> {
+        let temp_dir = tempfile::Builder::new()
+            .prefix("servo-fetch-session-")
+            .tempdir()
+            .map_err(worker_error)?;
+        Ok(Self {
+            temp_dir: Some(temp_dir),
+            permit: Some(permit),
+        })
+    }
+
+    pub(super) fn config_dir(&self) -> PathBuf {
+        self.temp_dir
+            .as_ref()
+            .expect("supervisor tempdir is present")
+            .path()
+            .to_path_buf()
+    }
+
+    pub(super) fn release(&mut self) {
+        if let Some(temp_dir) = self.temp_dir.take() {
+            let path = temp_dir.path().to_path_buf();
+            drop(temp_dir);
+            for _ in 0..3 {
+                if !path.exists() || std::fs::remove_dir_all(&path).is_ok() {
+                    break;
+                }
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            if path.exists() {
+                tracing::error!(path = %path.display(), "failed to delete browser session storage");
+            }
+        }
+        self.permit.take();
+    }
+}
+
+impl Drop for SupervisorOwner {
+    fn drop(&mut self) {
+        self.release();
+    }
+}
+
+#[derive(Debug)]
+struct ProcessTree {
+    #[cfg(windows)]
+    job: WindowsJob,
+    #[cfg(unix)]
+    process_group: Option<i32>,
+    #[cfg(not(any(unix, windows)))]
+    child_id: u32,
+}
+
+impl ProcessTree {
+    #[cfg(windows)]
+    fn attach(child: &Child) -> Result<Self> {
+        Ok(Self {
+            job: WindowsJob::attach(child)?,
+        })
+    }
+
+    #[cfg(not(windows))]
+    fn attach(child: &Child) -> Self {
+        #[cfg(unix)]
+        {
+            Self {
+                process_group: i32::try_from(child.id()).ok(),
+            }
+        }
+        #[cfg(not(any(unix, windows)))]
+        {
+            Self { child_id: child.id() }
+        }
+    }
+
+    fn terminate(&self, child: &Child) {
+        let child_id = child.id();
+        #[cfg(unix)]
+        debug_assert_eq!(
+            i32::try_from(child_id).ok(),
+            self.process_group,
+            "worker process group must match the direct child"
+        );
+        #[cfg(windows)]
+        debug_assert_ne!(child_id, 0, "worker child must have a process ID");
+        #[cfg(not(any(unix, windows)))]
+        debug_assert_eq!(self.child_id, child_id, "worker child identity must remain stable");
+        self.terminate_now();
+    }
+
+    fn terminate_now(&self) {
+        #[cfg(unix)]
+        if let Some(group) = self.process_group {
+            // SAFETY: this supervisor exclusively owns the child's dedicated process group.
+            #[allow(unsafe_code)]
+            unsafe {
+                libc::kill(-group, libc::SIGKILL);
+            }
+        }
+        #[cfg(windows)]
+        self.job.terminate();
+    }
+}
+
+#[cfg(windows)]
+#[derive(Debug)]
+struct WindowsJob(HANDLE);
+
+// SAFETY: job object handles are process-wide kernel objects; TerminateJobObject
+// and CloseHandle are documented as callable from any thread.
+#[cfg(windows)]
+#[allow(unsafe_code)]
+unsafe impl Send for WindowsJob {}
+#[cfg(windows)]
+#[allow(unsafe_code)]
+unsafe impl Sync for WindowsJob {}
+
+#[cfg(windows)]
+impl WindowsJob {
+    #[allow(unsafe_code)]
+    fn attach(child: &Child) -> Result<Self> {
+        unsafe {
+            let job = CreateJobObjectW(std::ptr::null(), std::ptr::null());
+            if job.is_null() {
+                return Err(worker_error(std::io::Error::last_os_error()));
+            }
+            let mut limits = JOBOBJECT_EXTENDED_LIMIT_INFORMATION::default();
+            limits.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+            let configured = SetInformationJobObject(
+                job,
+                JobObjectExtendedLimitInformation,
+                std::ptr::addr_of!(limits).cast(),
+                u32::try_from(std::mem::size_of_val(&limits)).expect("job limits size fits u32"),
+            );
+            if configured == 0 || AssignProcessToJobObject(job, child.as_raw_handle().cast()) == 0 {
+                let error = std::io::Error::last_os_error();
+                CloseHandle(job);
+                return Err(worker_error(error));
+            }
+            Ok(Self(job))
+        }
+    }
+
+    #[allow(unsafe_code)]
+    fn terminate(&self) {
+        unsafe {
+            TerminateJobObject(self.0, 1);
+        }
+    }
+}
+
+#[cfg(windows)]
+impl Drop for WindowsJob {
+    #[allow(unsafe_code)]
+    fn drop(&mut self) {
+        unsafe {
+            CloseHandle(self.0);
+        }
+    }
+}
+
+struct WorkerProcess {
+    child: Option<Child>,
+    process_tree: Arc<ProcessTree>,
+    stdin: Option<BufWriter<ChildStdin>>,
+    frames: Option<Receiver<std::io::Result<Vec<u8>>>>,
+    reader: Option<std::thread::JoinHandle<()>>,
+    reader_done: Option<Receiver<()>>,
+    #[cfg(unix)]
+    parent_lifeline: Option<OwnedFd>,
+    owner: SupervisorOwner,
+    lifecycle: Receiver<Lifecycle>,
+    next_id: u64,
+}
+
+impl WorkerProcess {
+    pub(super) fn spawn(
+        command: &WorkerCommand,
+        permit: OwnedSemaphorePermit,
+        lifecycle: Receiver<Lifecycle>,
+    ) -> Result<Self> {
+        command.validate()?;
+        let mut owner = SupervisorOwner::new(permit)?;
+        #[cfg(unix)]
+        let (lifeline_read, lifeline_write) = create_parent_lifeline()?;
+        let mut process = Command::new(&command.program);
+        process
+            .args(&command.args)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit());
+        #[cfg(unix)]
+        inherit_parent_lifeline(&mut process, lifeline_read.as_raw_fd());
+        let child = process.spawn();
+        let mut child = match child {
+            Ok(child) => child,
+            Err(error) => {
+                owner.release();
+                return Err(worker_error(error));
+            }
+        };
+        #[cfg(unix)]
+        drop(lifeline_read);
+        #[cfg(windows)]
+        let process_tree = match ProcessTree::attach(&child).map(Arc::new) {
+            Ok(process_tree) => process_tree,
+            Err(error) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                owner.release();
+                return Err(error);
+            }
+        };
+        #[cfg(not(windows))]
+        let process_tree = Arc::new(ProcessTree::attach(&child));
+        let Some(stdin) = child.stdin.take() else {
+            force_reap(&mut child, &process_tree);
+            owner.release();
+            return Err(worker_error("worker stdin unavailable"));
+        };
+        let Some(stdout) = child.stdout.take() else {
+            force_reap(&mut child, &process_tree);
+            owner.release();
+            return Err(worker_error("worker stdout unavailable"));
+        };
+        let (frames_tx, frames) = crossbeam_channel::bounded(1);
+        let (reader_done_tx, reader_done) = crossbeam_channel::bounded(1);
+        let reader = std::thread::Builder::new()
+            .name("servo-fetch-worker-reader".into())
+            .spawn(move || {
+                let mut reader = BufReader::new(stdout);
+                let mut first_frame = true;
+                loop {
+                    let max = if first_frame {
+                        MAX_WORKER_PROTOCOL_INFO_BYTES
+                    } else {
+                        MAX_WORKER_FRAME_BYTES
+                    };
+                    let frame = read_bounded_frame(&mut reader, max);
+                    if frame.is_ok() {
+                        first_frame = false;
+                    }
+                    let done = frame
+                        .as_ref()
+                        .is_err_and(|error| error.kind() == std::io::ErrorKind::UnexpectedEof);
+                    if frames_tx.send(frame).is_err() || done {
+                        break;
+                    }
+                }
+                let _ = reader_done_tx.send(());
+            });
+        let reader = match reader {
+            Ok(reader) => reader,
+            Err(error) => {
+                force_reap(&mut child, &process_tree);
+                owner.release();
+                return Err(worker_error(error));
+            }
+        };
+        Ok(Self {
+            child: Some(child),
+            process_tree,
+            stdin: Some(BufWriter::new(stdin)),
+            frames: Some(frames),
+            reader: Some(reader),
+            reader_done: Some(reader_done),
+            #[cfg(unix)]
+            parent_lifeline: Some(lifeline_write),
+            owner,
+            lifecycle,
+            next_id: 1,
+        })
+    }
+
+    pub(super) fn config_dir(&self) -> PathBuf {
+        self.owner.config_dir()
+    }
+
+    fn receive_protocol_info(&mut self) -> Result<()> {
+        let deadline = Instant::now() + BOOTSTRAP_TIMEOUT;
+        let bytes = self.recv_frame(BOOTSTRAP_TIMEOUT, deadline, BOOTSTRAP_TIMEOUT, "protocol info")?;
+        let info: WorkerProtocolInfo = decode_frame(&bytes)?;
+        if info.magic != WORKER_PROTOCOL_MAGIC {
+            return Err(worker_error(format!(
+                "worker protocol mismatch: expected magic {WORKER_PROTOCOL_MAGIC:?}; got {:?}",
+                info.magic
+            )));
+        }
+        // Postcard encoding is not forward-compatible, so a worker built from a
+        // different package version must be rejected before any request frame.
+        if info.package_version != PACKAGE_VERSION {
+            return Err(worker_error(format!(
+                "worker package version mismatch: parent {PACKAGE_VERSION}, worker {}",
+                info.package_version
+            )));
+        }
+        Ok(())
+    }
+
+    pub(super) fn initialize_session(&mut self, initialization: InitializeSession) -> Result<()> {
+        let id = self.write_request(WorkerRequest::Initialize(initialization))?;
+        match self.recv_response(id, BOOTSTRAP_TIMEOUT, "session initialization")? {
+            WorkerResponse::SessionInitialized => Ok(()),
+            WorkerResponse::Error(error) => Err(error.into_error()),
+            _ => Err(worker_error("unexpected session initialization response")),
+        }
+    }
+
+    fn fetch(&mut self, request: FetchWire) -> Result<(PageWire, Option<Vec<u8>>)> {
+        let timeout = fetch_wire_watchdog(&request);
+        let deadline = Instant::now() + timeout;
+        let id = self.write_request(WorkerRequest::Fetch(request))?;
+        let mut page = None;
+        let mut screenshot = None;
+        loop {
+            let response = self.recv_response_until(id, timeout, deadline, timeout, "fetch")?;
+            match response {
+                WorkerResponse::FetchResult(result) if page.is_none() => {
+                    let declared_size = result.screenshot_png_bytes();
+                    if declared_size.is_some_and(|size| size > MAX_SCREENSHOT_BYTES) {
+                        return Err(worker_error("declared screenshot payload exceeds maximum size"));
+                    }
+                    screenshot = declared_size.map(Vec::with_capacity);
+                    page = Some(result);
+                }
+                WorkerResponse::ScreenshotChunk(chunk) => {
+                    if chunk.is_empty() || chunk.len() > MAX_WORKER_BLOB_CHUNK_BYTES {
+                        return Err(worker_error("invalid screenshot chunk size"));
+                    }
+                    let expected = page
+                        .as_ref()
+                        .and_then(PageWire::screenshot_png_bytes)
+                        .ok_or_else(|| worker_error("unexpected screenshot chunk"))?;
+                    let target = screenshot
+                        .as_mut()
+                        .ok_or_else(|| worker_error("screenshot payload was not declared"))?;
+                    if chunk.len() > expected.saturating_sub(target.len()) {
+                        return Err(worker_error("screenshot payload exceeds declared size"));
+                    }
+                    target.extend_from_slice(&chunk);
+                }
+                WorkerResponse::FetchCompleted => {
+                    let page = page.ok_or_else(|| worker_error("fetch completed without a result"))?;
+                    if screenshot.as_ref().map(Vec::len) != page.screenshot_png_bytes() {
+                        return Err(worker_error("incomplete screenshot payload"));
+                    }
+                    return Ok((page, screenshot));
+                }
+                WorkerResponse::Error(error) if page.is_none() => return Err(error.into_error()),
+                WorkerResponse::Error(_) => {
+                    return Err(worker_error("worker returned an error after a partial fetch response"));
+                }
+                _ => return Err(worker_error("unexpected fetch response")),
+            }
+        }
+    }
+
+    fn crawl(&mut self, request: CrawlWire, events: &Sender<CrawlResult>) -> Result<()> {
+        let idle_timeout = crawl_wire_watchdog(&request);
+        let absolute_timeout = crawl_wire_absolute_watchdog(&request);
+        let deadline = Instant::now() + absolute_timeout;
+        let id = self.write_request(WorkerRequest::Crawl(request))?;
+        loop {
+            match self.recv_response_until(id, idle_timeout, deadline, absolute_timeout, "crawl")? {
+                WorkerResponse::CrawlResult(event) => {
+                    let result = event.into_result()?;
+                    crossbeam_channel::select_biased! {
+                        recv(self.lifecycle) -> _ => return Err(cancelled_error()),
+                        send(events, result) -> sent => {
+                            sent.map_err(|_| worker_error("crawl result receiver closed"))?;
+                        },
+                    }
+                }
+                WorkerResponse::CrawlProgress(_) => {}
+                WorkerResponse::CrawlCompleted => return Ok(()),
+                WorkerResponse::Error(error) => return Err(error.into_error()),
+                _ => return Err(worker_error("unexpected crawl response")),
+            }
+        }
+    }
+
+    fn graceful_shutdown(&mut self) -> Result<()> {
+        let id = self.write_request(WorkerRequest::Shutdown)?;
+        match self.recv_response(id, REAP_GRACE, "shutdown")? {
+            WorkerResponse::ShutdownAck => {}
+            WorkerResponse::Error(error) => return Err(error.into_error()),
+            _ => return Err(worker_error("unexpected shutdown response")),
+        }
+        self.stdin.take();
+        let child = self.child.as_mut().expect("worker child is present");
+        let deadline = Instant::now() + REAP_GRACE;
+        loop {
+            match child.try_wait() {
+                Ok(Some(status)) => {
+                    self.process_tree.terminate(child);
+                    if status.success() {
+                        return Ok(());
+                    }
+                    return Err(worker_error(format!("worker exited with {status} after shutdown ack")));
+                }
+                Ok(None) if Instant::now() < deadline => std::thread::sleep(Duration::from_millis(10)),
+                Ok(None) => return Err(worker_error("worker did not exit after shutdown acknowledgement")),
+                Err(error) => return Err(worker_error(error)),
+            }
+        }
+    }
+
+    fn write_request(&mut self, request: WorkerRequest) -> Result<u64> {
+        let id = self.next_id;
+        self.next_id = self.next_id.wrapping_add(1);
+        let frame = RequestFrame { id, request };
+        write_bounded_frame(
+            self.stdin.as_mut().ok_or_else(|| worker_error("worker stdin closed"))?,
+            &frame,
+            MAX_WORKER_REQUEST_FRAME_BYTES,
+        )?;
+        Ok(id)
+    }
+
+    fn recv_response(&self, id: u64, timeout: Duration, operation: &'static str) -> Result<WorkerResponse> {
+        let deadline = Instant::now() + timeout;
+        self.recv_response_until(id, timeout, deadline, timeout, operation)
+    }
+
+    fn recv_response_until(
+        &self,
+        id: u64,
+        idle_timeout: Duration,
+        absolute_deadline: Instant,
+        absolute_timeout: Duration,
+        operation: &'static str,
+    ) -> Result<WorkerResponse> {
+        let bytes = self.recv_frame(idle_timeout, absolute_deadline, absolute_timeout, operation)?;
+        let response: ResponseFrame = decode_frame(&bytes)?;
+        validate_response(&response, id)?;
+        Ok(response.response)
+    }
+
+    fn recv_frame(
+        &self,
+        idle_timeout: Duration,
+        absolute_deadline: Instant,
+        absolute_timeout: Duration,
+        operation: &'static str,
+    ) -> Result<Vec<u8>> {
+        let remaining = absolute_deadline.saturating_duration_since(Instant::now());
+        let Some(wait) = frame_wait_duration(idle_timeout, remaining) else {
+            return Err(Error::WorkerProtocolTimeout {
+                operation,
+                timeout: absolute_timeout,
+            });
+        };
+        let frames = self.frames.as_ref().expect("worker frame receiver is present");
+        let timer = crossbeam_channel::after(wait);
+        crossbeam_channel::select_biased! {
+            recv(self.lifecycle) -> _ => Err(cancelled_error()),
+            recv(frames) -> frame => match frame {
+                Ok(Ok(frame)) => Ok(frame),
+                Ok(Err(error)) => Err(worker_error(error)),
+                Err(_) => Err(worker_error("worker transport closed")),
+            },
+            recv(timer) -> _ => {
+                let timeout = if Instant::now() >= absolute_deadline {
+                    absolute_timeout
+                } else {
+                    idle_timeout
+                };
+                Err(Error::WorkerProtocolTimeout { operation, timeout })
+            },
+        }
+    }
+
+    fn cleanup(&mut self, force: bool) {
+        self.stdin.take();
+        #[cfg(unix)]
+        self.parent_lifeline.take();
+        if let Some(child) = self.child.as_mut()
+            && (force || child.try_wait().ok().flatten().is_none())
+        {
+            force_reap(child, &self.process_tree);
+        }
+        self.child.take();
+        self.frames.take();
+        let reader_finished = self
+            .reader_done
+            .take()
+            .is_none_or(|done| done.recv_timeout(READER_SHUTDOWN_GRACE).is_ok());
+        if let Some(reader) = self.reader.take() {
+            if reader_finished {
+                let _ = reader.join();
+            } else {
+                tracing::warn!("worker stdout reader did not stop before cleanup deadline");
+            }
+        }
+        self.owner.release();
+    }
+}
+
+impl Drop for WorkerProcess {
+    fn drop(&mut self) {
+        self.cleanup(true);
+    }
+}
+
+fn force_reap(child: &mut Child, process_tree: &ProcessTree) {
+    process_tree.terminate(child);
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+#[expect(
+    clippy::needless_pass_by_value,
+    reason = "the supervisor thread owns command channels and worker configuration for its lifetime"
+)]
+fn supervisor_thread(
+    command: WorkerCommand,
+    permit: OwnedSemaphorePermit,
+    commands: Receiver<SupervisorCommand>,
+    lifecycle: Receiver<Lifecycle>,
+    tree_slot: ProcessTreeSlot,
+    bootstrap_result: ResponseSender<PathBuf>,
+) {
+    let mut worker = match WorkerProcess::spawn(&command, permit, lifecycle.clone()) {
+        Ok(worker) => worker,
+        Err(error) => {
+            let _ = bootstrap_result.send(Err(error));
+            return;
+        }
+    };
+    let _ = tree_slot.set(worker.process_tree.clone());
+    if let Err(error) = worker.receive_protocol_info() {
+        worker.cleanup(true);
+        let _ = bootstrap_result.send(Err(error));
+        return;
+    }
+    if bootstrap_result.send(Ok(worker.config_dir())).is_err() {
+        worker.cleanup(true);
+        return;
+    }
+
+    loop {
+        crossbeam_channel::select_biased! {
+            recv(lifecycle) -> _ => {
+                worker.cleanup(true);
+                return;
+            },
+            recv(commands) -> command => {
+                let Ok(command) = command else {
+                    worker.cleanup(true);
+                    return;
+                };
+                match command {
+                    SupervisorCommand::Initialize { request, reply } => match worker.initialize_session(request) {
+                        Ok(()) => {
+                            let _ = reply.send(Ok(()));
+                        }
+                        Err(error) => {
+                            worker.cleanup(true);
+                            let _ = reply.send(Err(error));
+                            return;
+                        }
+                    },
+                    SupervisorCommand::Fetch { request, reply } => match worker.fetch(request) {
+                        Ok(page) => {
+                            let _ = reply.send(Ok(page));
+                        }
+                        Err(error) => {
+                            let terminal = is_terminal_session_error(&error);
+                            if terminal {
+                                worker.cleanup(true);
+                            }
+                            let _ = reply.send(Err(error));
+                            if terminal {
+                                return;
+                            }
+                        }
+                    },
+                    SupervisorCommand::Crawl { request, events, reply } => {
+                        let result = worker.crawl(request, &events);
+                        drop(events);
+                        match result {
+                            Ok(()) => {
+                                let _ = reply.send(Ok(()));
+                            }
+                            Err(error) => {
+                                let terminal = is_terminal_session_error(&error);
+                                if terminal {
+                                    worker.cleanup(true);
+                                }
+                                let _ = reply.send(Err(error));
+                                if terminal {
+                                    return;
+                                }
+                            }
+                        }
+                    }
+                    SupervisorCommand::Shutdown { reply } => {
+                        let result = worker.graceful_shutdown();
+                        let graceful = result.is_ok();
+                        worker.cleanup(!graceful);
+                        let _ = reply.send(result);
+                        return;
+                    }
+                }
+            },
+        }
+    }
+}

--- a/crates/servo-fetch/src/session/tests.rs
+++ b/crates/servo-fetch/src/session/tests.rs
@@ -1,0 +1,977 @@
+//! Session protocol, lifecycle, isolation, and resource-ordering tests.
+
+use std::ffi::OsString;
+use std::fmt::Write as _;
+use std::io::Read as _;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant, UNIX_EPOCH};
+
+use serde::Serialize;
+use tokio::sync::Semaphore;
+
+#[cfg(unix)]
+use super::supervisor::create_parent_lifeline;
+use super::supervisor::{SupervisorCommand, SupervisorOwner, frame_wait_duration, receive_response, response_channel};
+use super::*;
+use crate::worker::protocol::{
+    CrawlProgressState, PACKAGE_VERSION, RequestFrame, ResponseFrame, WorkerProtocolInfo, WorkerRequest,
+    WorkerResponse, decode_frame, read_bounded_frame, write_bounded_frame,
+};
+use crate::worker::wire::{
+    CrawlProgressWire, CrawlResultWire, CrawlWire, MAX_OPERATION_WATCHDOG, MAX_SCREENSHOT_BYTES, PageWire,
+    WorkerErrorWire, crawl_absolute_watchdog, crawl_watchdog, fetch_watchdog,
+};
+use crate::worker::{MAX_WORKER_BLOB_CHUNK_BYTES, MAX_WORKER_FRAME_BYTES, WORKER_PROTOCOL_MAGIC};
+use crate::{CrawlPage, CrawlResult, Page};
+
+fn encoded_frame(value: &impl Serialize) -> Vec<u8> {
+    let mut frame = Vec::new();
+    write_bounded_frame(&mut frame, value, MAX_WORKER_FRAME_BYTES).unwrap();
+    frame
+}
+
+fn shell_frame(value: &impl Serialize) -> String {
+    let encoded = encoded_frame(value);
+    let mut escaped = String::with_capacity(encoded.len().saturating_mul(4));
+    for byte in encoded {
+        write!(escaped, "\\{byte:03o}").unwrap();
+    }
+    format!("printf '{escaped}'; ")
+}
+
+fn protocol_info_shell() -> String {
+    shell_frame(&WorkerProtocolInfo {
+        magic: WORKER_PROTOCOL_MAGIC,
+        package_version: PACKAGE_VERSION.into(),
+    })
+}
+
+fn response_shell(id: u64, response: WorkerResponse) -> String {
+    shell_frame(&ResponseFrame { id, response })
+}
+
+fn initialized_shell(id: u64) -> String {
+    response_shell(id, WorkerResponse::SessionInitialized)
+}
+
+fn shutdown_ack_shell(id: u64) -> String {
+    response_shell(id, WorkerResponse::ShutdownAck)
+}
+
+fn page_with_declared_screenshot(size: Option<u32>) -> PageWire {
+    let (mut page, screenshot) = PageWire::from_page(Page::default()).unwrap();
+    assert!(screenshot.is_none());
+    page.set_screenshot_png_bytes(size);
+    page
+}
+
+fn empty_page_shell(id: u64) -> String {
+    let (page, screenshot) = PageWire::from_page(Page::default()).unwrap();
+    assert!(screenshot.is_none());
+    format!(
+        "{}{}",
+        response_shell(id, WorkerResponse::FetchResult(page)),
+        response_shell(id, WorkerResponse::FetchCompleted)
+    )
+}
+
+#[cfg(unix)]
+const READ_FRAME_SHELL: &str = concat!(
+    "read_frame() { ",
+    "out=$1; ",
+    "set -- $(dd bs=1 count=4 2>/dev/null | od -An -tu1); ",
+    "[ $# -eq 4 ] || exit 0; ",
+    "length=$(( $1 * 16777216 + $2 * 65536 + $3 * 256 + $4 )); ",
+    "if [ -n \"$out\" ]; then dd bs=1 count=$length of=\"$out\" 2>/dev/null; ",
+    "else dd bs=1 count=$length of=/dev/null 2>/dev/null; fi; ",
+    "}; ",
+);
+
+#[cfg(unix)]
+fn scripted_worker_prefix() -> String {
+    format!("{READ_FRAME_SHELL}{}", protocol_info_shell())
+}
+
+#[cfg(unix)]
+fn session_script() -> String {
+    format!(
+        "{}read_frame; {}read_frame; {}",
+        scripted_worker_prefix(),
+        initialized_shell(1),
+        shutdown_ack_shell(2)
+    )
+}
+
+#[test]
+fn page_wire_detaches_binary_payloads() {
+    let size = MAX_WORKER_BLOB_CHUNK_BYTES + 1;
+    let page = Page {
+        screenshot_png: Some(vec![0xff; size]),
+        extracted: Some(serde_json::json!({"ok": true, "count": 2})),
+        ..Page::default()
+    };
+    let (wire, screenshot) = PageWire::from_page(page).unwrap();
+    let encoded = postcard::to_stdvec(&wire).unwrap();
+    assert!(encoded.len() < 1024);
+    let wire: PageWire = decode_frame(&encoded).unwrap();
+    let screenshot = screenshot.unwrap();
+    assert_eq!(screenshot.len(), size);
+    let decoded = wire.into_page(Some(screenshot)).unwrap();
+    assert_eq!(decoded.extracted, Some(serde_json::json!({"ok": true, "count": 2})));
+    let decoded = decoded.screenshot_png.unwrap();
+    assert_eq!(decoded.len(), size);
+    assert!(decoded.iter().all(|byte| *byte == 0xff));
+}
+
+#[test]
+fn oversized_page_output_returns_typed_error() {
+    let screenshot = Page {
+        screenshot_png: Some(vec![0; 32 * 1024 * 1024 + 1]),
+        ..Page::default()
+    };
+    assert!(matches!(
+        PageWire::from_page(screenshot),
+        Err(Error::OutputTooLarge { kind: "screenshot", .. })
+    ));
+
+    let text = Page {
+        html: "x".repeat(MAX_WORKER_FRAME_BYTES),
+        ..Page::default()
+    };
+    assert!(matches!(
+        PageWire::from_page(text),
+        Err(Error::OutputTooLarge { kind: "page", .. })
+    ));
+}
+
+#[test]
+fn response_protocol_rejects_trailing_bytes_and_empty_frames() {
+    let response = ResponseFrame {
+        id: 7,
+        response: WorkerResponse::ShutdownAck,
+    };
+    let mut encoded = postcard::to_stdvec(&response).unwrap();
+    encoded.push(0);
+    assert!(decode_frame::<ResponseFrame>(&encoded).is_err());
+    assert!(decode_frame::<ResponseFrame>(&[u8::MAX]).is_err());
+
+    let mut empty = std::io::Cursor::new(0_u32.to_be_bytes());
+    assert_eq!(
+        read_bounded_frame(&mut empty, MAX_WORKER_FRAME_BYTES)
+            .unwrap_err()
+            .kind(),
+        std::io::ErrorKind::InvalidData
+    );
+}
+
+#[test]
+fn crawl_stream_progress_counts_results_and_suppressions() {
+    let mut progress = CrawlProgressState::default();
+    let result = CrawlResult {
+        url: "https://example.com/a".into(),
+        depth: 0,
+        fetched_at: UNIX_EPOCH,
+        outcome: Ok(CrawlPage {
+            title: None,
+            content: "a".into(),
+            links_found: 0,
+        }),
+    };
+    assert!(matches!(
+        progress.observe(crate::crawl::CrawlSessionEvent::Result(result)),
+        WorkerResponse::CrawlResult(_)
+    ));
+
+    let event = progress.observe(crate::crawl::CrawlSessionEvent::Suppressed(
+        crate::crawl::SuppressedPage {
+            url: "https://example.com/b".into(),
+            depth: 1,
+            reason: crate::crawl::SuppressionReason::DuplicateContent,
+        },
+    ));
+    let WorkerResponse::CrawlProgress(snapshot) = event else {
+        panic!("suppression must emit a progress snapshot");
+    };
+    assert_eq!(
+        snapshot,
+        CrawlProgressWire {
+            processed: 2,
+            emitted: 1,
+            suppressed: 1,
+        }
+    );
+    let encoded = postcard::to_stdvec(&ResponseFrame {
+        id: 7,
+        response: WorkerResponse::CrawlProgress(snapshot),
+    })
+    .unwrap();
+    let decoded: ResponseFrame = decode_frame(&encoded).unwrap();
+    assert!(matches!(decoded.response, WorkerResponse::CrawlProgress(_)));
+}
+
+#[test]
+fn crawl_error_round_trip_preserves_timeout_kind() {
+    let result = CrawlResult {
+        url: "https://example.com/slow".into(),
+        depth: 1,
+        fetched_at: UNIX_EPOCH,
+        outcome: Err(Error::Timeout {
+            url: "https://example.com/slow".into(),
+            timeout: Duration::from_secs(7),
+        }),
+    };
+    let decoded = CrawlResultWire::from_result(result).into_result().unwrap();
+    assert!(matches!(
+        decoded.outcome,
+        Err(Error::Timeout { ref url, timeout })
+            if url == "https://example.com/slow" && timeout == Duration::from_secs(7)
+    ));
+}
+
+#[cfg(unix)]
+#[test]
+fn parent_lifeline_reports_eof_when_owner_drops() {
+    let (read_end, write_end) = create_parent_lifeline().unwrap();
+    for descriptor in [&read_end, &write_end] {
+        let raw_fd = std::os::fd::AsRawFd::as_raw_fd(descriptor);
+        assert!(raw_fd >= 3);
+        // SAFETY: fcntl only reads flags from a descriptor owned by this test.
+        #[allow(unsafe_code)]
+        let flags = unsafe { libc::fcntl(raw_fd, libc::F_GETFD) };
+        assert!(flags >= 0);
+        assert_ne!(flags & libc::FD_CLOEXEC, 0);
+    }
+    let mut read_end = std::fs::File::from(read_end);
+    drop(write_end);
+    let mut byte = [0];
+    assert_eq!(read_end.read(&mut byte).unwrap(), 0);
+}
+
+#[test]
+fn tempdir_is_deleted_before_permit_release() {
+    let permits = Arc::new(Semaphore::new(1));
+    let permit = permits.clone().try_acquire_owned().unwrap();
+    let mut owner = SupervisorOwner::new(permit).unwrap();
+    let config_dir = owner.config_dir();
+    assert!(config_dir.is_dir());
+    let (observed, receive) = std::sync::mpsc::channel();
+    let contender = std::thread::spawn({
+        move || {
+            let _permit = crate::runtime::block_on(permits.acquire_owned()).unwrap().unwrap();
+            observed.send(config_dir.exists()).unwrap();
+        }
+    });
+    owner.release();
+    assert!(!receive.recv_timeout(Duration::from_secs(1)).unwrap());
+    contender.join().unwrap();
+}
+
+#[test]
+fn broker_rejects_invalid_configuration() {
+    let executable = WorkerCommand::new(std::env::current_exe().unwrap());
+    let cases = [
+        SessionBrokerConfig::default().worker_command(WorkerCommand::new("relative-worker")),
+        SessionBrokerConfig::default(),
+        SessionBrokerConfig::default()
+            .max_sessions(0)
+            .worker_command(executable.clone()),
+        SessionBrokerConfig::default()
+            .max_sessions(usize::MAX)
+            .worker_command(executable.clone()),
+        SessionBrokerConfig::default()
+            .queue_capacity(usize::MAX)
+            .worker_command(executable.clone()),
+        SessionBrokerConfig::default()
+            .max_sessions(1)
+            .prewarm(2)
+            .worker_command(executable.clone()),
+        SessionBrokerConfig::default()
+            .acquire_timeout(Duration::ZERO)
+            .worker_command(executable),
+    ];
+    for config in cases {
+        assert!(matches!(
+            SessionBroker::new(config),
+            Err(Error::InvalidSessionConfig { .. })
+        ));
+    }
+}
+
+#[test]
+fn session_rejects_per_request_state_bypasses() {
+    let options = FetchOptions::new("https://example.com/protected.pdf");
+    assert!(matches!(
+        validate_session_fetch(&options),
+        Err(Error::UnsupportedSessionOperation {
+            operation: "PDF extraction",
+            ..
+        })
+    ));
+
+    let mut fetch = FetchOptions::new("https://example.com");
+    fetch
+        .headers
+        .insert(http::header::USER_AGENT, http::HeaderValue::from_static("other"));
+    assert!(validate_session_fetch(&fetch).is_err());
+
+    let mut crawl = CrawlOptions::new("https://example.com");
+    crawl
+        .headers
+        .insert(http::header::COOKIE, http::HeaderValue::from_static("sid=other"));
+    assert!(validate_session_crawl(&crawl).is_err());
+}
+
+#[test]
+fn session_rejects_untransportable_operation_values_before_dispatch() {
+    let fetch = FetchOptions::new("https://example.com").timeout(MAX_WIRE_DURATION + Duration::from_millis(1));
+    assert!(validate_session_fetch(&fetch).is_err());
+
+    let mut reserved_header = FetchOptions::new("https://example.com");
+    reserved_header
+        .headers
+        .insert(http::header::HOST, http::HeaderValue::from_static("other.example"));
+    assert!(matches!(
+        validate_session_fetch(&reserved_header),
+        Err(Error::InvalidHeader(_))
+    ));
+
+    let crawl = CrawlOptions::new("https://example.com").concurrency(MAX_WIRE_CRAWL_CONCURRENCY + 1);
+    assert!(validate_session_crawl(&crawl).is_err());
+    let crawl = CrawlOptions::new("https://example.com").delay(Some(MAX_WIRE_DURATION + Duration::from_millis(1)));
+    assert!(validate_session_crawl(&crawl).is_err());
+}
+
+#[test]
+fn absolute_deadline_bounds_each_idle_wait() {
+    assert_eq!(
+        frame_wait_duration(Duration::from_secs(30), Duration::from_millis(5)),
+        Some(Duration::from_millis(5))
+    );
+    assert_eq!(
+        frame_wait_duration(Duration::from_millis(5), Duration::from_secs(30)),
+        Some(Duration::from_millis(5))
+    );
+    assert_eq!(frame_wait_duration(Duration::from_secs(30), Duration::ZERO), None);
+}
+
+#[test]
+fn worker_watchdogs_include_all_valid_wait_phases() {
+    let fetch = FetchOptions::new("https://example.com")
+        .timeout(Duration::from_secs(5))
+        .settle(Duration::from_secs(21));
+    assert_eq!(fetch_watchdog(&fetch), Duration::from_secs(41));
+    let crawl = CrawlOptions::new("https://example.com")
+        .timeout(Duration::from_secs(5))
+        .settle(Duration::from_secs(21))
+        .delay(Some(Duration::from_secs(3)))
+        .concurrency(4);
+    assert_eq!(crawl_watchdog(&crawl), Duration::from_secs(58));
+    assert!(crawl_absolute_watchdog(&crawl) > crawl_watchdog(&crawl));
+
+    let extreme_fetch = FetchOptions::new("https://example.com")
+        .timeout(Duration::MAX)
+        .settle(Duration::MAX);
+    assert_eq!(fetch_watchdog(&extreme_fetch), MAX_OPERATION_WATCHDOG);
+    let extreme_crawl = CrawlOptions::new("https://example.com")
+        .timeout(Duration::MAX)
+        .settle(Duration::MAX)
+        .delay(Some(Duration::MAX));
+    assert_eq!(crawl_watchdog(&extreme_crawl), MAX_OPERATION_WATCHDOG);
+    assert_eq!(crawl_absolute_watchdog(&extreme_crawl), MAX_OPERATION_WATCHDOG);
+}
+
+#[cfg(unix)]
+fn scripted_broker(script: &str, args: impl IntoIterator<Item = OsString>, queue_capacity: usize) -> SessionBroker {
+    SessionBroker::new(SessionBrokerConfig {
+        max_sessions: 1,
+        queue_capacity,
+        acquire_timeout: Duration::from_secs(3),
+        prewarm: 0,
+        worker_command: WorkerCommand::new("/bin/sh").args(
+            [OsString::from("-c"), OsString::from(script), OsString::from("worker")]
+                .into_iter()
+                .chain(args),
+        ),
+    })
+    .unwrap()
+}
+
+#[cfg(unix)]
+fn assert_fetch_protocol_failure(responses: &str) {
+    let script = format!(
+        "{}read_frame; {}read_frame; {responses}exec sleep 10",
+        scripted_worker_prefix(),
+        initialized_shell(1),
+    );
+    let broker = scripted_broker(&script, [], 0);
+    let mut session = broker.session_blocking(BrowserSessionConfig::new()).unwrap();
+    let config_dir = session.supervisor.as_ref().unwrap().config_dir.clone();
+    assert!(matches!(
+        session.fetch_blocking(&FetchOptions::new("https://example.com")),
+        Err(Error::WorkerUnavailable { .. })
+    ));
+    assert!(!config_dir.exists());
+    assert!(
+        session
+            .fetch_blocking(&FetchOptions::new("https://example.com"))
+            .is_err()
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn protocol_info_validation_fails_closed() {
+    let invalid_infos = [
+        WorkerProtocolInfo {
+            magic: *b"NOTWORK\0",
+            package_version: PACKAGE_VERSION.into(),
+        },
+        WorkerProtocolInfo {
+            magic: WORKER_PROTOCOL_MAGIC,
+            package_version: format!("{PACKAGE_VERSION}-mismatch"),
+        },
+    ];
+    for info in invalid_infos {
+        let script = format!("{READ_FRAME_SHELL}{}exec sleep 10", shell_frame(&info));
+        let broker = scripted_broker(&script, [], 0);
+        assert!(matches!(
+            broker.session_blocking(BrowserSessionConfig::new()),
+            Err(Error::WorkerUnavailable { .. })
+        ));
+    }
+
+    for script in [
+        "printf '\\000\\000\\020\\001'; exec sleep 10",
+        "printf '\\000\\000\\000\\001\\377'; exec sleep 10",
+    ] {
+        let broker = scripted_broker(script, [], 0);
+        assert!(matches!(
+            broker.session_blocking(BrowserSessionConfig::new()),
+            Err(Error::WorkerUnavailable { .. })
+        ));
+    }
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn force_close_terminates_worker_process_group() {
+    let directory = tempfile::tempdir().unwrap();
+    let child_pid = directory.path().join("child-pid");
+    let script = format!(
+        "{}read_frame; {}sleep 60 & echo $! > \"$1\"; exec sleep 60",
+        scripted_worker_prefix(),
+        initialized_shell(1)
+    );
+    let broker = scripted_broker(&script, [child_pid.clone().into_os_string()], 0);
+    let session = broker.session(BrowserSessionConfig::new()).await.unwrap();
+    let config_dir = session.supervisor.as_ref().unwrap().config_dir.clone();
+    let deadline = Instant::now() + Duration::from_secs(1);
+    while !child_pid.exists() {
+        assert!(Instant::now() < deadline, "worker descendant did not start");
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+    let pid = std::fs::read_to_string(&child_pid)
+        .unwrap()
+        .trim()
+        .parse::<i32>()
+        .unwrap();
+
+    tokio::time::timeout(Duration::from_secs(3), session.force_close())
+        .await
+        .expect("process-group cleanup must be bounded")
+        .unwrap();
+    assert!(!config_dir.exists());
+    let deadline = Instant::now() + Duration::from_secs(1);
+    loop {
+        // SAFETY: signal 0 only probes the PID captured from the test child.
+        #[allow(unsafe_code)]
+        let alive = unsafe { libc::kill(pid, 0) } == 0;
+        if !alive {
+            break;
+        }
+        assert!(Instant::now() < deadline, "worker descendant survived force close");
+        std::thread::sleep(Duration::from_millis(10));
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn drop_is_nonblocking_and_force_closes() {
+    let script = format!(
+        "{}read_frame; {}exec sleep 10",
+        scripted_worker_prefix(),
+        initialized_shell(1)
+    );
+    let broker = scripted_broker(&script, [], 0);
+    let session = broker.session_blocking(BrowserSessionConfig::new()).unwrap();
+    let config_dir = session.supervisor.as_ref().unwrap().config_dir.clone();
+    let started = Instant::now();
+    drop(session);
+    assert!(started.elapsed() < Duration::from_millis(100));
+
+    let deadline = Instant::now() + Duration::from_secs(3);
+    while config_dir.exists() {
+        assert!(Instant::now() < deadline, "background force close did not complete");
+        std::thread::sleep(Duration::from_millis(10));
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn graceful_close_sends_shutdown_reaps_descendants_and_deletes_storage() {
+    let directory = tempfile::tempdir().unwrap();
+    let initialize_request = directory.path().join("initialize-request");
+    let shutdown_request = directory.path().join("shutdown-request");
+    let child_pid = directory.path().join("child-pid");
+    let script = format!(
+        "{}read_frame \"$1\"; {}sleep 60 & echo $! > \"$3\"; read_frame \"$2\"; {}exit 0",
+        scripted_worker_prefix(),
+        initialized_shell(1),
+        shutdown_ack_shell(2)
+    );
+    let broker = scripted_broker(
+        &script,
+        [
+            initialize_request.clone().into_os_string(),
+            shutdown_request.clone().into_os_string(),
+            child_pid.clone().into_os_string(),
+        ],
+        0,
+    );
+    let session = broker.session_blocking(BrowserSessionConfig::new()).unwrap();
+    let config_dir = session.supervisor.as_ref().unwrap().config_dir.clone();
+    let deadline = Instant::now() + Duration::from_secs(1);
+    while !child_pid.exists() {
+        assert!(Instant::now() < deadline, "worker descendant did not start");
+        std::thread::sleep(Duration::from_millis(5));
+    }
+    let pid = std::fs::read_to_string(&child_pid)
+        .unwrap()
+        .trim()
+        .parse::<i32>()
+        .unwrap();
+
+    session.close_blocking().unwrap();
+    assert!(!config_dir.exists());
+
+    let initialize: RequestFrame = decode_frame(&std::fs::read(initialize_request).unwrap()).unwrap();
+    let WorkerRequest::Initialize(initialization) = initialize.request else {
+        panic!("expected initialize request");
+    };
+    assert_eq!(initialization.config_dir, config_dir);
+    let shutdown: RequestFrame = decode_frame(&std::fs::read(shutdown_request).unwrap()).unwrap();
+    assert!(matches!(shutdown.request, WorkerRequest::Shutdown));
+
+    let deadline = Instant::now() + Duration::from_secs(1);
+    loop {
+        // SAFETY: signal 0 only probes the PID captured from the test child.
+        #[allow(unsafe_code)]
+        let alive = unsafe { libc::kill(pid, 0) } == 0;
+        if !alive {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "worker descendant survived graceful shutdown"
+        );
+        std::thread::sleep(Duration::from_millis(10));
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn shutdown_faults_are_bounded_and_cleanup_storage() {
+    let cases = [
+        format!("{}exec sleep 10", shutdown_ack_shell(2)),
+        format!("{}exit 7", shutdown_ack_shell(2)),
+        format!("{}exec sleep 10", response_shell(2, WorkerResponse::CrawlCompleted)),
+    ];
+    for response in cases {
+        let script = format!(
+            "{}read_frame; {}read_frame; {response}",
+            scripted_worker_prefix(),
+            initialized_shell(1),
+        );
+        let broker = scripted_broker(&script, [], 0);
+        let session = broker.session_blocking(BrowserSessionConfig::new()).unwrap();
+        let config_dir = session.supervisor.as_ref().unwrap().config_dir.clone();
+        let started = Instant::now();
+        assert!(session.close_blocking().is_err());
+        assert!(started.elapsed() < Duration::from_secs(4));
+        assert!(!config_dir.exists());
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn malformed_fetch_sequences_are_terminal() {
+    let oversized = u32::try_from(MAX_SCREENSHOT_BYTES + 1).unwrap();
+    let sequences = [
+        response_shell(99, WorkerResponse::FetchCompleted),
+        response_shell(2, WorkerResponse::ScreenshotChunk(vec![1])),
+        response_shell(2, WorkerResponse::FetchCompleted),
+        format!(
+            "{}{}",
+            response_shell(2, WorkerResponse::FetchResult(page_with_declared_screenshot(None))),
+            response_shell(2, WorkerResponse::FetchResult(page_with_declared_screenshot(None))),
+        ),
+        format!(
+            "{}{}",
+            response_shell(2, WorkerResponse::FetchResult(page_with_declared_screenshot(Some(1)))),
+            response_shell(2, WorkerResponse::ScreenshotChunk(Vec::new())),
+        ),
+        format!(
+            "{}{}",
+            response_shell(2, WorkerResponse::FetchResult(page_with_declared_screenshot(None))),
+            response_shell(2, WorkerResponse::ScreenshotChunk(vec![1])),
+        ),
+        format!(
+            "{}{}",
+            response_shell(2, WorkerResponse::FetchResult(page_with_declared_screenshot(Some(2)))),
+            response_shell(2, WorkerResponse::ScreenshotChunk(vec![1, 2, 3])),
+        ),
+        format!(
+            "{}{}{}",
+            response_shell(2, WorkerResponse::FetchResult(page_with_declared_screenshot(Some(3)))),
+            response_shell(2, WorkerResponse::ScreenshotChunk(vec![1, 2])),
+            response_shell(2, WorkerResponse::FetchCompleted),
+        ),
+        format!(
+            "{}{}",
+            response_shell(2, WorkerResponse::FetchResult(page_with_declared_screenshot(None))),
+            response_shell(
+                2,
+                WorkerResponse::Error(WorkerErrorWire::failure("engine", "late error"))
+            ),
+        ),
+        response_shell(
+            2,
+            WorkerResponse::FetchResult(page_with_declared_screenshot(Some(oversized))),
+        ),
+    ];
+    for sequence in sequences {
+        assert_fetch_protocol_failure(&sequence);
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn oversized_screenshot_chunk_is_terminal() {
+    let directory = tempfile::tempdir().unwrap();
+    let response_path = directory.path().join("oversized-chunk");
+    let chunk_size = MAX_WORKER_BLOB_CHUNK_BYTES + 1;
+    std::fs::write(
+        &response_path,
+        encoded_frame(&ResponseFrame {
+            id: 2,
+            response: WorkerResponse::ScreenshotChunk(vec![0; chunk_size]),
+        }),
+    )
+    .unwrap();
+    let script = format!(
+        "{}read_frame; {}read_frame; {}cat \"$1\"; exec sleep 10",
+        scripted_worker_prefix(),
+        initialized_shell(1),
+        response_shell(
+            2,
+            WorkerResponse::FetchResult(page_with_declared_screenshot(Some(u32::try_from(chunk_size).unwrap()))),
+        ),
+    );
+    let broker = scripted_broker(&script, [response_path.into_os_string()], 0);
+    let mut session = broker.session_blocking(BrowserSessionConfig::new()).unwrap();
+    assert!(matches!(
+        session.fetch_blocking(&FetchOptions::new("https://example.com")),
+        Err(Error::WorkerUnavailable { .. })
+    ));
+}
+
+#[cfg(unix)]
+#[test]
+fn application_error_keeps_session_usable() {
+    let script = format!(
+        "{}read_frame; {}read_frame; {}read_frame; {}read_frame; {}",
+        scripted_worker_prefix(),
+        initialized_shell(1),
+        response_shell(2, WorkerResponse::Error(WorkerErrorWire::failure("engine", "boom")),),
+        empty_page_shell(3),
+        shutdown_ack_shell(4)
+    );
+    let broker = scripted_broker(&script, [], 0);
+    let mut session = broker.session_blocking(BrowserSessionConfig::new()).unwrap();
+    let config_dir = session.supervisor.as_ref().unwrap().config_dir.clone();
+
+    assert!(
+        session
+            .fetch_blocking(&FetchOptions::new("https://example.com"))
+            .is_err()
+    );
+    assert!(config_dir.exists(), "application error unexpectedly closed the session");
+    session
+        .fetch_blocking(&FetchOptions::new("https://example.com"))
+        .unwrap();
+    session.close_blocking().unwrap();
+    assert!(!config_dir.exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn screenshot_chunks_are_reassembled_by_supervisor() {
+    let (page, screenshot) = PageWire::from_page(Page {
+        screenshot_png: Some(vec![1, 2, 3, 4, 5]),
+        ..Page::default()
+    })
+    .unwrap();
+    assert_eq!(screenshot.unwrap(), vec![1, 2, 3, 4, 5]);
+    let script = format!(
+        "{}read_frame; {}read_frame; {}{}{}{}read_frame; {}",
+        scripted_worker_prefix(),
+        initialized_shell(1),
+        response_shell(2, WorkerResponse::FetchResult(page)),
+        response_shell(2, WorkerResponse::ScreenshotChunk(vec![1, 2])),
+        response_shell(2, WorkerResponse::ScreenshotChunk(vec![3, 4, 5])),
+        response_shell(2, WorkerResponse::FetchCompleted),
+        shutdown_ack_shell(3)
+    );
+    let broker = scripted_broker(&script, [], 0);
+    let mut session = broker.session_blocking(BrowserSessionConfig::new()).unwrap();
+    let page = session
+        .fetch_blocking(&FetchOptions::screenshot("https://example.com", false))
+        .unwrap();
+    assert_eq!(page.screenshot_png, Some(vec![1, 2, 3, 4, 5]));
+    session.close_blocking().unwrap();
+}
+
+#[cfg(unix)]
+#[test]
+fn force_cancel_releases_capacity_without_waiting_for_handle_drop() {
+    let script = session_script();
+    let broker = scripted_broker(&script, [], 1);
+    let cancellation = SessionCancellation::new();
+    let mut session = broker
+        .session_blocking_with_cancellation(BrowserSessionConfig::new(), &cancellation)
+        .unwrap();
+    cancellation.cancel();
+    let mut replacement = broker.session_blocking(BrowserSessionConfig::new()).unwrap();
+    replacement.cancel();
+    session.cancel();
+}
+
+#[cfg(unix)]
+#[test]
+fn prewarmed_worker_is_clean_and_never_reused_after_close() {
+    let directory = tempfile::tempdir().unwrap();
+    let spawns = directory.path().join("spawns");
+    let script = format!(
+        "printf x >> \"$1\"; {}read_frame; {}read_frame; {}",
+        scripted_worker_prefix(),
+        initialized_shell(1),
+        shutdown_ack_shell(2)
+    );
+    let broker = SessionBroker::new(SessionBrokerConfig {
+        max_sessions: 1,
+        queue_capacity: 0,
+        acquire_timeout: Duration::from_secs(1),
+        prewarm: 1,
+        worker_command: WorkerCommand::new("/bin/sh").args([
+            OsString::from("-c"),
+            OsString::from(script),
+            OsString::from("worker"),
+            spawns.clone().into_os_string(),
+        ]),
+    })
+    .unwrap();
+    assert_eq!(std::fs::read(&spawns).unwrap(), b"x");
+    broker
+        .session_blocking(BrowserSessionConfig::new())
+        .unwrap()
+        .close_blocking()
+        .unwrap();
+    broker
+        .session_blocking(BrowserSessionConfig::new())
+        .unwrap()
+        .close_blocking()
+        .unwrap();
+    assert_eq!(std::fs::read(spawns).unwrap(), b"xx");
+}
+
+#[cfg(unix)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn bounded_queue_enforces_capacity_and_fifo_fairness() {
+    let script = session_script();
+    let saturated = scripted_broker(&script, [], 0);
+    let held = saturated.session(BrowserSessionConfig::new()).await.unwrap();
+    assert!(matches!(
+        saturated.session(BrowserSessionConfig::new()).await,
+        Err(Error::SessionBrokerFull)
+    ));
+    held.close().await.unwrap();
+
+    let broker = Arc::new(scripted_broker(&script, [], 3));
+    let held = broker.session(BrowserSessionConfig::new()).await.unwrap();
+    let order = Arc::new(Mutex::new(Vec::new()));
+    let mut tasks = Vec::new();
+    for id in 0..3 {
+        let broker = broker.clone();
+        let order = order.clone();
+        tasks.push(tokio::spawn(async move {
+            let session = broker.session(BrowserSessionConfig::new()).await.unwrap();
+            order.lock().unwrap().push(id);
+            session.close().await.unwrap();
+        }));
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    held.close().await.unwrap();
+    for task in tasks {
+        task.await.unwrap();
+    }
+    assert_eq!(*order.lock().unwrap(), vec![0, 1, 2]);
+}
+
+#[cfg(unix)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn startup_cancellation_force_closes_before_permit_reuse() {
+    let directory = tempfile::tempdir().unwrap();
+    let gate = directory.path().join("gate");
+    let starts = directory.path().join("starts");
+    let script = format!(
+        "printf x >> \"$1\"; while [ ! -e \"$2\" ]; do sleep 0.01; done; {}read_frame; {}read_frame; {}",
+        scripted_worker_prefix(),
+        initialized_shell(1),
+        shutdown_ack_shell(2)
+    );
+    let broker = Arc::new(scripted_broker(
+        &script,
+        [starts.clone().into_os_string(), gate.clone().into_os_string()],
+        1,
+    ));
+    let cancellation = SessionCancellation::new();
+    let first_broker = broker.clone();
+    let first_cancel = cancellation.clone();
+    let first = tokio::spawn(async move {
+        first_broker
+            .session_with_cancellation(BrowserSessionConfig::new(), &first_cancel)
+            .await
+    });
+    while std::fs::read(&starts).map_or(0, |bytes| bytes.len()) < 1 {
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+    cancellation.cancel();
+    let second_broker = broker.clone();
+    let second = tokio::spawn(async move { second_broker.session(BrowserSessionConfig::new()).await });
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(1);
+    while std::fs::read(&starts).map_or(0, |bytes| bytes.len()) < 2 {
+        assert!(tokio::time::Instant::now() < deadline);
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+    std::fs::write(gate, b"open").unwrap();
+    assert!(first.await.unwrap().is_err());
+    second.await.unwrap().unwrap().close().await.unwrap();
+}
+
+#[cfg(unix)]
+#[test]
+fn stalled_crawl_consumer_does_not_block_force_close() {
+    let event = || {
+        WorkerResponse::CrawlResult(CrawlResultWire::from_result(CrawlResult {
+            url: "https://example.com".into(),
+            depth: 0,
+            fetched_at: UNIX_EPOCH,
+            outcome: Ok(CrawlPage {
+                title: None,
+                content: "x".into(),
+                links_found: 0,
+            }),
+        }))
+    };
+    let script = format!(
+        "{}read_frame; {}read_frame; {}{}exec sleep 10",
+        scripted_worker_prefix(),
+        initialized_shell(1),
+        response_shell(2, event()),
+        response_shell(2, event())
+    );
+    let broker = scripted_broker(&script, [], 1);
+    let cancellation = SessionCancellation::new();
+    let mut session = broker
+        .session_blocking_with_cancellation(BrowserSessionConfig::new(), &cancellation)
+        .unwrap();
+    let (events, _receive_events) = crossbeam_channel::bounded(1);
+    let (reply, receive) = response_channel();
+    session
+        .supervisor_mut()
+        .unwrap()
+        .send(SupervisorCommand::Crawl {
+            request: CrawlWire::from_options(&CrawlOptions::new("https://example.com").delay(None)),
+            events,
+            reply,
+        })
+        .unwrap();
+    std::thread::sleep(Duration::from_millis(50));
+
+    cancellation.cancel();
+    assert!(receive_response(&receive, "crawl cancellation").is_err());
+    let mut replacement = broker.session_blocking(BrowserSessionConfig::new()).unwrap();
+    replacement.cancel();
+    session.cancel();
+}
+
+#[cfg(unix)]
+#[test]
+fn crawl_progress_frames_extend_per_frame_watchdog() {
+    let progress = |processed, suppressed| {
+        response_shell(
+            2,
+            WorkerResponse::CrawlProgress(CrawlProgressWire {
+                processed,
+                emitted: 0,
+                suppressed,
+            }),
+        )
+    };
+    let script = format!(
+        "{}read_frame; {}read_frame; sleep 0.04; {}sleep 0.04; {}sleep 0.04; {}read_frame; {}",
+        scripted_worker_prefix(),
+        initialized_shell(1),
+        progress(1, 1),
+        progress(2, 2),
+        response_shell(2, WorkerResponse::CrawlCompleted),
+        shutdown_ack_shell(3)
+    );
+    let broker = scripted_broker(&script, [], 0);
+    let mut session = broker.session_blocking(BrowserSessionConfig::new()).unwrap();
+    let (events, _receive_events) = crossbeam_channel::bounded(1);
+    let (reply, receive) = response_channel();
+    let request = CrawlWire::from_options(
+        &CrawlOptions::new("https://example.com")
+            .timeout(Duration::from_millis(1))
+            .delay(None),
+    );
+    session
+        .supervisor_mut()
+        .unwrap()
+        .send(SupervisorCommand::Crawl { request, events, reply })
+        .unwrap();
+    let started = Instant::now();
+    receive_response(&receive, "crawl").unwrap();
+    assert!(started.elapsed() >= Duration::from_millis(100));
+    session.close_blocking().unwrap();
+}
+
+#[tokio::test]
+async fn ordinary_acquisition_failures_do_not_poison_cancellation() {
+    let script = session_script();
+    let broker = scripted_broker(&script, [], 0);
+    let held = broker.session(BrowserSessionConfig::new()).await.unwrap();
+    let cancellation = SessionCancellation::new();
+    assert!(matches!(
+        broker
+            .session_with_cancellation(BrowserSessionConfig::new(), &cancellation)
+            .await,
+        Err(Error::SessionBrokerFull)
+    ));
+    assert!(
+        !cancellation.is_cancelled(),
+        "a failed acquisition must not cancel the caller's handle"
+    );
+    held.close().await.unwrap();
+}

--- a/crates/servo-fetch/src/session/tests.rs
+++ b/crates/servo-fetch/src/session/tests.rs
@@ -15,7 +15,7 @@ use super::supervisor::{SupervisorCommand, SupervisorOwner, frame_wait_duration,
 use super::*;
 use crate::worker::protocol::{
     CrawlProgressState, PACKAGE_VERSION, RequestFrame, ResponseFrame, WorkerProtocolInfo, WorkerRequest,
-    WorkerResponse, decode_frame, read_bounded_frame, write_bounded_frame,
+    WorkerResponse, decode_frame, write_bounded_frame,
 };
 use crate::worker::wire::{
     CrawlProgressWire, CrawlResultWire, CrawlWire, MAX_OPERATION_WATCHDOG, MAX_SCREENSHOT_BYTES, PageWire,
@@ -124,28 +124,7 @@ fn page_wire_detaches_binary_payloads() {
 }
 
 #[test]
-fn oversized_page_output_returns_typed_error() {
-    let screenshot = Page {
-        screenshot_png: Some(vec![0; 32 * 1024 * 1024 + 1]),
-        ..Page::default()
-    };
-    assert!(matches!(
-        PageWire::from_page(screenshot),
-        Err(Error::OutputTooLarge { kind: "screenshot", .. })
-    ));
-
-    let text = Page {
-        html: "x".repeat(MAX_WORKER_FRAME_BYTES),
-        ..Page::default()
-    };
-    assert!(matches!(
-        PageWire::from_page(text),
-        Err(Error::OutputTooLarge { kind: "page", .. })
-    ));
-}
-
-#[test]
-fn response_protocol_rejects_trailing_bytes_and_empty_frames() {
+fn response_decoding_rejects_trailing_bytes_and_invalid_payloads() {
     let response = ResponseFrame {
         id: 7,
         response: WorkerResponse::ShutdownAck,
@@ -154,14 +133,6 @@ fn response_protocol_rejects_trailing_bytes_and_empty_frames() {
     encoded.push(0);
     assert!(decode_frame::<ResponseFrame>(&encoded).is_err());
     assert!(decode_frame::<ResponseFrame>(&[u8::MAX]).is_err());
-
-    let mut empty = std::io::Cursor::new(0_u32.to_be_bytes());
-    assert_eq!(
-        read_bounded_frame(&mut empty, MAX_WORKER_FRAME_BYTES)
-            .unwrap_err()
-            .kind(),
-        std::io::ErrorKind::InvalidData
-    );
 }
 
 #[test]

--- a/crates/servo-fetch/src/worker.rs
+++ b/crates/servo-fetch/src/worker.rs
@@ -1,16 +1,17 @@
 //! Process-local implementation of the isolated worker protocol.
-mod protocol;
+pub(crate) mod protocol;
 #[cfg(test)]
 mod tests;
-mod wire;
+pub(crate) mod wire;
 pub use protocol::run_worker_stdio;
 
 use crate::error::Error;
 pub(crate) const MAX_WORKER_FRAME_BYTES: usize = 64 * 1024 * 1024;
-const MAX_WORKER_REQUEST_FRAME_BYTES: usize = 8 * 1024 * 1024;
-const WORKER_PROTOCOL_MAGIC: [u8; 8] = *b"SFETCHW\0";
-const MAX_WORKER_PROTOCOL_INFO_BYTES: usize = 4 * 1024;
-const MAX_WORKER_BLOB_CHUNK_BYTES: usize = 1024 * 1024;
-fn worker_error(source: impl Into<crate::error::BoxError>) -> Error {
+pub(crate) const MAX_WORKER_REQUEST_FRAME_BYTES: usize = 8 * 1024 * 1024;
+pub(crate) const WORKER_PROTOCOL_MAGIC: [u8; 8] = *b"SFETCHW\0";
+pub(crate) const MAX_WORKER_PROTOCOL_INFO_BYTES: usize = 4 * 1024;
+pub(crate) const MAX_WORKER_BLOB_CHUNK_BYTES: usize = 1024 * 1024;
+pub(crate) const PARENT_LIFELINE_FD_ENV: &str = "SERVO_FETCH_INTERNAL_PARENT_LIFELINE_FD";
+pub(crate) fn worker_error(source: impl Into<crate::error::BoxError>) -> Error {
     Error::WorkerUnavailable { source: source.into() }
 }

--- a/crates/servo-fetch/src/worker/protocol.rs
+++ b/crates/servo-fetch/src/worker/protocol.rs
@@ -16,10 +16,10 @@ use crate::NetworkPolicy;
 use crate::cookies::CookieWire;
 use crate::error::{Error, Result};
 
-pub(super) const PACKAGE_VERSION: &str = env!("CARGO_PKG_VERSION");
+pub(crate) const PACKAGE_VERSION: &str = env!("CARGO_PKG_VERSION");
 const FRAME_LENGTH_BYTES: usize = size_of::<u32>();
 
-pub(super) fn decode_frame<T: DeserializeOwned>(bytes: &[u8]) -> Result<T> {
+pub(crate) fn decode_frame<T: DeserializeOwned>(bytes: &[u8]) -> Result<T> {
     let (value, remainder) = postcard::take_from_bytes(bytes).map_err(|error| worker_error(error.to_string()))?;
     if !remainder.is_empty() {
         return Err(worker_error("worker frame has trailing bytes"));
@@ -27,7 +27,7 @@ pub(super) fn decode_frame<T: DeserializeOwned>(bytes: &[u8]) -> Result<T> {
     Ok(value)
 }
 
-pub(super) fn read_bounded_frame(reader: &mut impl Read, max: usize) -> std::io::Result<Vec<u8>> {
+pub(crate) fn read_bounded_frame(reader: &mut impl Read, max: usize) -> std::io::Result<Vec<u8>> {
     let mut prefix = [0; FRAME_LENGTH_BYTES];
     loop {
         match reader.read(&mut prefix[..1]) {
@@ -63,13 +63,13 @@ fn truncated_frame(error: std::io::Error) -> std::io::Error {
     }
 }
 
-pub(super) struct BoundedBuffer {
-    pub(super) bytes: Vec<u8>,
+pub(crate) struct BoundedBuffer {
+    pub(crate) bytes: Vec<u8>,
     max: usize,
 }
 
 impl BoundedBuffer {
-    pub(super) fn new(max: usize) -> Self {
+    pub(crate) fn new(max: usize) -> Self {
         Self {
             bytes: Vec::with_capacity(max.min(8 * 1024)),
             max,
@@ -94,7 +94,7 @@ impl Write for BoundedBuffer {
     }
 }
 
-pub(super) fn write_bounded_frame(writer: &mut impl Write, value: &impl Serialize, max: usize) -> Result<()> {
+pub(crate) fn write_bounded_frame(writer: &mut impl Write, value: &impl Serialize, max: usize) -> Result<()> {
     let mut frame = BoundedBuffer::new(max);
     postcard::to_io(value, &mut frame).map_err(|error| worker_error(error.to_string()))?;
     let length = u32::try_from(frame.bytes.len()).map_err(|_| worker_error("worker frame length exceeds u32"))?;
@@ -107,8 +107,74 @@ fn write_response(writer: &mut impl Write, id: u64, response: WorkerResponse) ->
     write_bounded_frame(writer, &ResponseFrame { id, response }, MAX_WORKER_FRAME_BYTES)
 }
 
+/// Terminate the worker as soon as the owning parent process disappears.
+#[cfg(unix)]
+#[allow(unsafe_code)]
+fn install_parent_lifeline() -> Result<()> {
+    use std::os::fd::{FromRawFd, OwnedFd};
+
+    let Some(raw_fd) = std::env::var_os(super::PARENT_LIFELINE_FD_ENV) else {
+        return Ok(());
+    };
+    let raw_fd = raw_fd
+        .to_str()
+        .ok_or_else(|| worker_error("parent lifeline descriptor is not valid UTF-8"))?
+        .parse::<i32>()
+        .map_err(|error| worker_error(format!("invalid parent lifeline descriptor: {error}")))?;
+    if raw_fd < 0 {
+        return Err(worker_error("parent lifeline descriptor is negative"));
+    }
+    // Duplicate instead of adopting the inherited descriptor: fcntl validates it
+    // and returns a fresh descriptor, so a spoofed or already-owned value in the
+    // environment can never be double-closed through OwnedFd.
+    // SAFETY: fcntl(F_DUPFD_CLOEXEC) either fails or returns a new descriptor
+    // whose sole owner is the OwnedFd constructed below.
+    let duplicated = unsafe { libc::fcntl(raw_fd, libc::F_DUPFD_CLOEXEC, 3) };
+    if duplicated < 0 {
+        return Err(worker_error(std::io::Error::last_os_error()));
+    }
+    // SAFETY: `duplicated` was just created by fcntl and has independent ownership.
+    let descriptor = unsafe { OwnedFd::from_raw_fd(duplicated) };
+    std::thread::Builder::new()
+        .name("servo-fetch-parent-lifeline".into())
+        .spawn(move || {
+            let mut pipe = std::fs::File::from(descriptor);
+            let mut byte = [0];
+            loop {
+                match pipe.read(&mut byte) {
+                    Ok(0) => {
+                        // SAFETY: parent loss requires process-wide termination without Servo static destructors.
+                        unsafe { libc::_exit(0) };
+                    }
+                    Ok(_) => {}
+                    Err(error) if error.kind() == std::io::ErrorKind::Interrupted => {}
+                    Err(_) => {
+                        // SAFETY: a broken lifeline is equivalent to losing the owning parent.
+                        unsafe { libc::_exit(1) };
+                    }
+                }
+            }
+        })
+        .map_err(worker_error)?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn install_parent_lifeline() -> Result<()> {
+    Ok(())
+}
+
+/// Reject a response frame whose id does not match the awaited request.
+pub(crate) fn validate_response(response: &ResponseFrame, id: u64) -> Result<()> {
+    if response.id != id {
+        return Err(worker_error("worker response id mismatch"));
+    }
+    Ok(())
+}
+
 /// Run the isolated worker protocol before any Servo use.
 pub fn run_worker_stdio() -> Result<()> {
+    install_parent_lifeline()?;
     let stdin = std::io::stdin();
     let stdout = std::io::stdout();
     let mut reader = stdin.lock();
@@ -116,7 +182,7 @@ pub fn run_worker_stdio() -> Result<()> {
     run_worker(&mut reader, &mut writer)
 }
 
-pub(super) fn run_worker<R: Read, W: Write>(reader: &mut R, writer: &mut W) -> Result<()> {
+pub(crate) fn run_worker<R: Read, W: Write>(reader: &mut R, writer: &mut W) -> Result<()> {
     write_bounded_frame(
         writer,
         &WorkerProtocolInfo {
@@ -148,7 +214,7 @@ pub(super) fn run_worker<R: Read, W: Write>(reader: &mut R, writer: &mut W) -> R
     }
 }
 
-pub(super) fn handle_worker_initialize(config: InitializeSession, state: &mut WorkerState) -> WorkerResponse {
+pub(crate) fn handle_worker_initialize(config: InitializeSession, state: &mut WorkerState) -> WorkerResponse {
     if !matches!(state, WorkerState::AwaitingInitialize) {
         let message = if matches!(state, WorkerState::Ready { .. }) {
             "worker session is already initialized"
@@ -189,11 +255,11 @@ pub(super) fn handle_worker_initialize(config: InitializeSession, state: &mut Wo
     }
 }
 
-pub(super) struct ValidatedInitialize {
-    pub(super) policy: NetworkPolicy,
-    pub(super) user_agent: Option<String>,
+pub(crate) struct ValidatedInitialize {
+    pub(crate) policy: NetworkPolicy,
+    pub(crate) user_agent: Option<String>,
     cookies: Vec<crate::cookies::CookieSpec>,
-    pub(super) cookie_scope: Option<String>,
+    pub(crate) cookie_scope: Option<String>,
     config_dir: PathBuf,
     temporary_storage: bool,
 }
@@ -201,7 +267,7 @@ pub(super) struct ValidatedInitialize {
 impl ValidatedInitialize {
     const MAX_USER_AGENT_BYTES: usize = 8 * 1024;
 
-    pub(super) fn from_wire(config: InitializeSession) -> Result<Self> {
+    pub(crate) fn from_wire(config: InitializeSession) -> Result<Self> {
         let policy = if config.permissive_network {
             NetworkPolicy::PERMISSIVE
         } else {
@@ -276,14 +342,14 @@ fn handle_worker_fetch(id: u64, fetch: FetchWire, state: &WorkerState, writer: &
 }
 
 #[derive(Default)]
-pub(super) struct CrawlProgressState {
+pub(crate) struct CrawlProgressState {
     processed: u64,
     emitted: u64,
     suppressed: u64,
 }
 
 impl CrawlProgressState {
-    pub(super) fn observe(&mut self, event: crate::crawl::CrawlSessionEvent) -> WorkerResponse {
+    pub(crate) fn observe(&mut self, event: crate::crawl::CrawlSessionEvent) -> WorkerResponse {
         self.processed = self.processed.saturating_add(1);
         match event {
             crate::crawl::CrawlSessionEvent::Result(result) => {
@@ -330,36 +396,36 @@ fn handle_worker_crawl(id: u64, crawl: CrawlWire, state: &WorkerState, writer: &
 }
 
 #[derive(Clone, PartialEq, Eq)]
-pub(super) enum WorkerState {
+pub(crate) enum WorkerState {
     AwaitingInitialize,
     Ready { user_agent: Option<String> },
     Failed,
 }
 
 #[derive(Serialize, Deserialize)]
-pub(super) struct WorkerProtocolInfo {
-    pub(super) magic: [u8; 8],
-    pub(super) package_version: String,
+pub(crate) struct WorkerProtocolInfo {
+    pub(crate) magic: [u8; 8],
+    pub(crate) package_version: String,
 }
 
 #[derive(Serialize, Deserialize)]
-pub(super) struct InitializeSession {
-    pub(super) permissive_network: bool,
-    pub(super) user_agent: Option<String>,
-    pub(super) cookies: Vec<CookieWire>,
-    pub(super) cookie_scope: Option<String>,
-    pub(super) config_dir: PathBuf,
-    pub(super) temporary_storage: bool,
+pub(crate) struct InitializeSession {
+    pub(crate) permissive_network: bool,
+    pub(crate) user_agent: Option<String>,
+    pub(crate) cookies: Vec<CookieWire>,
+    pub(crate) cookie_scope: Option<String>,
+    pub(crate) config_dir: PathBuf,
+    pub(crate) temporary_storage: bool,
 }
 
 #[derive(Serialize, Deserialize)]
-pub(super) struct RequestFrame {
-    pub(super) id: u64,
-    pub(super) request: WorkerRequest,
+pub(crate) struct RequestFrame {
+    pub(crate) id: u64,
+    pub(crate) request: WorkerRequest,
 }
 
 #[derive(Serialize, Deserialize)]
-pub(super) enum WorkerRequest {
+pub(crate) enum WorkerRequest {
     Initialize(InitializeSession),
     Fetch(FetchWire),
     Crawl(CrawlWire),
@@ -367,13 +433,13 @@ pub(super) enum WorkerRequest {
 }
 
 #[derive(Serialize, Deserialize)]
-pub(super) struct ResponseFrame {
-    pub(super) id: u64,
-    pub(super) response: WorkerResponse,
+pub(crate) struct ResponseFrame {
+    pub(crate) id: u64,
+    pub(crate) response: WorkerResponse,
 }
 
 #[derive(Serialize, Deserialize)]
-pub(super) enum WorkerResponse {
+pub(crate) enum WorkerResponse {
     SessionInitialized,
     FetchResult(PageWire),
     ScreenshotChunk(Vec<u8>),

--- a/crates/servo-fetch/src/worker/protocol.rs
+++ b/crates/servo-fetch/src/worker/protocol.rs
@@ -63,13 +63,13 @@ fn truncated_frame(error: std::io::Error) -> std::io::Error {
     }
 }
 
-pub(crate) struct BoundedBuffer {
-    pub(crate) bytes: Vec<u8>,
+pub(super) struct BoundedBuffer {
+    pub(super) bytes: Vec<u8>,
     max: usize,
 }
 
 impl BoundedBuffer {
-    pub(crate) fn new(max: usize) -> Self {
+    pub(super) fn new(max: usize) -> Self {
         Self {
             bytes: Vec::with_capacity(max.min(8 * 1024)),
             max,
@@ -182,7 +182,7 @@ pub fn run_worker_stdio() -> Result<()> {
     run_worker(&mut reader, &mut writer)
 }
 
-pub(crate) fn run_worker<R: Read, W: Write>(reader: &mut R, writer: &mut W) -> Result<()> {
+pub(super) fn run_worker<R: Read, W: Write>(reader: &mut R, writer: &mut W) -> Result<()> {
     write_bounded_frame(
         writer,
         &WorkerProtocolInfo {
@@ -214,7 +214,7 @@ pub(crate) fn run_worker<R: Read, W: Write>(reader: &mut R, writer: &mut W) -> R
     }
 }
 
-pub(crate) fn handle_worker_initialize(config: InitializeSession, state: &mut WorkerState) -> WorkerResponse {
+pub(super) fn handle_worker_initialize(config: InitializeSession, state: &mut WorkerState) -> WorkerResponse {
     if !matches!(state, WorkerState::AwaitingInitialize) {
         let message = if matches!(state, WorkerState::Ready { .. }) {
             "worker session is already initialized"
@@ -255,7 +255,7 @@ pub(crate) fn handle_worker_initialize(config: InitializeSession, state: &mut Wo
     }
 }
 
-pub(crate) struct ValidatedInitialize {
+pub(super) struct ValidatedInitialize {
     pub(crate) policy: NetworkPolicy,
     pub(crate) user_agent: Option<String>,
     cookies: Vec<crate::cookies::CookieSpec>,
@@ -396,7 +396,7 @@ fn handle_worker_crawl(id: u64, crawl: CrawlWire, state: &WorkerState, writer: &
 }
 
 #[derive(Clone, PartialEq, Eq)]
-pub(crate) enum WorkerState {
+pub(super) enum WorkerState {
     AwaitingInitialize,
     Ready { user_agent: Option<String> },
     Failed,

--- a/crates/servo-fetch/src/worker/wire.rs
+++ b/crates/servo-fetch/src/worker/wire.rs
@@ -1,16 +1,15 @@
 //! Serializable request, result, progress, and error types for isolated sessions.
 
 use std::io::Write;
+use std::sync::Arc;
 use std::time::{Duration, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
 
 use super::{MAX_WORKER_FRAME_BYTES, worker_error};
 use crate::error::{Error, Result};
-#[cfg(test)]
-use crate::fetch::FetchMode;
-use crate::fetch::{ConsoleMessage, FetchOptions, Page};
-use crate::{CrawlOptions, CrawlResult, VisibilityPolicy};
+use crate::fetch::{ConsoleLevel, ConsoleMessage, FetchMode, FetchOptions, Page};
+use crate::{CrawlOptions, CrawlPage, CrawlResult, VisibilityPolicy};
 
 const MAX_ERROR_KIND_BYTES: usize = 64;
 const MAX_ERROR_MESSAGE_BYTES: usize = 8 * 1024;
@@ -46,7 +45,7 @@ fn error_kind(error: &Error) -> &'static str {
 }
 
 #[derive(Serialize, Deserialize)]
-pub(super) struct WorkerErrorWire {
+pub(crate) struct WorkerErrorWire {
     kind: String,
     message: String,
     #[serde(default)]
@@ -64,7 +63,7 @@ pub(super) struct WorkerErrorWire {
 }
 
 impl WorkerErrorWire {
-    pub(super) fn failure(kind: impl Into<String>, message: impl Into<String>) -> Self {
+    pub(crate) fn failure(kind: impl Into<String>, message: impl Into<String>) -> Self {
         Self {
             kind: bounded_text(kind.into(), MAX_ERROR_KIND_BYTES),
             message: bounded_text(message.into(), MAX_ERROR_MESSAGE_BYTES),
@@ -77,7 +76,7 @@ impl WorkerErrorWire {
         }
     }
 
-    pub(super) fn from_error(error: &Error) -> Self {
+    pub(crate) fn from_error(error: &Error) -> Self {
         let (url, timeout_ms, host) = match error {
             Error::Timeout { url, timeout } => (
                 Some(url.clone()),
@@ -117,9 +116,106 @@ impl WorkerErrorWire {
             max,
         }
     }
+
+    pub(crate) fn into_error(self) -> Error {
+        match self.kind.as_str() {
+            "timeout" => Error::Timeout {
+                url: self.url.unwrap_or_default(),
+                timeout: Duration::from_millis(self.timeout_ms.unwrap_or_default()),
+            },
+            "invalid_url" => Error::InvalidUrl {
+                url: self.url.unwrap_or_default(),
+                reason: self.message,
+            },
+            "address_not_allowed" => Error::AddressNotAllowed {
+                host: self.host.unwrap_or_default(),
+            },
+            "javascript" => Error::javascript(self.message, self.url),
+            "screenshot" => Error::screenshot(self.message, self.url),
+            "output_too_large" => Error::OutputTooLarge {
+                kind: match self.output_kind.as_deref() {
+                    Some("screenshot") => "screenshot",
+                    Some("page") => "page",
+                    _ => "worker output",
+                },
+                size: usize::try_from(self.size.unwrap_or(u64::MAX)).unwrap_or(usize::MAX),
+                max: usize::try_from(self.max.unwrap_or(u64::MAX)).unwrap_or(usize::MAX),
+            },
+            "engine" => Error::engine(self.message, self.url),
+            _ => worker_error(format!("{}: {}", self.kind, self.message)),
+        }
+    }
 }
 
-pub(super) const MAX_WIRE_DURATION: Duration = Duration::from_secs(24 * 60 * 60);
+#[cfg(test)]
+pub(crate) fn fetch_watchdog(opts: &FetchOptions) -> Duration {
+    fetch_wire_watchdog(&FetchWire::from_options(opts))
+}
+
+#[cfg(test)]
+pub(crate) fn crawl_watchdog(opts: &CrawlOptions) -> Duration {
+    crawl_wire_watchdog(&CrawlWire::from_options(opts))
+}
+
+#[cfg(test)]
+pub(crate) fn crawl_absolute_watchdog(opts: &CrawlOptions) -> Duration {
+    crawl_wire_absolute_watchdog(&CrawlWire::from_options(opts))
+}
+
+pub(crate) const MAX_OPERATION_WATCHDOG: Duration = Duration::from_secs(24 * 60 * 60);
+
+fn saturating_duration_mul(mut duration: Duration, mut factor: usize) -> Duration {
+    let mut total = Duration::ZERO;
+    while factor > 0 {
+        if factor & 1 == 1 {
+            total = total.saturating_add(duration);
+        }
+        factor >>= 1;
+        if factor > 0 {
+            duration = duration.saturating_add(duration);
+        }
+    }
+    total
+}
+
+pub(crate) fn fetch_wire_watchdog(wire: &FetchWire) -> Duration {
+    Duration::from_millis(wire.timeout_ms)
+        .saturating_add(Duration::from_millis(wire.settle_ms))
+        .saturating_add(Duration::from_secs(15))
+        .min(MAX_OPERATION_WATCHDOG)
+}
+
+pub(crate) fn crawl_wire_watchdog(wire: &CrawlWire) -> Duration {
+    let dispatch_slots = wire.concurrency.min(wire.limit).max(1);
+    let dispatch_wait = saturating_duration_mul(
+        wire.delay_ms.map_or(Duration::ZERO, Duration::from_millis),
+        dispatch_slots,
+    );
+    Duration::from_millis(wire.timeout_ms)
+        .saturating_mul(2)
+        .saturating_add(Duration::from_millis(wire.settle_ms))
+        .saturating_add(dispatch_wait)
+        .saturating_add(Duration::from_secs(15))
+        .min(MAX_OPERATION_WATCHDOG)
+}
+
+pub(crate) fn crawl_wire_absolute_watchdog(wire: &CrawlWire) -> Duration {
+    let concurrency = wire.concurrency.max(1);
+    let waves = wire.limit.max(1).div_ceil(concurrency);
+    let page_budget = Duration::from_millis(wire.timeout_ms)
+        .saturating_mul(2)
+        .saturating_add(Duration::from_millis(wire.settle_ms))
+        .saturating_add(Duration::from_secs(15));
+    let total_delay = saturating_duration_mul(
+        wire.delay_ms.map_or(Duration::ZERO, Duration::from_millis),
+        wire.limit.saturating_sub(1),
+    );
+    saturating_duration_mul(page_budget, waves)
+        .saturating_add(total_delay)
+        .min(MAX_OPERATION_WATCHDOG)
+}
+
+pub(crate) const MAX_WIRE_DURATION: Duration = Duration::from_secs(24 * 60 * 60);
 const MAX_WIRE_USER_AGENT_BYTES: usize = 8 * 1024;
 const MAX_WIRE_URL_BYTES: usize = 2 * 1024 * 1024;
 const MAX_WIRE_SCRIPT_BYTES: usize = 4 * 1024 * 1024;
@@ -129,7 +225,7 @@ const MAX_WIRE_SCOPE_PATTERNS: usize = 1024;
 const MAX_WIRE_SCOPE_PATTERN_BYTES: usize = 256 * 1024;
 const MAX_WIRE_CRAWL_LIMIT: usize = 100_000;
 const MAX_WIRE_CRAWL_DEPTH: usize = 1024;
-pub(super) const MAX_WIRE_CRAWL_CONCURRENCY: usize = 64;
+pub(crate) const MAX_WIRE_CRAWL_CONCURRENCY: usize = 64;
 
 fn ensure_bytes(value: &str, field: &str, max: usize) -> Result<()> {
     if value.len() > max {
@@ -193,7 +289,6 @@ struct SchemaWire {
     json: Vec<u8>,
 }
 impl SchemaWire {
-    #[cfg(test)]
     fn from_schema(schema: &crate::schema::ExtractSchema) -> Self {
         Self {
             json: serde_json::to_vec(schema).expect("schema serializes"),
@@ -212,7 +307,7 @@ impl SchemaWire {
     }
 }
 #[derive(Serialize, Deserialize)]
-pub(super) struct FetchWire {
+pub(crate) struct FetchWire {
     url: String,
     timeout_ms: u64,
     settle_ms: u64,
@@ -223,8 +318,7 @@ pub(super) struct FetchWire {
 }
 
 impl FetchWire {
-    #[cfg(test)]
-    pub(super) fn from_options(opts: &FetchOptions) -> Self {
+    pub(crate) fn from_options(opts: &FetchOptions) -> Self {
         Self {
             url: opts.url.clone(),
             timeout_ms: u64::try_from(opts.effective_timeout().as_millis()).unwrap_or(u64::MAX),
@@ -242,7 +336,7 @@ impl FetchWire {
         }
     }
 
-    pub(super) fn into_options(self) -> Result<FetchOptions> {
+    pub(crate) fn into_options(self) -> Result<FetchOptions> {
         ensure_bytes(&self.url, "fetch URL", MAX_WIRE_URL_BYTES)?;
         if let FetchModeWire::JavaScript(expression) = &self.mode {
             ensure_bytes(expression, "JavaScript expression", MAX_WIRE_SCRIPT_BYTES)?;
@@ -270,7 +364,7 @@ impl FetchWire {
     }
 }
 
-pub(super) const MAX_SCREENSHOT_BYTES: usize = 32 * 1024 * 1024;
+pub(crate) const MAX_SCREENSHOT_BYTES: usize = 32 * 1024 * 1024;
 const RESPONSE_FRAME_HEADROOM: usize = 64;
 
 #[derive(Default)]
@@ -294,7 +388,7 @@ fn encoded_size(value: &impl Serialize) -> Result<usize> {
 }
 
 #[derive(Serialize, Deserialize)]
-pub(super) struct PageWire {
+pub(crate) struct PageWire {
     html: String,
     inner_text: String,
     title: Option<String>,
@@ -309,7 +403,7 @@ pub(super) struct PageWire {
 }
 
 impl PageWire {
-    pub(super) fn from_page(mut page: Page) -> Result<(Self, Option<Vec<u8>>)> {
+    pub(crate) fn from_page(mut page: Page) -> Result<(Self, Option<Vec<u8>>)> {
         let screenshot_size = page.screenshot_png.as_ref().map_or(0, Vec::len);
         if screenshot_size > MAX_SCREENSHOT_BYTES {
             return Err(Error::OutputTooLarge {
@@ -355,6 +449,61 @@ impl PageWire {
         }
         Ok((wire, screenshot_png))
     }
+
+    pub(crate) fn screenshot_png_bytes(&self) -> Option<usize> {
+        self.screenshot_png_bytes.and_then(|size| usize::try_from(size).ok())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_screenshot_png_bytes(&mut self, size: Option<u32>) {
+        self.screenshot_png_bytes = size;
+    }
+
+    pub(crate) fn into_page(self, screenshot_png: Option<Vec<u8>>) -> Result<Page> {
+        let actual_size = screenshot_png.as_ref().map(Vec::len);
+        let expected_size = self.screenshot_png_bytes.and_then(|size| usize::try_from(size).ok());
+        if actual_size != expected_size {
+            return Err(worker_error(format!(
+                "screenshot payload size mismatch: expected {expected_size:?}, got {actual_size:?}"
+            )));
+        }
+        let extracted = self
+            .extracted_json
+            .as_deref()
+            .map(serde_json::from_slice)
+            .transpose()
+            .map_err(worker_error)?;
+        let a11y = self
+            .accessibility_tree
+            .as_deref()
+            .map(serde_json::from_str)
+            .transpose()
+            .map_err(worker_error)?
+            .map(Arc::new);
+        let console_messages = self
+            .console_messages
+            .into_iter()
+            .map(ConsoleMessageWire::into_message)
+            .collect::<Result<Vec<_>>>()?;
+        let visibility = crate::VisibilityFlags::from_bits(self.visibility_bits)
+            .ok_or_else(|| worker_error("worker page contains unknown visibility flags"))?;
+        Ok(Page {
+            html: self.html,
+            inner_text: self.inner_text,
+            title: self.title,
+            layout_json: self.layout_json,
+            visibility_json: self.visibility_json,
+            js_result: self.js_result,
+            console_messages,
+            accessibility_tree: self.accessibility_tree,
+            extracted,
+            screenshot_png,
+            a11y,
+            visibility_policy: VisibilityPolicy {
+                strip_if_any: visibility,
+            },
+        })
+    }
 }
 
 #[derive(Serialize, Deserialize)]
@@ -370,10 +519,27 @@ impl ConsoleMessageWire {
             message: message.message,
         }
     }
+
+    fn into_message(self) -> Result<ConsoleMessage> {
+        let level = match self.level.as_str() {
+            "log" => ConsoleLevel::Log,
+            "debug" => ConsoleLevel::Debug,
+            "info" => ConsoleLevel::Info,
+            "warn" => ConsoleLevel::Warn,
+            "error" => ConsoleLevel::Error,
+            "trace" => ConsoleLevel::Trace,
+            "dir" => ConsoleLevel::Dir,
+            _ => return Err(worker_error("worker page contains an unknown console level")),
+        };
+        Ok(ConsoleMessage {
+            level,
+            message: self.message,
+        })
+    }
 }
 
 #[derive(Serialize, Deserialize)]
-pub(super) struct CrawlWire {
+pub(crate) struct CrawlWire {
     url: String,
     limit: usize,
     max_depth: usize,
@@ -390,8 +556,7 @@ pub(super) struct CrawlWire {
 }
 
 impl CrawlWire {
-    #[cfg(test)]
-    pub(super) fn from_options(opts: &CrawlOptions) -> Self {
+    pub(crate) fn from_options(opts: &CrawlOptions) -> Self {
         Self {
             url: opts.url.clone(),
             limit: opts.limit,
@@ -411,7 +576,7 @@ impl CrawlWire {
         }
     }
 
-    pub(super) fn into_options(self, fallback_user_agent: Option<&str>) -> Result<CrawlOptions> {
+    pub(crate) fn into_options(self, fallback_user_agent: Option<&str>) -> Result<CrawlOptions> {
         ensure_bytes(&self.url, "crawl URL", MAX_WIRE_URL_BYTES)?;
         if self.limit > MAX_WIRE_CRAWL_LIMIT {
             return Err(worker_error(format!(
@@ -463,14 +628,14 @@ impl CrawlWire {
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
-pub(super) struct CrawlProgressWire {
-    pub(super) processed: u64,
-    pub(super) emitted: u64,
-    pub(super) suppressed: u64,
+pub(crate) struct CrawlProgressWire {
+    pub(crate) processed: u64,
+    pub(crate) emitted: u64,
+    pub(crate) suppressed: u64,
 }
 
 #[derive(Serialize, Deserialize)]
-pub(super) struct CrawlResultWire {
+pub(crate) struct CrawlResultWire {
     url: String,
     depth: usize,
     fetched_at_ms: u64,
@@ -491,7 +656,7 @@ struct CrawlPageWire {
 }
 
 impl CrawlResultWire {
-    pub(super) fn from_result(result: CrawlResult) -> Self {
+    pub(crate) fn from_result(result: CrawlResult) -> Self {
         let fetched_at_ms = result
             .fetched_at
             .duration_since(UNIX_EPOCH)
@@ -515,9 +680,28 @@ impl CrawlResultWire {
             },
         }
     }
+
+    pub(crate) fn into_result(self) -> Result<CrawlResult> {
+        let outcome = match self.outcome {
+            CrawlOutcomeWire::Page(page) => Ok(CrawlPage {
+                title: page.title,
+                content: page.content,
+                links_found: page.links_found,
+            }),
+            CrawlOutcomeWire::Error(error) => Err(error.into_error()),
+        };
+        let fetched_at = UNIX_EPOCH
+            .checked_add(Duration::from_millis(self.fetched_at_ms))
+            .ok_or_else(|| worker_error("worker crawl result timestamp is out of range"))?;
+        Ok(CrawlResult {
+            url: self.url,
+            depth: self.depth,
+            fetched_at,
+            outcome,
+        })
+    }
 }
 
-#[cfg(test)]
 fn encode_headers(headers: &http::HeaderMap) -> Vec<(String, Vec<u8>)> {
     headers
         .iter()

--- a/crates/servo-fetch/tests/session_config.rs
+++ b/crates/servo-fetch/tests/session_config.rs
@@ -1,0 +1,22 @@
+//! Global session configuration validation.
+
+use std::time::Duration;
+
+use servo_fetch::{SessionBrokerConfig, WorkerCommand, configure_default_broker, set_default_worker_command};
+
+#[test]
+fn invalid_global_configuration_does_not_consume_once_lock() {
+    assert!(set_default_worker_command(WorkerCommand::new("relative-worker")).is_err());
+    let executable = std::env::current_exe().unwrap();
+    set_default_worker_command(WorkerCommand::new(executable)).unwrap();
+
+    assert!(configure_default_broker(SessionBrokerConfig::default().max_sessions(0)).is_err());
+    configure_default_broker(
+        SessionBrokerConfig::default()
+            .max_sessions(1)
+            .queue_capacity(1)
+            .prewarm(0)
+            .acquire_timeout(Duration::from_secs(1)),
+    )
+    .unwrap();
+}


### PR DESCRIPTION
## Summary

Adds process-isolated browser sessions: each `BrowserSession` runs Servo in a one-use OS worker process, so cookies, `localStorage`, and caches never leak between logical sessions. Builds on the worker stdio protocol from #393 as the single protocol definition.

## Related issues

N/A

## Test Plan

- `cargo test -p servo-fetch --lib`
- `cargo test -p servo-fetch-cli --test cli` and `--test cli -- --ignored`
- `cargo test -p servo-fetch-cli --test session -- --ignored`

## Checklist

- [x] Ran `cargo +nightly fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
- [x] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed
- [x] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it