### PR TITLE
chore(deps): update chacha20 to 0.10.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -858,9 +858,9 @@ dependencies = [
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cipher 0.5.2",


### PR DESCRIPTION
## Summary

Update chacha20 to 0.10.2.

## Related issues

N/A

## Test Plan

`cargo check`

## Checklist

- [x] Ran `cargo +nightly fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
- [ ] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed
- [ ] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it
