### PR TITLE
fix(tests): poll for parseable pid in graceful-close session test

### DIFF
--- a/crates/servo-fetch/src/session/tests.rs
+++ b/crates/servo-fetch/src/session/tests.rs
@@ -511,8 +511,6 @@ fn graceful_close_sends_shutdown_reaps_descendants_and_deletes_storage() {
     );
     let session = broker.session_blocking(BrowserSessionConfig::new()).unwrap();
     let config_dir = session.supervisor.as_ref().unwrap().config_dir.clone();
-    // Poll for parseable content, not mere existence: the shell's redirection
-    // creates the file before the pid is written.
     let deadline = Instant::now() + Duration::from_secs(1);
     let pid = loop {
         if let Some(pid) = std::fs::read_to_string(&child_pid)

--- a/crates/servo-fetch/src/session/tests.rs
+++ b/crates/servo-fetch/src/session/tests.rs
@@ -511,16 +511,19 @@ fn graceful_close_sends_shutdown_reaps_descendants_and_deletes_storage() {
     );
     let session = broker.session_blocking(BrowserSessionConfig::new()).unwrap();
     let config_dir = session.supervisor.as_ref().unwrap().config_dir.clone();
+    // Poll for parseable content, not mere existence: the shell's redirection
+    // creates the file before the pid is written.
     let deadline = Instant::now() + Duration::from_secs(1);
-    while !child_pid.exists() {
+    let pid = loop {
+        if let Some(pid) = std::fs::read_to_string(&child_pid)
+            .ok()
+            .and_then(|content| content.trim().parse::<i32>().ok())
+        {
+            break pid;
+        }
         assert!(Instant::now() < deadline, "worker descendant did not start");
         std::thread::sleep(Duration::from_millis(5));
-    }
-    let pid = std::fs::read_to_string(&child_pid)
-        .unwrap()
-        .trim()
-        .parse::<i32>()
-        .unwrap();
+    };
 
     session.close_blocking().unwrap();
     assert!(!config_dir.exists());


### PR DESCRIPTION
## Summary

`session::tests::graceful_close_sends_shutdown_reaps_descendants_and_deletes_storage` is flaky on loaded runners: the scripted worker writes its descendant pid with `echo $! > "$file"`, and shell redirection creates the file before the pid lands in it. The test polled for mere file existence and then parsed, so it could read the empty just-created file and panic with `ParseIntError { kind: Empty }`.

## Related issues

Unblocks CI on #409.

## Test Plan

- `cargo test -p servo-fetch --lib`

## Checklist

- [x] Ran `cargo +nightly fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
- [ ] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed
- [x] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it