### PR TITLE
chore(ci): build releases hermetically without compile caches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,9 +106,6 @@ jobs:
     env:
       RUST_BACKTRACE: 1
       CARGO_INCREMENTAL: 0
-      SCCACHE_GHA_ENABLED: "true"
-      RUSTC_WRAPPER: sccache
-      CCACHE: sccache
       TARGET: ${{ matrix.target }}
       TAG: ${{ needs.release-plz-release.outputs.tag }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -122,9 +119,6 @@ jobs:
         with:
           toolchain: "1.95.0"
           targets: ${{ matrix.target }}
-
-      # zizmor: ignore[cache-poisoning] -- maintainer-controlled trigger only (push to main, gated on release-plz creating a release)
-      - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
 
       - name: Install system dependencies (Linux)
         if: runner.os == 'Linux'


### PR DESCRIPTION
## Summary

Remove sccache from release builds so release binaries are built hermetically from a cold cache.

## Test Plan

- `actionlint` and `zizmor` pass on `.github/workflows/release.yml`

## Checklist

- [ ] Ran `cargo +nightly fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
- [ ] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed
- [ ] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it