### PR TITLE
fix(session): isolate worker current directory

### DIFF
--- a/crates/servo-fetch/src/session/supervisor.rs
+++ b/crates/servo-fetch/src/session/supervisor.rs
@@ -445,6 +445,7 @@ impl WorkerProcess {
         let mut process = Command::new(&command.program);
         process
             .args(&command.args)
+            .current_dir(owner.config_dir())
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::inherit());

--- a/crates/servo-fetch/src/session/tests.rs
+++ b/crates/servo-fetch/src/session/tests.rs
@@ -368,6 +368,29 @@ fn scripted_broker(script: &str, args: impl IntoIterator<Item = OsString>, queue
 }
 
 #[cfg(unix)]
+#[test]
+fn worker_starts_in_private_session_directory() {
+    let directory = tempfile::tempdir().unwrap();
+    let reported_cwd = directory.path().join("worker-cwd");
+    let script = format!(
+        "pwd -P > \"$1\"; {}read_frame; {}read_frame; {}",
+        scripted_worker_prefix(),
+        initialized_shell(1),
+        shutdown_ack_shell(2)
+    );
+    let broker = scripted_broker(&script, [reported_cwd.clone().into_os_string()], 0);
+    let session = broker.session_blocking(BrowserSessionConfig::new()).unwrap();
+    let config_dir = session.supervisor.as_ref().unwrap().config_dir.clone();
+    let worker_cwd = std::fs::read_to_string(reported_cwd).unwrap();
+
+    assert_eq!(
+        std::fs::canonicalize(worker_cwd.trim()).unwrap(),
+        std::fs::canonicalize(config_dir).unwrap()
+    );
+    session.close_blocking().unwrap();
+}
+
+#[cfg(unix)]
 fn assert_fetch_protocol_failure(responses: &str) {
     let script = format!(
         "{}read_frame; {}read_frame; {responses}exec sleep 10",


### PR DESCRIPTION
## Summary

Run isolated workers from their per-session temporary directory so relative writes, including Servo's IndexedDB `bottles/` fallback, cannot leak into the caller's current directory.

## Related issues

Fixes #424

## Test Plan

- `cargo test --locked --profile ci -p servo-fetch --lib`
- `cargo test --locked --profile ci -p servo-fetch-cli --test session -- --ignored`

## Checklist

- [x] Ran `cargo +nightly fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
- [ ] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed
- [x] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it