### PR TITLE
fix(session): scavenge stale session storage at broker startup

### DIFF
--- a/crates/servo-fetch/src/session.rs
+++ b/crates/servo-fetch/src/session.rs
@@ -1,5 +1,6 @@
 //! Strong browser-state isolation using one one-use OS process per logical session.
 
+mod scavenge;
 mod supervisor;
 
 use std::ffi::OsString;
@@ -360,6 +361,7 @@ impl SessionBroker {
             config.worker_command = WorkerCommand::resolved()?;
         }
         config.validate()?;
+        scavenge::scavenge_stale_sessions_once();
         let permits = Arc::new(Semaphore::new(config.max_sessions));
         let mut prewarmed = Vec::with_capacity(config.prewarm);
         for _ in 0..config.prewarm {

--- a/crates/servo-fetch/src/session/scavenge.rs
+++ b/crates/servo-fetch/src/session/scavenge.rs
@@ -10,7 +10,7 @@ pub(super) fn write_owner_marker(config_dir: &Path) {
     let _ = std::fs::write(config_dir.join(OWNER_MARKER), std::process::id().to_string());
 }
 
-/// Delete session directories whose recorded owner is dead; unreadable markers and live owners are always kept.
+/// Delete session directories whose recorded owner is dead.
 pub(super) fn scavenge_stale_sessions_once() {
     static SCAVENGE: Once = Once::new();
     SCAVENGE.call_once(|| {
@@ -65,7 +65,6 @@ fn process_is_alive(pid: u32) -> bool {
     unsafe {
         let handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid);
         if handle.is_null() {
-            // Access denied means the process exists; treat other failures as dead.
             return std::io::Error::last_os_error().raw_os_error() == Some(5);
         }
         CloseHandle(handle);

--- a/crates/servo-fetch/src/session/scavenge.rs
+++ b/crates/servo-fetch/src/session/scavenge.rs
@@ -5,17 +5,12 @@ use std::sync::Once;
 
 const OWNER_MARKER: &str = "owner.pid";
 
-/// Record the owning process in `config_dir` so future processes can tell a
-/// stale directory from one belonging to a live broker.
+/// Record the owning process so future processes can tell stale storage from a live broker's.
 pub(super) fn write_owner_marker(config_dir: &Path) {
     let _ = std::fs::write(config_dir.join(OWNER_MARKER), std::process::id().to_string());
 }
 
-/// Delete session directories whose recorded owner is no longer alive.
-///
-/// Runs once per process on a background thread. Deletion is conservative:
-/// directories without a readable marker or with a live owner are left alone,
-/// so a false positive can never remove another broker's storage.
+/// Delete session directories whose recorded owner is dead; unreadable markers and live owners are always kept.
 pub(super) fn scavenge_stale_sessions_once() {
     static SCAVENGE: Once = Once::new();
     SCAVENGE.call_once(|| {

--- a/crates/servo-fetch/src/session/scavenge.rs
+++ b/crates/servo-fetch/src/session/scavenge.rs
@@ -7,7 +7,12 @@ const OWNER_MARKER: &str = "owner.pid";
 
 /// Record the owning process so future processes can tell stale storage from a live broker's.
 pub(super) fn write_owner_marker(config_dir: &Path) {
-    let _ = std::fs::write(config_dir.join(OWNER_MARKER), std::process::id().to_string());
+    // Write-then-rename publishes the marker atomically: a scavenger can never
+    // observe a partially written PID under the final name.
+    let staged = config_dir.join("owner.pid.tmp");
+    if std::fs::write(&staged, std::process::id().to_string()).is_ok() {
+        let _ = std::fs::rename(&staged, config_dir.join(OWNER_MARKER));
+    }
 }
 
 /// Delete session directories whose recorded owner is dead.
@@ -65,7 +70,9 @@ fn process_is_alive(pid: u32) -> bool {
     unsafe {
         let handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid);
         if handle.is_null() {
-            return std::io::Error::last_os_error().raw_os_error() == Some(5);
+            // Only "no such process" proves death; every other failure keeps the directory.
+            const ERROR_INVALID_PARAMETER: i32 = 87;
+            return std::io::Error::last_os_error().raw_os_error() != Some(ERROR_INVALID_PARAMETER);
         }
         CloseHandle(handle);
         true
@@ -102,6 +109,7 @@ mod tests {
         let unmarked = stale_dir(root.path(), "servo-fetch-session-unmarked", None);
         let malformed = stale_dir(root.path(), "servo-fetch-session-bad", Some("not-a-pid"));
         let unrelated = stale_dir(root.path(), "other-app-data", Some("999999999"));
+        let overflow = stale_dir(root.path(), "servo-fetch-session-overflow", Some(&u32::MAX.to_string()));
 
         scavenge_stale_sessions(root.path());
 
@@ -110,5 +118,21 @@ mod tests {
         assert!(unmarked.exists(), "unmarked directories must be preserved");
         assert!(malformed.exists(), "malformed markers must be preserved");
         assert!(unrelated.exists(), "non-session directories must be ignored");
+        assert!(overflow.exists(), "owners beyond i32::MAX must be treated as alive");
+    }
+
+    #[test]
+    fn owner_marker_is_published_atomically() {
+        let dir = tempfile::tempdir().unwrap();
+        write_owner_marker(dir.path());
+        let owner: u32 = std::fs::read_to_string(dir.path().join(OWNER_MARKER))
+            .unwrap()
+            .parse()
+            .unwrap();
+        assert_eq!(owner, std::process::id());
+        assert!(
+            !dir.path().join("owner.pid.tmp").exists(),
+            "staging file must not survive"
+        );
     }
 }

--- a/crates/servo-fetch/src/session/scavenge.rs
+++ b/crates/servo-fetch/src/session/scavenge.rs
@@ -1,0 +1,120 @@
+//! Best-effort cleanup of session storage left behind by killed processes.
+
+use std::path::Path;
+use std::sync::Once;
+
+const OWNER_MARKER: &str = "owner.pid";
+
+/// Record the owning process in `config_dir` so future processes can tell a
+/// stale directory from one belonging to a live broker.
+pub(super) fn write_owner_marker(config_dir: &Path) {
+    let _ = std::fs::write(config_dir.join(OWNER_MARKER), std::process::id().to_string());
+}
+
+/// Delete session directories whose recorded owner is no longer alive.
+///
+/// Runs once per process on a background thread. Deletion is conservative:
+/// directories without a readable marker or with a live owner are left alone,
+/// so a false positive can never remove another broker's storage.
+pub(super) fn scavenge_stale_sessions_once() {
+    static SCAVENGE: Once = Once::new();
+    SCAVENGE.call_once(|| {
+        let _ = std::thread::Builder::new()
+            .name("servo-fetch-scavenger".into())
+            .spawn(|| scavenge_stale_sessions(&std::env::temp_dir()));
+    });
+}
+
+fn scavenge_stale_sessions(temp_root: &Path) {
+    let Ok(entries) = std::fs::read_dir(temp_root) else {
+        return;
+    };
+    for entry in entries.filter_map(Result::ok) {
+        let path = entry.path();
+        if !entry.file_name().to_string_lossy().starts_with("servo-fetch-session-") {
+            continue;
+        }
+        let Ok(owner) = std::fs::read_to_string(path.join(OWNER_MARKER)) else {
+            continue;
+        };
+        let Ok(owner) = owner.trim().parse::<u32>() else {
+            continue;
+        };
+        if process_is_alive(owner) {
+            continue;
+        }
+        match std::fs::remove_dir_all(&path) {
+            Ok(()) => tracing::debug!(path = %path.display(), owner, "removed stale session storage"),
+            Err(error) => tracing::debug!(path = %path.display(), %error, "failed to remove stale session storage"),
+        }
+    }
+}
+
+#[cfg(unix)]
+#[allow(unsafe_code)]
+fn process_is_alive(pid: u32) -> bool {
+    let Ok(pid) = i32::try_from(pid) else {
+        return true;
+    };
+    // SAFETY: kill with signal 0 performs a liveness/permission probe only.
+    let alive = unsafe { libc::kill(pid, 0) } == 0;
+    alive || std::io::Error::last_os_error().kind() == std::io::ErrorKind::PermissionDenied
+}
+
+#[cfg(windows)]
+#[allow(unsafe_code)]
+fn process_is_alive(pid: u32) -> bool {
+    use windows_sys::Win32::Foundation::CloseHandle;
+    use windows_sys::Win32::System::Threading::{OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION};
+    // SAFETY: OpenProcess/CloseHandle probe a foreign process without touching it.
+    unsafe {
+        let handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid);
+        if handle.is_null() {
+            // Access denied means the process exists; treat other failures as dead.
+            return std::io::Error::last_os_error().raw_os_error() == Some(5);
+        }
+        CloseHandle(handle);
+        true
+    }
+}
+
+#[cfg(not(any(unix, windows)))]
+fn process_is_alive(_pid: u32) -> bool {
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn stale_dir(root: &Path, name: &str, marker: Option<&str>) -> std::path::PathBuf {
+        let dir = root.join(name);
+        std::fs::create_dir(&dir).unwrap();
+        if let Some(marker) = marker {
+            std::fs::write(dir.join(OWNER_MARKER), marker).unwrap();
+        }
+        dir
+    }
+
+    #[test]
+    fn removes_only_dead_owner_directories() {
+        let root = tempfile::tempdir().unwrap();
+        let live = stale_dir(
+            root.path(),
+            "servo-fetch-session-live",
+            Some(&std::process::id().to_string()),
+        );
+        let dead = stale_dir(root.path(), "servo-fetch-session-dead", Some("999999999"));
+        let unmarked = stale_dir(root.path(), "servo-fetch-session-unmarked", None);
+        let malformed = stale_dir(root.path(), "servo-fetch-session-bad", Some("not-a-pid"));
+        let unrelated = stale_dir(root.path(), "other-app-data", Some("999999999"));
+
+        scavenge_stale_sessions(root.path());
+
+        assert!(live.exists(), "live owner must be preserved");
+        assert!(!dead.exists(), "dead owner must be removed");
+        assert!(unmarked.exists(), "unmarked directories must be preserved");
+        assert!(malformed.exists(), "malformed markers must be preserved");
+        assert!(unrelated.exists(), "non-session directories must be ignored");
+    }
+}

--- a/crates/servo-fetch/src/session/scavenge.rs
+++ b/crates/servo-fetch/src/session/scavenge.rs
@@ -7,8 +7,6 @@ const OWNER_MARKER: &str = "owner.pid";
 
 /// Record the owning process so future processes can tell stale storage from a live broker's.
 pub(super) fn write_owner_marker(config_dir: &Path) {
-    // Write-then-rename publishes the marker atomically: a scavenger can never
-    // observe a partially written PID under the final name.
     let staged = config_dir.join("owner.pid.tmp");
     if std::fs::write(&staged, std::process::id().to_string()).is_ok() {
         let _ = std::fs::rename(&staged, config_dir.join(OWNER_MARKER));
@@ -70,7 +68,6 @@ fn process_is_alive(pid: u32) -> bool {
     unsafe {
         let handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid);
         if handle.is_null() {
-            // Only "no such process" proves death; every other failure keeps the directory.
             const ERROR_INVALID_PARAMETER: i32 = 87;
             return std::io::Error::last_os_error().raw_os_error() != Some(ERROR_INVALID_PARAMETER);
         }

--- a/crates/servo-fetch/src/session/supervisor.rs
+++ b/crates/servo-fetch/src/session/supervisor.rs
@@ -265,6 +265,7 @@ impl SupervisorOwner {
             .prefix("servo-fetch-session-")
             .tempdir()
             .map_err(worker_error)?;
+        super::scavenge::write_owner_marker(temp_dir.path());
         Ok(Self {
             temp_dir: Some(temp_dir),
             permit: Some(permit),


### PR DESCRIPTION
## Summary

A `SIGKILL`ed broker process cannot delete its session storage, so `servo-fetch-session-*` directories could accumulate in the temp dir (observed during #405).

## Related issues

Follow-up to #405.

## Test Plan

- `cargo test -p servo-fetch --lib`
- `cargo test -p servo-fetch-cli --test cli` and `--test session

## Checklist

- [x] Ran `cargo +nightly fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
- [ ] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed
- [x] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it