### PR TITLE
feat(node): expose isolated browser sessions over the RPC server

### DIFF
--- a/bindings/node/README.md
+++ b/bindings/node/README.md
@@ -57,6 +57,23 @@ const products = await extractSchema("https://shop.example.com", {
 });
 ```
 
+## Isolated Sessions
+
+Each `Session` runs in its own one-use worker process, so cookies and storage
+persist across fetches within the session and never leak between sessions:
+
+```ts
+import { Session } from "servo-fetch";
+
+const session = await Session.open();
+try {
+  await session.fetch("https://example.com/login");
+  const page = await session.fetch("https://example.com/dashboard");
+} finally {
+  await session.close();
+}
+```
+
 ## CLI
 
 The bundled binary is also runnable directly:

--- a/bindings/node/src/generated/index.ts
+++ b/bindings/node/src/generated/index.ts
@@ -584,6 +584,95 @@ name: string,
 version: string, };
 
 /**
+ * Parameters for the `session/close` method.
+ */
+export type SessionCloseRequest = { 
+/**
+ * Session obtained from `session/open`.
+ */
+sessionId: number, };
+
+/**
+ * Parameters for the `session/fetch` method (returns the formatted page as a string).
+ */
+export type SessionFetchRequest = { 
+/**
+ * Session obtained from `session/open`.
+ */
+sessionId: number, 
+/**
+ * URL to fetch (http/https only).
+ */
+url: string, 
+/**
+ * Output format (default: markdown).
+ */
+format?: FetchFormat, 
+/**
+ * CSS selector to extract a specific section (Markdown only).
+ */
+selector?: string, 
+/**
+ * Truncate the result to this many characters (default: 5000).
+ */
+maxLength?: number, 
+/**
+ * Character offset to start the result from, for pagination (default: 0).
+ */
+startIndex?: number, 
+/**
+ * Visibility filtering policy (default: moderate).
+ */
+visibility?: Visibility, 
+/**
+ * Page-load timeout in seconds (default: 30).
+ */
+timeout?: number, 
+/**
+ * Extra wait in milliseconds after the load event (default: 0).
+ */
+settleMs?: number, 
+/**
+ * Custom request headers.
+ */
+headers?: { [key in string]: string }, };
+
+/**
+ * Parameters for the `session/open` method.
+ */
+export type SessionOpenRequest = { 
+/**
+ * User-Agent for every request in the session.
+ */
+userAgent?: string, };
+
+/**
+ * Result of the `session/open` method.
+ */
+export type SessionOpenResult = { 
+/**
+ * Identifier for subsequent `session/fetch` and `session/close` calls.
+ */
+sessionId: number, };
+
+/**
+ * Request options for `session/fetch`; session identity (user agent, cookies) is fixed at open.
+ */
+export type SessionRequestOptions = { 
+/**
+ * Page-load timeout in seconds (default: 30).
+ */
+timeout?: number, 
+/**
+ * Extra wait in milliseconds after the load event (default: 0).
+ */
+settleMs?: number, 
+/**
+ * Custom request headers.
+ */
+headers?: { [key in string]: string }, };
+
+/**
  * Visibility-aware filtering policy applied during extraction.
  */
 export type Visibility = "moderate" | "strict" | "off";

--- a/bindings/node/src/index.ts
+++ b/bindings/node/src/index.ts
@@ -1,3 +1,4 @@
+import { ServoFetchError } from "./errors.js";
 import type {
   Article,
   CrawlEvent,
@@ -13,8 +14,13 @@ import type {
   SchemaExtractRequest,
   SchemaExtractResult,
   ScreenshotRequest,
+  SessionCloseRequest,
+  SessionFetchRequest,
+  SessionOpenRequest,
+  SessionOpenResult,
+  Visibility,
 } from "./generated/index.js";
-import { request, stream } from "./rpc-client.js";
+import { generation, request, stream } from "./rpc-client.js";
 import { type Schema, schemaToValue } from "./schema.js";
 import type { BatchResult, CrawlOptions, CrawlResult, FetchOptions, MapOptions } from "./types.js";
 
@@ -251,4 +257,83 @@ export function map(url: string, options: MapOptions = {}): Promise<MappedUrl[]>
 export async function version(): Promise<string> {
   const info = await request<InitializeResult>("initialize", {});
   return info.serverInfo.version;
+}
+/** Options for `Session.fetch`; session identity (user agent, cookies) is fixed at `Session.open`. */
+export interface SessionFetchOptions {
+  /** Seconds to wait for the page (default: 30). */
+  timeout?: number;
+  /** Extra milliseconds to wait after load for late JS (default: 0). */
+  settle?: number;
+  /** CSS selector to extract a specific section. */
+  selector?: string;
+  /** Visibility filtering policy (default: moderate). */
+  visibility?: Visibility;
+  /** Custom request headers. */
+  headers?: Record<string, string>;
+  /** Abort the in-flight request. */
+  signal?: AbortSignal;
+}
+
+/** A process-isolated browser session; state persists across fetches and never leaks between sessions. */
+export class Session {
+  #closed = false;
+
+  private constructor(
+    private readonly id: number,
+    private readonly boundGeneration: number,
+  ) {}
+
+  /** Whether `close` has been called. */
+  isClosed(): boolean {
+    return this.#closed;
+  }
+
+  /** Open a new isolated session backed by a dedicated worker process. */
+  static async open(options: { userAgent?: string } = {}): Promise<Session> {
+    const bound = generation();
+    const result = await request<SessionOpenResult>("session/open", {
+      userAgent: options.userAgent,
+    } satisfies SessionOpenRequest);
+    return new Session(result.sessionId, bound);
+  }
+
+  private guard(): void {
+    if (this.#closed) {
+      throw new ServoFetchError("browser session is closed", "requestCancelled");
+    }
+    if (generation() !== this.boundGeneration) {
+      throw new ServoFetchError("session belongs to a previous server process", "requestCancelled");
+    }
+  }
+
+  /** Fetch a URL inside this session and return readable Markdown. */
+  async fetch(url: string, options: SessionFetchOptions = {}): Promise<string> {
+    this.guard();
+    return await request(
+      "session/fetch",
+      {
+        sessionId: this.id,
+        url,
+        format: "markdown",
+        selector: options.selector,
+        visibility: options.visibility,
+        timeout: options.timeout,
+        settleMs: options.settle,
+        headers: options.headers,
+      } satisfies SessionFetchRequest,
+      options.signal,
+    );
+  }
+
+  /** Close the session, tearing down its worker process and storage. */
+  async close(): Promise<void> {
+    if (this.#closed) return;
+    this.#closed = true;
+    if (generation() !== this.boundGeneration) return;
+    await request("session/close", { sessionId: this.id } satisfies SessionCloseRequest);
+  }
+
+  async [Symbol.asyncDispose](): Promise<void> {
+    await this.close();
+  }
 }

--- a/bindings/node/src/rpc-client.ts
+++ b/bindings/node/src/rpc-client.ts
@@ -238,10 +238,20 @@ function abortError(): ServoFetchError {
 }
 
 let current: RpcClient | undefined;
+let currentGeneration = 0;
 
 function client(): RpcClient {
-  if (!current) current = new RpcClient();
+  if (!current) {
+    current = new RpcClient();
+    currentGeneration += 1;
+  }
   return current;
+}
+
+/** Monotonic id of the server process behind `request`; bumps on respawn. */
+export function generation(): number {
+  client();
+  return currentGeneration;
 }
 
 export function request<T>(method: string, params: unknown, signal?: AbortSignal): Promise<T> {

--- a/bindings/node/test/e2e.test.ts
+++ b/bindings/node/test/e2e.test.ts
@@ -38,4 +38,45 @@ describe.runIf(e2e)("real binary E2E", () => {
     expect(err).toBeInstanceOf(InvalidUrlError);
     expect((err as { kind: string }).kind).toBe("invalidUrl");
   });
+
+  it("session fetches within an isolated worker and closes cleanly", async () => {
+    const { Session } = await import("../src/index.js");
+    const session = await Session.open();
+    try {
+      const markdown = await session.fetch(URL);
+      expect(typeof markdown).toBe("string");
+      expect(markdown.length).toBeGreaterThan(0);
+    } finally {
+      await session.close();
+    }
+  });
+
+  it("closed session is rejected with a typed error", async () => {
+    const { Session, ServoFetchError } = await import("../src/index.js");
+    const session = await Session.open();
+    expect(session.isClosed()).toBe(false);
+    await session.close();
+    await session.close();
+    expect(session.isClosed()).toBe(true);
+    const err = await session.fetch(URL).then(
+      () => null,
+      (e: unknown) => e,
+    );
+    expect(err).toBeInstanceOf(ServoFetchError);
+    expect((err as Error).message).toContain("browser session is closed");
+  });
+
+  it("session handle from a previous server process is rejected", async () => {
+    const { Session, ServoFetchError } = await import("../src/index.js");
+    const { shutdown } = await import("../src/rpc-client.js");
+    const stale = await Session.open();
+    shutdown();
+    const err = await stale.fetch(URL).then(
+      () => null,
+      (e: unknown) => e,
+    );
+    expect(err).toBeInstanceOf(ServoFetchError);
+    expect((err as Error).message).toContain("previous server process");
+    await stale.close();
+  });
 });

--- a/crates/servo-fetch-cli/src/rpc.rs
+++ b/crates/servo-fetch-cli/src/rpc.rs
@@ -18,12 +18,15 @@ use tokio_util::codec::LinesCodecError;
 use tokio_util::sync::CancellationToken;
 
 type Cancellations = Arc<Mutex<HashMap<RequestId, CancellationToken>>>;
+pub(crate) type SessionSlot = Arc<tokio::sync::Mutex<Option<servo_fetch::BrowserSession>>>;
+pub(crate) type Sessions = Arc<tokio::sync::Mutex<HashMap<u64, SessionSlot>>>;
 
 /// Serve JSON-RPC over stdio until stdin closes or an `exit` notification arrives.
 pub(crate) async fn run() -> anyhow::Result<()> {
     let (tx, rx) = mpsc::unbounded_channel::<String>();
     let writer = tokio::spawn(transport::write_loop(tokio::io::stdout(), rx));
     let cancels: Cancellations = Arc::new(Mutex::new(HashMap::new()));
+    let sessions: Sessions = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
     let mut reader = transport::frame_reader(tokio::io::stdin());
 
     while let Some(frame) = reader.next().await {
@@ -54,7 +57,7 @@ pub(crate) async fn run() -> anyhow::Result<()> {
             }
         };
         match incoming.id {
-            Some(id) => spawn_request(id, incoming.method, incoming.params, &tx, &cancels),
+            Some(id) => spawn_request(id, incoming.method, incoming.params, &tx, &cancels, &sessions),
             None => match incoming.method.as_str() {
                 "$/cancelRequest" => cancel(incoming.params, &cancels),
                 "exit" => break,
@@ -71,7 +74,14 @@ pub(crate) async fn run() -> anyhow::Result<()> {
     Ok(())
 }
 
-fn spawn_request(id: RequestId, method: String, params: Value, tx: &UnboundedSender<String>, cancels: &Cancellations) {
+fn spawn_request(
+    id: RequestId,
+    method: String,
+    params: Value,
+    tx: &UnboundedSender<String>,
+    cancels: &Cancellations,
+    sessions: &Sessions,
+) {
     let token = CancellationToken::new();
     {
         let mut guard = cancels.lock().expect("cancellations poisoned");
@@ -86,8 +96,9 @@ fn spawn_request(id: RequestId, method: String, params: Value, tx: &UnboundedSen
 
     let tx = tx.clone();
     let cancels = cancels.clone();
+    let sessions = sessions.clone();
     tokio::spawn(async move {
-        let dispatched = AssertUnwindSafe(dispatch::dispatch(&method, params, &id, &tx)).catch_unwind();
+        let dispatched = AssertUnwindSafe(dispatch::dispatch(&method, params, &id, &tx, &sessions)).catch_unwind();
         let outcome = tokio::select! {
             biased;
             () = token.cancelled() => Err(ResponseError::cancelled()),

--- a/crates/servo-fetch-cli/src/rpc/dispatch.rs
+++ b/crates/servo-fetch-cli/src/rpc/dispatch.rs
@@ -8,7 +8,8 @@ use serde_json::{Value, json};
 use servo_fetch::FetchOptions;
 use servo_fetch_types::{
     CrawlRequest, CrawlStats, ErrorKind, EvaluateRequest, ExtractRequest, FetchRequest, InitializeResult, MapRequest,
-    SchemaExtractRequest, ScreenshotRequest, ServerCapabilities, ServerInfo,
+    SchemaExtractRequest, ScreenshotRequest, ServerCapabilities, ServerInfo, SessionCloseRequest, SessionFetchRequest,
+    SessionOpenRequest, SessionOpenResult,
 };
 use tokio::sync::mpsc::UnboundedSender;
 
@@ -22,6 +23,7 @@ pub(crate) async fn dispatch(
     params: Value,
     id: &RequestId,
     tx: &UnboundedSender<String>,
+    sessions: &super::Sessions,
 ) -> Result<Value, ResponseError> {
     match method {
         "initialize" => Ok(initialize()),
@@ -32,8 +34,80 @@ pub(crate) async fn dispatch(
         "extractSchema" => extract_schema(params).await,
         "map" => map(params).await,
         "crawl" => crawl(params, id, tx).await,
+        "session/open" => session_open(params, sessions).await,
+        "session/fetch" => session_fetch(params, sessions).await,
+        "session/close" => session_close(params, sessions).await,
         other => Err(ResponseError::method_not_found(other)),
     }
+}
+
+static NEXT_SESSION_ID: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
+
+async fn session_open(params: Value, sessions: &super::Sessions) -> Result<Value, ResponseError> {
+    let req: SessionOpenRequest = parse(params)?;
+    let mut config = servo_fetch::BrowserSessionConfig::new();
+    if let Some(user_agent) = req.user_agent {
+        config = config.user_agent(user_agent);
+    }
+    let session = servo_fetch::BrowserSession::new(config)
+        .await
+        .map_err(|e| ResponseError::from(ToolError::from(e)))?;
+    let session_id = NEXT_SESSION_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    sessions
+        .lock()
+        .await
+        .insert(session_id, std::sync::Arc::new(tokio::sync::Mutex::new(Some(session))));
+    Ok(serde_json::to_value(SessionOpenResult { session_id })?)
+}
+
+async fn session_fetch(params: Value, sessions: &super::Sessions) -> Result<Value, ResponseError> {
+    let req: SessionFetchRequest = parse(params)?;
+    let url = tools::validated_url(&req.url)?;
+    tools::validate_selector(req.selector.as_deref())?;
+
+    let slot = sessions
+        .lock()
+        .await
+        .get(&req.session_id)
+        .cloned()
+        .ok_or_else(|| ResponseError::invalid_params(format!("unknown session {}", req.session_id)))?;
+
+    let format = req.format.unwrap_or_default();
+    let opts = tools::content_options(&url, format, tools::visibility_policy(req.visibility))
+        .timeout(tools::resolve_timeout(req.options.timeout))
+        .settle(tools::resolve_settle(req.options.settle_ms))
+        .headers(tools::build_headers(req.options.headers)?);
+    let mut guard = slot.lock().await;
+    let session = guard
+        .as_mut()
+        .ok_or_else(|| ResponseError::invalid_params(format!("session {} is closed", req.session_id)))?;
+    let page = session
+        .fetch(&opts)
+        .await
+        .map_err(|e| ResponseError::from(ToolError::from(e)))?;
+    drop(guard);
+
+    let full = tools::render_page(&page, &url, format, req.selector.as_deref())?;
+    let sanitized = servo_fetch::sanitize::sanitize(&full);
+    let content = tools::paginate_opt(&sanitized, req.start_index, req.max_length);
+    Ok(json!(content))
+}
+
+async fn session_close(params: Value, sessions: &super::Sessions) -> Result<Value, ResponseError> {
+    let req: SessionCloseRequest = parse(params)?;
+    let slot = sessions.lock().await.remove(&req.session_id);
+    let Some(slot) = slot else {
+        return Ok(Value::Null);
+    };
+    // Waits for an in-flight fetch on this session; concurrent holders then observe `None`.
+    let session = slot.lock().await.take();
+    if let Some(session) = session {
+        session
+            .close()
+            .await
+            .map_err(|e| ResponseError::from(ToolError::from(e)))?;
+    }
+    Ok(Value::Null)
 }
 
 fn initialize() -> Value {

--- a/crates/servo-fetch-cli/src/tools.rs
+++ b/crates/servo-fetch-cli/src/tools.rs
@@ -12,5 +12,8 @@ pub(crate) use crawl::{CrawlSpec, build_crawl_options, crawl_pages};
 pub(crate) use error::ToolError;
 pub(crate) use fetch::{BatchSpec, batch_fetch_pages, fetch_with};
 pub(crate) use map::{MapSpec, build_map_options, map_with};
-pub(crate) use options::{apply_options, content_options, validate_selector, validated_url, visibility_policy};
+pub(crate) use options::{
+    apply_options, build_headers, content_options, resolve_settle, resolve_timeout, validate_selector, validated_url,
+    visibility_policy,
+};
 pub(crate) use render::{clamp_js_output, paginate, paginate_opt, render_page};

--- a/crates/servo-fetch-cli/tests/rpc.rs
+++ b/crates/servo-fetch-cli/tests/rpc.rs
@@ -279,3 +279,20 @@ async fn cancel_aborts_in_flight_crawl() {
 
     assert_eq!(code, Some(-32800), "expected RequestCancelled (-32800)");
 }
+
+#[test]
+fn session_fetch_on_unknown_session_is_invalid_params() {
+    let frames = run_rpc(
+        r#"{"jsonrpc":"2.0","id":1,"method":"session/fetch","params":{"sessionId":42,"url":"https://example.com"}}"#,
+    );
+    let error = &frames[0]["error"];
+    assert_eq!(error["code"], -32602);
+    assert!(error["message"].as_str().unwrap().contains("unknown session 42"));
+}
+
+#[test]
+fn session_close_is_idempotent_for_unknown_sessions() {
+    let frames = run_rpc(r#"{"jsonrpc":"2.0","id":1,"method":"session/close","params":{"sessionId":42}}"#);
+    assert_eq!(frames[0]["result"], Value::Null);
+    assert!(frames[0].get("error").is_none());
+}

--- a/crates/servo-fetch-types/src/request.rs
+++ b/crates/servo-fetch-types/src/request.rs
@@ -87,6 +87,96 @@ pub struct FetchRequest {
     pub options: RequestOptions,
 }
 
+/// Request options for `session/fetch`; session identity (user agent, cookies) is fixed at open.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[cfg_attr(feature = "codegen", derive(ts_rs::TS), ts(export, export_to = "index.ts"))]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "camelCase")]
+pub struct SessionRequestOptions {
+    /// Page-load timeout in seconds (default: 30).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "codegen", ts(optional, type = "number"))]
+    pub timeout: Option<u64>,
+    /// Extra wait in milliseconds after the load event (default: 0).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "codegen", ts(optional, type = "number"))]
+    pub settle_ms: Option<u64>,
+    /// Custom request headers.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "codegen", ts(optional))]
+    pub headers: Option<BTreeMap<String, String>>,
+}
+
+/// Parameters for the `session/open` method.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "codegen", derive(ts_rs::TS), ts(export, export_to = "index.ts"))]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "camelCase")]
+pub struct SessionOpenRequest {
+    /// User-Agent for every request in the session.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "codegen", ts(optional))]
+    pub user_agent: Option<String>,
+}
+
+/// Result of the `session/open` method.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "codegen", derive(ts_rs::TS), ts(export, export_to = "index.ts"))]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "camelCase")]
+pub struct SessionOpenResult {
+    /// Identifier for subsequent `session/fetch` and `session/close` calls.
+    #[cfg_attr(feature = "codegen", ts(type = "number"))]
+    pub session_id: u64,
+}
+
+/// Parameters for the `session/fetch` method (returns the formatted page as a string).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "codegen", derive(ts_rs::TS), ts(export, export_to = "index.ts"))]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "camelCase")]
+pub struct SessionFetchRequest {
+    /// Session obtained from `session/open`.
+    #[cfg_attr(feature = "codegen", ts(type = "number"))]
+    pub session_id: u64,
+    /// URL to fetch (http/https only).
+    pub url: String,
+    /// Output format (default: markdown).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "codegen", ts(optional))]
+    pub format: Option<FetchFormat>,
+    /// CSS selector to extract a specific section (Markdown only).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "codegen", ts(optional))]
+    pub selector: Option<String>,
+    /// Truncate the result to this many characters (default: 5000).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "codegen", ts(optional, type = "number"))]
+    pub max_length: Option<u64>,
+    /// Character offset to start the result from, for pagination (default: 0).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "codegen", ts(optional, type = "number"))]
+    pub start_index: Option<u64>,
+    /// Visibility filtering policy (default: moderate).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "codegen", ts(optional))]
+    pub visibility: Option<Visibility>,
+    /// Per-request options valid inside a session.
+    #[serde(flatten)]
+    pub options: SessionRequestOptions,
+}
+
+/// Parameters for the `session/close` method.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "codegen", derive(ts_rs::TS), ts(export, export_to = "index.ts"))]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "camelCase")]
+pub struct SessionCloseRequest {
+    /// Session obtained from `session/open`.
+    #[cfg_attr(feature = "codegen", ts(type = "number"))]
+    pub session_id: u64,
+}
+
 /// Parameters for the `batchFetch` method.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "codegen", derive(ts_rs::TS), ts(export, export_to = "index.ts"))]


### PR DESCRIPTION
## Summary

Exposes process-isolated browser sessions (#405) in the Node SDK. Each `Session` runs in its own one-use worker process behind the internal JSON-RPC server, so cookies and storage persist across fetches within a session and never leak between sessions.

## Related issues

Part of the isolated-sessions work (#405, #406, #407).

## Test Plan

- `cargo test -p servo-fetch-cli --test rpc`
- `cargo test -p servo-fetch-types --features codegen`
- Node: Biome, `tsc --noEmit`, Vitest all passed

## Checklist

- [x] Ran `cargo +nightly fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
- [x] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed
- [x] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it