### PR TITLE
fix(ci): scan docker image before publishing stable tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -218,7 +218,7 @@ jobs:
           retention-days: 1
 
   publish-docker:
-    name: Publish Docker image
+    name: Publish Docker candidate
     needs: [release-plz-release, build-release]
     if: needs.release-plz-release.outputs.tag != ''
     runs-on: ubuntu-24.04
@@ -226,7 +226,6 @@ jobs:
     permissions:
       contents: read
       packages: write
-      id-token: write
     env:
       TAG: ${{ needs.release-plz-release.outputs.tag }}
     outputs:
@@ -265,14 +264,14 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
-        id: meta
+        id: candidate-meta
         with:
           images: ghcr.io/${{ github.repository }}
-          tags: |
-            type=semver,pattern={{version}},value=${{ needs.release-plz-release.outputs.tag }}
-            type=semver,pattern={{major}}.{{minor}},value=${{ needs.release-plz-release.outputs.tag }}
-            type=semver,pattern={{major}},value=${{ needs.release-plz-release.outputs.tag }}
-            type=raw,value=latest,enable=${{ !contains(needs.release-plz-release.outputs.tag, '-') }}
+          flavor: latest=false
+          tags: type=raw,value=candidate-${{ github.run_id }}-${{ github.run_attempt }}
+          labels: |
+            org.opencontainers.image.version=${{ env.VERSION }}
+            org.opencontainers.image.revision=${{ env.REVISION }}
 
       - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         id: build
@@ -280,24 +279,16 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.candidate-meta.outputs.tags }}
+          labels: ${{ steps.candidate-meta.outputs.labels }}
           build-args: |
             VERSION=${{ env.VERSION }}
             REVISION=${{ env.REVISION }}
           provenance: mode=max
           sbom: true
 
-      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
-
-      - name: Sign image with cosign (keyless)
-        env:
-          DIGEST: ${{ steps.build.outputs.digest }}
-        run: |
-          cosign sign --yes --recursive "ghcr.io/${{ github.repository }}@${DIGEST}"
-
   trivy-scan:
-    name: Scan Docker image
+    name: Scan Docker candidate
     needs: publish-docker
     runs-on: ubuntu-24.04
     timeout-minutes: 10
@@ -325,9 +316,101 @@ jobs:
           sarif_file: trivy-results.sarif
           category: trivy-image
 
+  promote-docker:
+    name: Promote and sign Docker image
+    needs: [release-plz-release, publish-docker, trivy-scan]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    steps:
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        id: stable-meta
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}},value=${{ needs.release-plz-release.outputs.tag }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ needs.release-plz-release.outputs.tag }}
+            type=semver,pattern={{major}},value=${{ needs.release-plz-release.outputs.tag }}
+            type=raw,value=latest,enable=${{ !contains(needs.release-plz-release.outputs.tag, '-') }}
+
+      - name: Promote scanned digest to stable tags
+        env:
+          EXPECTED_DIGEST: ${{ needs.publish-docker.outputs.digest }}
+          IMAGE: ghcr.io/${{ github.repository }}
+          STABLE_TAGS: ${{ steps.stable-meta.outputs.tags }}
+        run: |
+          set -euo pipefail
+
+          source_ref="${IMAGE}@${EXPECTED_DIGEST}"
+          source_digest=$(docker buildx imagetools inspect "$source_ref" --format '{{json .Manifest}}' | jq -r '.digest')
+          if [[ "$source_digest" != "$EXPECTED_DIGEST" ]]; then
+            echo "Candidate digest mismatch: expected $EXPECTED_DIGEST, got $source_digest" >&2
+            exit 1
+          fi
+
+          manifest=$(mktemp)
+          trap 'rm -f "$manifest"' EXIT
+          docker buildx imagetools create --prefer-index=false --dry-run "$source_ref" > "$manifest"
+          preflight_digest=$(python3 - "$manifest" <<'PY'
+          from hashlib import sha256
+          from pathlib import Path
+          import sys
+
+          data = Path(sys.argv[1]).read_bytes()
+          if data.endswith(b"\n"):
+              data = data[:-1]
+          print(f"sha256:{sha256(data).hexdigest()}")
+          PY
+          )
+          if [[ "$preflight_digest" != "$EXPECTED_DIGEST" ]]; then
+            echo "Promotion would change digest: expected $EXPECTED_DIGEST, got $preflight_digest" >&2
+            exit 1
+          fi
+
+          tags=()
+          while IFS= read -r tag; do
+            [[ -n "$tag" ]] && tags+=("$tag")
+          done <<< "$STABLE_TAGS"
+          if (( ${#tags[@]} == 0 )); then
+            echo "No stable tags were generated" >&2
+            exit 1
+          fi
+
+          tag_args=()
+          for tag in "${tags[@]}"; do
+            tag_args+=(--tag "$tag")
+          done
+          docker buildx imagetools create --prefer-index=false "${tag_args[@]}" "$source_ref"
+
+          for tag in "${tags[@]}"; do
+            published_digest=$(docker buildx imagetools inspect "$tag" --format '{{json .Manifest}}' | jq -r '.digest')
+            if [[ "$published_digest" != "$EXPECTED_DIGEST" ]]; then
+              echo "Published digest mismatch for $tag: expected $EXPECTED_DIGEST, got $published_digest" >&2
+              exit 1
+            fi
+          done
+
+      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Sign promoted digest with cosign (keyless)
+        env:
+          DIGEST: ${{ needs.publish-docker.outputs.digest }}
+        run: cosign sign --yes --recursive "ghcr.io/${{ github.repository }}@${DIGEST}"
+
   publish-release:
     name: Publish release
-    needs: [release-plz-release, build-release, publish-docker, trivy-scan]
+    needs: [release-plz-release, build-release, publish-docker, trivy-scan, promote-docker]
     if: needs.release-plz-release.outputs.tag != ''
     runs-on: ubuntu-24.04
     timeout-minutes: 5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -217,8 +217,8 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
-  publish-docker:
-    name: Publish Docker candidate
+  build-docker:
+    name: Build Docker candidate
     needs: [release-plz-release, build-release]
     if: needs.release-plz-release.outputs.tag != ''
     runs-on: ubuntu-24.04
@@ -287,18 +287,22 @@ jobs:
           provenance: mode=max
           sbom: true
 
-  trivy-scan:
-    name: Scan Docker candidate
-    needs: publish-docker
+  scan-docker:
+    name: Scan Docker candidate / ${{ matrix.arch }}
+    needs: build-docker
     runs-on: ubuntu-24.04
     timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [amd64, arm64]
     permissions:
       security-events: write
     steps:
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
-          image-ref: ghcr.io/${{ github.repository }}@${{ needs.publish-docker.outputs.digest }}
+          image-ref: ghcr.io/${{ github.repository }}@${{ needs.build-docker.outputs.digest }}
           severity: CRITICAL,HIGH
           ignore-unfixed: true
           exit-code: "1"
@@ -306,6 +310,7 @@ jobs:
           output: trivy-results.sarif
           limit-severities-for-sarif: true
         env:
+          TRIVY_PLATFORM: linux/${{ matrix.arch }}
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2
           TRIVY_DISABLE_VEX_NOTICE: "true"
 
@@ -314,15 +319,14 @@ jobs:
         uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           sarif_file: trivy-results.sarif
-          category: trivy-image
+          category: trivy-image-${{ matrix.arch }}
 
-  promote-docker:
-    name: Promote and sign Docker image
-    needs: [release-plz-release, publish-docker, trivy-scan]
+  publish-docker:
+    name: Publish and sign Docker image
+    needs: [release-plz-release, build-docker, scan-docker]
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:
-      contents: read
       packages: write
       id-token: write
     steps:
@@ -346,37 +350,13 @@ jobs:
 
       - name: Promote scanned digest to stable tags
         env:
-          EXPECTED_DIGEST: ${{ needs.publish-docker.outputs.digest }}
+          EXPECTED_DIGEST: ${{ needs.build-docker.outputs.digest }}
           IMAGE: ghcr.io/${{ github.repository }}
           STABLE_TAGS: ${{ steps.stable-meta.outputs.tags }}
         run: |
           set -euo pipefail
 
           source_ref="${IMAGE}@${EXPECTED_DIGEST}"
-          source_digest=$(docker buildx imagetools inspect "$source_ref" --format '{{json .Manifest}}' | jq -r '.digest')
-          if [[ "$source_digest" != "$EXPECTED_DIGEST" ]]; then
-            echo "Candidate digest mismatch: expected $EXPECTED_DIGEST, got $source_digest" >&2
-            exit 1
-          fi
-
-          manifest=$(mktemp)
-          trap 'rm -f "$manifest"' EXIT
-          docker buildx imagetools create --prefer-index=false --dry-run "$source_ref" > "$manifest"
-          preflight_digest=$(python3 - "$manifest" <<'PY'
-          from hashlib import sha256
-          from pathlib import Path
-          import sys
-
-          data = Path(sys.argv[1]).read_bytes()
-          if data.endswith(b"\n"):
-              data = data[:-1]
-          print(f"sha256:{sha256(data).hexdigest()}")
-          PY
-          )
-          if [[ "$preflight_digest" != "$EXPECTED_DIGEST" ]]; then
-            echo "Promotion would change digest: expected $EXPECTED_DIGEST, got $preflight_digest" >&2
-            exit 1
-          fi
 
           tags=()
           while IFS= read -r tag; do
@@ -405,12 +385,12 @@ jobs:
 
       - name: Sign promoted digest with cosign (keyless)
         env:
-          DIGEST: ${{ needs.publish-docker.outputs.digest }}
+          DIGEST: ${{ needs.build-docker.outputs.digest }}
         run: cosign sign --yes --recursive "ghcr.io/${{ github.repository }}@${DIGEST}"
 
   publish-release:
     name: Publish release
-    needs: [release-plz-release, build-release, publish-docker, trivy-scan, promote-docker]
+    needs: [release-plz-release, publish-docker]
     if: needs.release-plz-release.outputs.tag != ''
     runs-on: ubuntu-24.04
     timeout-minutes: 5

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7
 
-FROM debian:trixie-slim@sha256:3a39a0592364683e6bab97937b72cad5a8fa6dcbbee90edb3bb48c7f8e94f258
+FROM debian:trixie-slim@sha256:d7e12182ce18b85b93007c1dedf31f2d29e01ccf3182cc4017c709b6259bc132
 
 ARG TARGETARCH
 ARG VERSION=dev
@@ -16,7 +16,7 @@ LABEL org.opencontainers.image.title="servo-fetch" \
       org.opencontainers.image.revision="${REVISION}" \
       org.opencontainers.image.licenses="MIT OR Apache-2.0" \
       org.opencontainers.image.base.name="debian:trixie-slim" \
-      org.opencontainers.image.base.digest="sha256:b6e2a152f22a40ff69d92cb397223c906017e1391a73c952b588e51af8883bf8"
+      org.opencontainers.image.base.digest="sha256:d7e12182ce18b85b93007c1dedf31f2d29e01ccf3182cc4017c709b6259bc132"
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
       ca-certificates \


### PR DESCRIPTION
## Summary

- Update the pinned Debian base image to include the fixed `util-linux` packages.
- Scan a run-specific Docker candidate before promoting the same verified digest to stable tags and signing it.

## Test Plan

- `actionlint`
- `zizmor .github/workflows/release.yml`
- `cargo test --workspace`

## Checklist

- [ ] Ran `cargo +nightly fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
- [x] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed (not applicable)
- [x] Tests added or updated, or explained why not in the Test Plan (workflow-only change; validated above)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it