### PR TITLE
feat(python): expose isolated browser sessions

### DIFF
--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -69,6 +69,23 @@ pages = client.crawl("https://app.example.com", cookies_file="cookies.txt", max_
 A missing or malformed file raises `servo_fetch.CookieError`. Cookies are scoped
 to the target's site, so out-of-scope entries in the file are ignored.
 
+## Isolated Sessions
+
+Each `Session` runs in its own one-use worker process, so cookies and storage
+persist across fetches within the session and never leak between sessions:
+
+```python
+import servo_fetch
+
+with servo_fetch.Session() as session:
+    session.fetch("https://example.com/login")
+    page = session.fetch("https://example.com/dashboard")
+
+# async
+async with servo_fetch.AsyncSession() as session:
+    page = await session.fetch("https://example.com")
+```
+
 ## Custom Headers
 
 Pass a `dict[str, str]` via `headers` to add request headers (e.g. API tokens).

--- a/bindings/python/python/servo_fetch/__init__.py
+++ b/bindings/python/python/servo_fetch/__init__.py
@@ -15,13 +15,15 @@ from ._native import (
     Schema,
     SchemaError,
     ServoFetchError,
+    Session,
     __version__,
     fetch,
 )
-from .async_api import AsyncClient, fetch_async
+from .async_api import AsyncClient, AsyncSession, fetch_async
 
 __all__ = [
     "AsyncClient",
+    "AsyncSession",
     "Client",
     "ConsoleMessage",
     "CookieError",
@@ -36,6 +38,7 @@ __all__ = [
     "Schema",
     "SchemaError",
     "ServoFetchError",
+    "Session",
     "__version__",
     "fetch",
     "fetch_async",

--- a/bindings/python/python/servo_fetch/_native.pyi
+++ b/bindings/python/python/servo_fetch/_native.pyi
@@ -99,6 +99,33 @@ class MappedUrl:
     def lastmod(self) -> str | None: ...
 
 @final
+class Session:
+    def __new__(
+        cls,
+        *,
+        user_agent: str | None = None,
+        cookies_file: str | os.PathLike[str] | None = None,
+        cookies_url: str | None = None,
+    ) -> Session: ...
+    def fetch(
+        self,
+        url: str,
+        *,
+        timeout: float | None = None,
+        settle: float | None = None,
+        screenshot: bool = False,
+        javascript: str | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> Page: ...
+    def close(self) -> None: ...
+    @property
+    def is_closed(self) -> bool: ...
+    def __enter__(self) -> Session: ...
+    def __exit__(self, *args: object) -> None: ...
+
+def run_worker_stdio() -> None: ...
+
+@final
 class Client:
     def __new__(
         cls,

--- a/bindings/python/python/servo_fetch/_worker.py
+++ b/bindings/python/python/servo_fetch/_worker.py
@@ -1,0 +1,6 @@
+"""Internal isolated-worker entry point: ``python -m servo_fetch._worker``."""
+
+from servo_fetch._native import run_worker_stdio
+
+if __name__ == "__main__":
+    run_worker_stdio()

--- a/bindings/python/python/servo_fetch/async_api.py
+++ b/bindings/python/python/servo_fetch/async_api.py
@@ -9,10 +9,11 @@ from collections.abc import AsyncIterator
 from typing import Self, cast
 
 from ._native import Client as _SyncClient
-from ._native import CrawlResult, MappedUrl, Page, Schema
+from ._native import CrawlResult, MappedUrl, Page, Schema, ServoFetchError
+from ._native import Session as _SyncSession
 from ._native import fetch as _sync_fetch
 
-__all__ = ["AsyncClient", "fetch_async"]
+__all__ = ["AsyncClient", "AsyncSession", "fetch_async"]
 
 _SENTINEL = object()
 
@@ -180,3 +181,75 @@ class AsyncClient:
 
     async def __aexit__(self, *_: object) -> None:
         """No-op; the engine is process-global. Provided for forward compatibility."""
+
+
+class AsyncSession:
+    """Async wrapper over an isolated browser session."""
+
+    def __init__(
+        self,
+        *,
+        user_agent: str | None = None,
+        cookies_file: str | os.PathLike[str] | None = None,
+        cookies_url: str | None = None,
+    ) -> None:
+        self._user_agent = user_agent
+        self._cookies_file = cookies_file
+        self._cookies_url = cookies_url
+        self._inner: _SyncSession | None = None
+        self._closed = False
+        self._lock = asyncio.Lock()
+
+    async def _session(self) -> _SyncSession:
+        async with self._lock:
+            if self._closed:
+                msg = "browser session is closed"
+                raise ServoFetchError(msg)
+            if self._inner is None:
+                self._inner = await asyncio.to_thread(
+                    _SyncSession,
+                    user_agent=self._user_agent,
+                    cookies_file=self._cookies_file,
+                    cookies_url=self._cookies_url,
+                )
+            return self._inner
+
+    async def fetch(
+        self,
+        url: str,
+        *,
+        timeout: float | None = None,
+        settle: float | None = None,
+        screenshot: bool = False,
+        javascript: str | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> Page:
+        session = await self._session()
+        return await asyncio.to_thread(
+            session.fetch,
+            url,
+            timeout=timeout,
+            settle=settle,
+            screenshot=screenshot,
+            javascript=javascript,
+            headers=headers,
+        )
+
+    @property
+    def is_closed(self) -> bool:
+        """Whether ``close`` has been called."""
+        return self._closed
+
+    async def close(self) -> None:
+        async with self._lock:
+            self._closed = True
+            if self._inner is not None:
+                inner, self._inner = self._inner, None
+                await asyncio.to_thread(inner.close)
+
+    async def __aenter__(self) -> Self:
+        await self._session()
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        await self.close()

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -12,6 +12,7 @@ mod errors;
 mod opts;
 mod page;
 mod schema;
+mod session;
 mod validate;
 
 use crate::errors::map_error;
@@ -64,6 +65,8 @@ fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<schema::Schema>()?;
     m.add_class::<schema::Field>()?;
     m.add_class::<client::Client>()?;
+    m.add_class::<session::Session>()?;
+    m.add_function(wrap_pyfunction!(session::run_worker_stdio, m)?)?;
     m.add_class::<console::ConsoleMessage>()?;
     m.add_class::<crawl::CrawlResult>()?;
     m.add_class::<crawl::MappedUrl>()?;

--- a/bindings/python/src/session.rs
+++ b/bindings/python/src/session.rs
@@ -1,0 +1,154 @@
+//! `Session` pyclass: process-isolated browser session.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::{Mutex, OnceLock};
+
+use pyo3::prelude::*;
+
+use crate::errors::map_error;
+use crate::opts::{BuildOpts, prepare};
+use crate::page::Page;
+use crate::validate;
+
+/// Route isolated workers through `python -m servo_fetch._worker` unless overridden.
+fn configure_worker_command(py: Python<'_>) -> PyResult<()> {
+    static CONFIGURED: OnceLock<()> = OnceLock::new();
+    if CONFIGURED.get().is_some() {
+        return Ok(());
+    }
+    let program = match std::env::var_os("SERVO_FETCH_WORKER") {
+        Some(program) => PathBuf::from(program),
+        None => py.import("sys")?.getattr("executable")?.extract::<PathBuf>()?,
+    };
+    let command = servo_fetch::WorkerCommand::new(program).args(["-m", "servo_fetch._worker"]);
+    let _ = servo_fetch::set_default_worker_command(command);
+    let _ = CONFIGURED.set(());
+    Ok(())
+}
+
+/// Run the isolated worker protocol on stdio.
+#[pyfunction]
+pub(crate) fn run_worker_stdio(py: Python<'_>) -> PyResult<()> {
+    py.detach(servo_fetch::run_worker_stdio).map_err(map_error)
+}
+
+/// An isolated browser session backed by a one-use worker process.
+#[pyclass(module = "servo_fetch._native")]
+pub(crate) struct Session {
+    inner: Mutex<Option<servo_fetch::BrowserSession>>,
+}
+
+#[pymethods]
+impl Session {
+    #[new]
+    #[pyo3(signature = (*, user_agent=None, cookies_file=None, cookies_url=None))]
+    fn new(
+        py: Python<'_>,
+        user_agent: Option<String>,
+        cookies_file: Option<PathBuf>,
+        cookies_url: Option<String>,
+    ) -> PyResult<Self> {
+        configure_worker_command(py)?;
+        let mut config = servo_fetch::BrowserSessionConfig::new();
+        if let Some(user_agent) = user_agent {
+            config = config.user_agent(user_agent);
+        }
+        match (cookies_file, cookies_url) {
+            (Some(path), Some(url)) => {
+                validate::url(&url)?;
+                let cookies = servo_fetch::load_cookies(&path).map_err(map_error)?;
+                config = config.cookies(url, cookies);
+            }
+            (None, None) => {}
+            _ => {
+                return Err(pyo3::exceptions::PyValueError::new_err(
+                    "cookies_file and cookies_url must be provided together",
+                ));
+            }
+        }
+        let session = py
+            .detach(|| servo_fetch::BrowserSession::new_blocking(config))
+            .map_err(map_error)?;
+        Ok(Self {
+            inner: Mutex::new(Some(session)),
+        })
+    }
+
+    /// Fetch a URL inside this session, preserving cookies and storage across calls.
+    #[pyo3(signature = (url, *, timeout=None, settle=None, screenshot=false, javascript=None, headers=None))]
+    #[allow(clippy::too_many_arguments)]
+    fn fetch(
+        &self,
+        py: Python<'_>,
+        url: String,
+        timeout: Option<f64>,
+        settle: Option<f64>,
+        screenshot: bool,
+        javascript: Option<String>,
+        headers: Option<HashMap<String, String>>,
+    ) -> PyResult<Page> {
+        let prepared = prepare(BuildOpts {
+            url,
+            timeout,
+            settle,
+            user_agent: None,
+            screenshot,
+            javascript,
+            schema: None,
+            cookies_file: None,
+            headers,
+        })?;
+        let servo_page = py
+            .detach(|| {
+                let mut guard = self.inner.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+                let session = guard.as_mut().ok_or_else(|| servo_fetch::Error::WorkerUnavailable {
+                    source: "browser session is closed".into(),
+                })?;
+                session.fetch_blocking(&prepared.opts)
+            })
+            .map_err(map_error)?;
+        Ok(Page::new(
+            servo_page,
+            prepared.url,
+            prepared.screenshot_requested,
+            prepared.js_requested,
+        ))
+    }
+
+    /// Close the session, tearing down its worker process and storage.
+    fn close(&self, py: Python<'_>) -> PyResult<()> {
+        // Lock acquisition may wait behind a long fetch, so it must not hold the GIL.
+        py.detach(|| {
+            let session = self
+                .inner
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .take();
+            match session {
+                Some(session) => session.close_blocking(),
+                None => Ok(()),
+            }
+        })
+        .map_err(map_error)
+    }
+
+    /// Whether `close` has been called; an in-flight fetch still counts as open.
+    #[getter]
+    fn is_closed(&self) -> bool {
+        match self.inner.try_lock() {
+            Ok(guard) => guard.is_none(),
+            Err(std::sync::TryLockError::Poisoned(poisoned)) => poisoned.into_inner().is_none(),
+            Err(std::sync::TryLockError::WouldBlock) => false,
+        }
+    }
+
+    fn __enter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+        slf
+    }
+
+    #[pyo3(signature = (*_args))]
+    fn __exit__(&self, py: Python<'_>, _args: &Bound<'_, pyo3::types::PyTuple>) -> PyResult<()> {
+        self.close(py)
+    }
+}

--- a/bindings/python/tests/test_async.py
+++ b/bindings/python/tests/test_async.py
@@ -6,7 +6,7 @@ import concurrent.futures
 
 import pytest
 
-from servo_fetch import AsyncClient, Schema, fetch_async
+from servo_fetch import AsyncClient, AsyncSession, Schema, ServoFetchError, fetch_async
 
 
 @pytest.mark.asyncio
@@ -57,3 +57,14 @@ def test_schema_base_selector_thread_safe() -> None:
     with concurrent.futures.ThreadPoolExecutor(max_workers=4) as ex:
         results = list(ex.map(lambda _: schema.extract(html), range(20)))
     assert all(r == expected for r in results)
+
+
+@pytest.mark.asyncio
+async def test_async_session_close_is_terminal_and_idempotent() -> None:
+    session = AsyncSession()
+    assert not session.is_closed
+    await session.close()
+    await session.close()
+    assert session.is_closed
+    with pytest.raises(ServoFetchError, match="browser session is closed"):
+        await session.fetch("https://example.com")

--- a/bindings/python/tests/test_package.py
+++ b/bindings/python/tests/test_package.py
@@ -18,6 +18,8 @@ def test_public_api() -> None:
         "fetch_async",
         "Client",
         "AsyncClient",
+        "Session",
+        "AsyncSession",
         "Page",
         "Schema",
         "Field",
@@ -49,5 +51,7 @@ def test_docstrings_present() -> None:
     assert servo_fetch.Field.__doc__
     assert servo_fetch.Client.__doc__
     assert servo_fetch.AsyncClient.__doc__
+    assert servo_fetch.Session.__doc__
+    assert servo_fetch.AsyncSession.__doc__
     assert servo_fetch.fetch.__doc__
     assert servo_fetch.fetch_async.__doc__

--- a/bindings/python/tests/test_session.py
+++ b/bindings/python/tests/test_session.py
@@ -1,0 +1,43 @@
+"""Isolated browser sessions — requires Servo engine."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+import pytest
+
+import servo_fetch
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("SERVO_FETCH_E2E") != "1",
+    reason="set SERVO_FETCH_E2E=1 to run end-to-end tests",
+)
+
+URL = os.environ.get("SERVO_FETCH_TEST_URL", "https://example.com")
+
+
+def test_session_fetch_and_close() -> None:
+    with servo_fetch.Session() as session:
+        page = session.fetch(URL)
+        assert isinstance(page, servo_fetch.Page)
+        assert page.url == URL
+
+
+def test_session_close_is_terminal_and_idempotent() -> None:
+    session = servo_fetch.Session()
+    assert not session.is_closed
+    session.close()
+    session.close()
+    assert session.is_closed
+    with pytest.raises(servo_fetch.ServoFetchError, match="browser session is closed"):
+        session.fetch(URL)
+
+
+def test_async_session_fetch_and_close() -> None:
+    async def scenario() -> None:
+        async with servo_fetch.AsyncSession() as session:
+            page = await session.fetch(URL)
+            assert isinstance(page, servo_fetch.Page)
+
+    asyncio.run(scenario())


### PR DESCRIPTION
## Summary

Exposes process-isolated browser sessions (#405) in the Python SDK. Each `Session` runs in its own one-use worker process, so cookies and storage persist across fetches within a session and never leak between sessions.

- `Session` — sync constructor, `fetch`/`close`/`is_closed`, context manager; API shape follows `httpx.Client` / `requests.Session` conventions (terminal, idempotent `close`; clear "browser session is closed" error afterwards).
- `AsyncSession` — `asyncio.to_thread` wrapper like the existing `AsyncClient`, with single-flight lazy startup and `async with` support.

## Related issues

Part of the isolated-sessions work (#405, #406).

## Test Plan

- `pytest`

## Checklist

- [x] Ran `cargo +nightly fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
- [x] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed
- [x] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it