### PR TITLE
fix(mcp): separate tool and internal errors

### DIFF
--- a/crates/servo-fetch-cli/src/mcp/output.rs
+++ b/crates/servo-fetch-cli/src/mcp/output.rs
@@ -117,7 +117,7 @@ pub(super) fn bounded_text(value: impl fmt::Display) -> String {
     bounded_format(format_args!("{value}"), MAX_MCP_PREBUILD_TEXT_CHARS)
 }
 
-pub(super) fn labeled_content(url: &str, content: &str) -> String {
+pub(super) fn labeled_content(url: &str, content: impl fmt::Display) -> String {
     bounded_format(format_args!("URL: {url}\n\n{content}"), MAX_MCP_PREBUILD_TEXT_CHARS)
 }
 
@@ -316,7 +316,7 @@ pub(super) fn checked_base64_length(raw_len: usize, encoded_limit: usize) -> Res
         .and_then(|groups| groups.checked_mul(4))
         .ok_or_else(|| ToolError::internal("screenshot base64 size overflow"))?;
     if encoded_len > encoded_limit {
-        return Err(ToolError::internal(format!(
+        return Err(ToolError::operation(format!(
             "screenshot base64 data exceeds {encoded_limit} byte MCP response limit"
         )));
     }
@@ -515,8 +515,8 @@ mod tests {
             "<response truncated: omitted 2 content blocks>",
         )]);
         let mut output = TextOutput::with_limit(false, serialized_len(&summary));
-        assert!(!output.push(labeled_content("https://example.com/a", &"x".repeat(200))));
-        assert!(!output.push(labeled_content("https://example.com/b", &"y".repeat(200))));
+        assert!(!output.push(labeled_content("https://example.com/a", "x".repeat(200))));
+        assert!(!output.push(labeled_content("https://example.com/b", "y".repeat(200))));
         let result = output.finish();
         assert_eq!(
             text_blocks(&result),
@@ -593,9 +593,13 @@ mod tests {
     }
 
     #[test]
-    fn checked_base64_length_handles_cap_and_arithmetic_overflow_without_allocation() {
+    fn checked_base64_length_classifies_cap_as_operation_and_overflow_as_internal() {
         assert_eq!(checked_base64_length(6, 8).unwrap(), 8);
-        assert!(checked_base64_length(7, 8).is_err());
-        assert!(checked_base64_length(usize::MAX, usize::MAX).is_err());
+
+        let over_cap = checked_base64_length(7, 8).expect_err("encoded output exceeds cap");
+        assert!(over_cap.is_operation());
+
+        let overflow = checked_base64_length(usize::MAX, usize::MAX).expect_err("arithmetic overflows");
+        assert!(overflow.is_internal());
     }
 }

--- a/crates/servo-fetch-cli/src/mcp/server.rs
+++ b/crates/servo-fetch-cli/src/mcp/server.rs
@@ -1,10 +1,15 @@
 //! MCP server handler — tool routing and server info.
 
+use std::future::Future;
+use std::marker::PhantomData;
+
 use base64::Engine as _;
 use rmcp::handler::server::router::tool::ToolRouter;
 use rmcp::handler::server::wrapper::Parameters;
-use rmcp::model::{CallToolResult, ContentBlock, ProtocolVersion, ServerCapabilities, ServerInfo};
+use rmcp::model::{CallToolResult, ContentBlock, JsonObject, ProtocolVersion, ServerCapabilities, ServerInfo};
+use rmcp::schemars::{JsonSchema, Schema, SchemaGenerator};
 use rmcp::{ErrorData, ServerHandler, tool, tool_handler, tool_router};
+use serde::de::DeserializeOwned;
 use servo_fetch::FetchOptions;
 use servo_fetch_types::{
     BatchFetchRequest, CrawlRequest, EvaluateRequest, FetchRequest, MapRequest, ScreenshotRequest,
@@ -12,6 +17,50 @@ use servo_fetch_types::{
 
 use super::{output, tools};
 use crate::tools::limits::{CRAWL_LIMIT, DEFAULT_MAX_LENGTH, MAX_BATCH_URLS, MAX_JS_LEN, clamp_count, to_len};
+
+#[derive(serde::Deserialize)]
+#[serde(transparent, bound(deserialize = ""))]
+struct RawArguments<T> {
+    value: JsonObject,
+    #[serde(skip)]
+    request: PhantomData<fn() -> T>,
+}
+
+impl<T: JsonSchema> JsonSchema for RawArguments<T> {
+    fn inline_schema() -> bool {
+        T::inline_schema()
+    }
+
+    fn schema_name() -> std::borrow::Cow<'static, str> {
+        T::schema_name()
+    }
+
+    fn schema_id() -> std::borrow::Cow<'static, str> {
+        T::schema_id()
+    }
+
+    fn json_schema(generator: &mut SchemaGenerator) -> Schema {
+        T::json_schema(generator)
+    }
+}
+
+async fn complete_decoded_tool_call<T, F, Fut>(
+    tool: &'static str,
+    arguments: RawArguments<T>,
+    run: F,
+) -> Result<CallToolResult, ErrorData>
+where
+    T: DeserializeOwned,
+    F: FnOnce(T) -> Fut,
+    Fut: Future<Output = Result<CallToolResult, tools::ToolError>>,
+{
+    let request = serde_json::from_value(serde_json::Value::Object(arguments.value))
+        .map_err(|error| tools::ToolError::invalid_params(format!("failed to deserialize parameters: {error}")));
+    match request {
+        Ok(request) => complete_tool_call(tool, run(request).await),
+        Err(error) => complete_tool_call(tool, Err(error)),
+    }
+}
 
 #[derive(Debug, Clone)]
 pub(crate) struct ServoFetchMcp {
@@ -36,8 +85,8 @@ impl ServoFetchMcp {
             open_world_hint = true
         )
     )]
-    async fn fetch(&self, Parameters(p): Parameters<FetchRequest>) -> Result<CallToolResult, ErrorData> {
-        Ok(run_fetch(p).await.unwrap_or_else(tools::tool_error))
+    async fn fetch(&self, Parameters(p): Parameters<RawArguments<FetchRequest>>) -> Result<CallToolResult, ErrorData> {
+        complete_decoded_tool_call("fetch", p, run_fetch).await
     }
 
     #[tool(
@@ -49,8 +98,11 @@ impl ServoFetchMcp {
             open_world_hint = true
         )
     )]
-    async fn screenshot(&self, Parameters(p): Parameters<ScreenshotRequest>) -> Result<CallToolResult, ErrorData> {
-        Ok(run_screenshot(p).await.unwrap_or_else(tools::tool_error))
+    async fn screenshot(
+        &self,
+        Parameters(p): Parameters<RawArguments<ScreenshotRequest>>,
+    ) -> Result<CallToolResult, ErrorData> {
+        complete_decoded_tool_call("screenshot", p, run_screenshot).await
     }
 
     #[tool(
@@ -62,8 +114,11 @@ impl ServoFetchMcp {
             open_world_hint = true
         )
     )]
-    async fn execute_js(&self, Parameters(p): Parameters<EvaluateRequest>) -> Result<CallToolResult, ErrorData> {
-        Ok(run_execute_js(p).await.unwrap_or_else(tools::tool_error))
+    async fn execute_js(
+        &self,
+        Parameters(p): Parameters<RawArguments<EvaluateRequest>>,
+    ) -> Result<CallToolResult, ErrorData> {
+        complete_decoded_tool_call("execute_js", p, run_execute_js).await
     }
 
     #[tool(
@@ -75,8 +130,11 @@ impl ServoFetchMcp {
             open_world_hint = true
         )
     )]
-    async fn batch_fetch(&self, Parameters(p): Parameters<BatchFetchRequest>) -> Result<CallToolResult, ErrorData> {
-        Ok(run_batch_fetch(p).await.unwrap_or_else(tools::tool_error))
+    async fn batch_fetch(
+        &self,
+        Parameters(p): Parameters<RawArguments<BatchFetchRequest>>,
+    ) -> Result<CallToolResult, ErrorData> {
+        complete_decoded_tool_call("batch_fetch", p, run_batch_fetch).await
     }
 
     #[tool(
@@ -88,8 +146,8 @@ impl ServoFetchMcp {
             open_world_hint = true
         )
     )]
-    async fn crawl(&self, Parameters(p): Parameters<CrawlRequest>) -> Result<CallToolResult, ErrorData> {
-        Ok(run_crawl(p).await.unwrap_or_else(tools::tool_error))
+    async fn crawl(&self, Parameters(p): Parameters<RawArguments<CrawlRequest>>) -> Result<CallToolResult, ErrorData> {
+        complete_decoded_tool_call("crawl", p, run_crawl).await
     }
 
     #[tool(
@@ -101,9 +159,43 @@ impl ServoFetchMcp {
             open_world_hint = true
         )
     )]
-    async fn map(&self, Parameters(p): Parameters<MapRequest>) -> Result<CallToolResult, ErrorData> {
-        Ok(run_map(p).await.unwrap_or_else(tools::tool_error))
+    async fn map(&self, Parameters(p): Parameters<RawArguments<MapRequest>>) -> Result<CallToolResult, ErrorData> {
+        complete_decoded_tool_call("map", p, run_map).await
     }
+}
+
+const INTERNAL_ERROR_MESSAGE: &str = "Internal server error";
+
+fn complete_tool_call(
+    tool: &'static str,
+    result: Result<CallToolResult, tools::ToolError>,
+) -> Result<CallToolResult, ErrorData> {
+    match result {
+        Ok(result) => Ok(result),
+        Err(error) if error.is_internal() => {
+            tracing::error!(tool, kind = ?error.kind(), error = ?error, "MCP tool internal failure");
+            Err(ErrorData::internal_error(INTERNAL_ERROR_MESSAGE, None))
+        }
+        Err(error) => Ok(tools::tool_error(error)),
+    }
+}
+
+fn labeled_results(
+    results: Vec<(String, Result<String, tools::ToolError>)>,
+) -> Result<CallToolResult, tools::ToolError> {
+    let mut output = output::TextOutput::success();
+    for (url, result) in results {
+        match result {
+            Ok(content) => {
+                output.push(output::labeled_content(&url, content));
+            }
+            Err(error) if error.is_operation() => {
+                output.push(output::labeled_content(&url, format_args!("[error] {error}")));
+            }
+            Err(error) => return Err(error),
+        }
+    }
+    Ok(output.finish())
 }
 
 async fn run_fetch(p: FetchRequest) -> Result<CallToolResult, tools::ToolError> {
@@ -183,12 +275,8 @@ async fn run_batch_fetch(p: BatchFetchRequest) -> Result<CallToolResult, tools::
         visibility: tools::visibility_policy(p.visibility),
         options: p.options,
     })
-    .await;
-    let mut output = output::TextOutput::success();
-    for (url, text) in results {
-        output.push(output::labeled_content(&url, &text));
-    }
-    Ok(output.finish())
+    .await?;
+    labeled_results(results)
 }
 
 async fn run_crawl(p: CrawlRequest) -> Result<CallToolResult, tools::ToolError> {
@@ -213,11 +301,7 @@ async fn run_crawl(p: CrawlRequest) -> Result<CallToolResult, tools::ToolError> 
         max_len,
     )
     .await?;
-    let mut output = output::TextOutput::success();
-    for (url, text) in results {
-        output.push(output::labeled_content(&url, &text));
-    }
-    Ok(output.finish())
+    labeled_results(results)
 }
 
 async fn run_map(p: MapRequest) -> Result<CallToolResult, tools::ToolError> {
@@ -269,5 +353,107 @@ mod tests {
         assert!(info.server_info.name.contains("servo-fetch"));
         assert!(!info.server_info.version.is_empty());
         assert!(info.instructions.is_some());
+    }
+
+    struct IdentitySchema;
+
+    impl JsonSchema for IdentitySchema {
+        fn inline_schema() -> bool {
+            true
+        }
+
+        fn schema_name() -> std::borrow::Cow<'static, str> {
+            "identity-name".into()
+        }
+
+        fn schema_id() -> std::borrow::Cow<'static, str> {
+            "identity-id".into()
+        }
+
+        fn json_schema(_generator: &mut SchemaGenerator) -> Schema {
+            serde_json::json!({"type": "object"}).try_into().expect("valid schema")
+        }
+    }
+
+    #[test]
+    fn raw_arguments_delegate_schema_identity() {
+        assert_eq!(
+            RawArguments::<IdentitySchema>::inline_schema(),
+            IdentitySchema::inline_schema()
+        );
+        assert_eq!(
+            RawArguments::<IdentitySchema>::schema_name(),
+            IdentitySchema::schema_name()
+        );
+        assert_eq!(RawArguments::<IdentitySchema>::schema_id(), IdentitySchema::schema_id());
+    }
+
+    #[test]
+    fn validation_and_operation_failures_remain_tool_errors() {
+        let validation = complete_tool_call("fetch", Err(tools::ToolError::invalid_params("caller can fix this")))
+            .expect("validation should be a tool result");
+        assert_eq!(validation.is_error, Some(true));
+
+        let operation = complete_tool_call(
+            "fetch",
+            Err(tools::ToolError::from(servo_fetch::Error::Timeout {
+                url: "https://example.com".to_string(),
+                timeout: std::time::Duration::from_secs(1),
+            })),
+        )
+        .expect("operation failure should be a tool result");
+        assert_eq!(operation.is_error, Some(true));
+    }
+
+    #[test]
+    fn internal_failure_is_generic_json_rpc_error_without_data_or_detail() {
+        let detail = "sensitive worker transport detail";
+        let failure = servo_fetch::Error::WorkerUnavailable {
+            source: std::io::Error::other(detail).into(),
+        };
+        let error = complete_tool_call("fetch", Err(tools::ToolError::from(failure)))
+            .expect_err("internal failure should be a JSON-RPC error");
+
+        assert_eq!(error.code, rmcp::model::ErrorCode::INTERNAL_ERROR);
+        assert_eq!(error.message, INTERNAL_ERROR_MESSAGE);
+        assert_eq!(error.data, None);
+        assert!(!serde_json::to_string(&error).unwrap().contains(detail));
+    }
+
+    #[test]
+    fn batch_and_crawl_typed_partial_results_keep_labels_and_propagate_input_and_internal_errors() {
+        let results = vec![
+            ("https://example.com/ok".to_string(), Ok("body".to_string())),
+            (
+                "https://example.com/failed".to_string(),
+                Err(tools::ToolError::from(servo_fetch::Error::Timeout {
+                    url: "https://example.com/failed".to_string(),
+                    timeout: std::time::Duration::from_secs(1),
+                })),
+            ),
+        ];
+        let result = labeled_results(results).expect("ordinary per-item failures should be partial results");
+        let text: Vec<_> = result
+            .content
+            .iter()
+            .map(|block| block.as_text().expect("text block").text.as_str())
+            .collect();
+        assert_eq!(text.len(), 2);
+        assert_eq!(text[0], "URL: https://example.com/ok\n\nbody");
+        assert!(text[1].starts_with("URL: https://example.com/failed\n\n[error] page load timed out"));
+
+        let invalid_input = labeled_results(vec![(
+            "https://example.com/invalid".to_string(),
+            Err(tools::ToolError::invalid_params("invalid shared option")),
+        )])
+        .expect_err("invalid per-item input must become an isError tool result");
+        assert_eq!(invalid_input.to_string(), "invalid shared option");
+
+        let internal = labeled_results(vec![(
+            "https://example.com/private".to_string(),
+            Err(tools::ToolError::internal("private detail")),
+        )])
+        .expect_err("internal per-item failure must not be returned inline");
+        assert_eq!(internal.to_string(), "private detail");
     }
 }

--- a/crates/servo-fetch-cli/src/mcp/server.rs
+++ b/crates/servo-fetch-cli/src/mcp/server.rs
@@ -18,6 +18,7 @@ use servo_fetch_types::{
 use super::{output, tools};
 use crate::tools::limits::{CRAWL_LIMIT, DEFAULT_MAX_LENGTH, MAX_BATCH_URLS, MAX_JS_LEN, clamp_count, to_len};
 
+// Defer decoding to the bounded error boundary while preserving the DTO schema.
 #[derive(serde::Deserialize)]
 #[serde(transparent, bound(deserialize = ""))]
 struct RawArguments<T> {
@@ -54,8 +55,11 @@ where
     F: FnOnce(T) -> Fut,
     Fut: Future<Output = Result<CallToolResult, tools::ToolError>>,
 {
-    let request = serde_json::from_value(serde_json::Value::Object(arguments.value))
-        .map_err(|error| tools::ToolError::invalid_params(format!("failed to deserialize parameters: {error}")));
+    let request = serde_json::from_value(serde_json::Value::Object(arguments.value)).map_err(|error| {
+        tools::ToolError::invalid_params(output::bounded_text(format_args!(
+            "failed to deserialize parameters: {error}"
+        )))
+    });
     match request {
         Ok(request) => complete_tool_call(tool, run(request).await),
         Err(error) => complete_tool_call(tool, Err(error)),
@@ -386,6 +390,13 @@ mod tests {
             IdentitySchema::schema_name()
         );
         assert_eq!(RawArguments::<IdentitySchema>::schema_id(), IdentitySchema::schema_id());
+
+        let mut raw_generator = SchemaGenerator::default();
+        let mut identity_generator = SchemaGenerator::default();
+        assert_eq!(
+            RawArguments::<IdentitySchema>::json_schema(&mut raw_generator),
+            IdentitySchema::json_schema(&mut identity_generator)
+        );
     }
 
     #[test]
@@ -426,10 +437,7 @@ mod tests {
             ("https://example.com/ok".to_string(), Ok("body".to_string())),
             (
                 "https://example.com/failed".to_string(),
-                Err(tools::ToolError::from(servo_fetch::Error::Timeout {
-                    url: "https://example.com/failed".to_string(),
-                    timeout: std::time::Duration::from_secs(1),
-                })),
+                Err(tools::ToolError::operation("ordinary failure")),
             ),
         ];
         let result = labeled_results(results).expect("ordinary per-item failures should be partial results");
@@ -438,9 +446,13 @@ mod tests {
             .iter()
             .map(|block| block.as_text().expect("text block").text.as_str())
             .collect();
-        assert_eq!(text.len(), 2);
-        assert_eq!(text[0], "URL: https://example.com/ok\n\nbody");
-        assert!(text[1].starts_with("URL: https://example.com/failed\n\n[error] page load timed out"));
+        assert_eq!(
+            text,
+            [
+                "URL: https://example.com/ok\n\nbody",
+                "URL: https://example.com/failed\n\n[error] ordinary failure",
+            ]
+        );
 
         let invalid_input = labeled_results(vec![(
             "https://example.com/invalid".to_string(),

--- a/crates/servo-fetch-cli/src/serve/handlers.rs
+++ b/crates/servo-fetch-cli/src/serve/handlers.rs
@@ -106,11 +106,8 @@ pub(super) async fn batch_fetch(Json(req): Json<BatchFetchRequest>) -> Result<Ax
         visibility: tools::visibility_policy(req.visibility),
         options: req.options,
     })
-    .await;
-    let results = raw
-        .into_iter()
-        .map(|(url, content)| FetchResponse { url, content })
-        .collect();
+    .await?;
+    let results = raw.into_iter().map(flatten_page_result).collect();
     Ok(AxumJson(BatchFetchResponse { results }))
 }
 
@@ -134,11 +131,13 @@ pub(super) async fn crawl(Json(req): Json<CrawlRequest>) -> Result<AxumJson<Craw
         to_len(req.max_length, DEFAULT_MAX_LENGTH),
     )
     .await?;
-    let results = pages
-        .into_iter()
-        .map(|(url, content)| FetchResponse { url, content })
-        .collect();
+    let results = pages.into_iter().map(flatten_page_result).collect();
     Ok(AxumJson(CrawlResponse { results }))
+}
+
+fn flatten_page_result((url, content): (String, Result<String, ToolError>)) -> FetchResponse {
+    let content = content.unwrap_or_else(|error| format!("[error] {error}"));
+    FetchResponse { url, content }
 }
 
 pub(super) async fn map(Json(req): Json<MapRequest>) -> Result<AxumJson<MapResponse>, ApiError> {
@@ -160,4 +159,20 @@ pub(super) async fn map(Json(req): Json<MapRequest>) -> Result<AxumJson<MapRespo
         .map(|entry| entry.url)
         .collect();
     Ok(AxumJson(MapResponse { urls }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn typed_item_error_keeps_http_url_and_inline_error_shape() {
+        let page = flatten_page_result((
+            "https://example.com/failed".to_string(),
+            Err(ToolError::internal("existing detail")),
+        ));
+
+        assert_eq!(page.url, "https://example.com/failed");
+        assert_eq!(page.content, "[error] existing detail");
+    }
 }

--- a/crates/servo-fetch-cli/src/tools/crawl.rs
+++ b/crates/servo-fetch-cli/src/tools/crawl.rs
@@ -59,20 +59,20 @@ fn resolve_delay(delay_ms: Option<u64>) -> Option<Duration> {
     }
 }
 
-pub(crate) async fn crawl_pages(spec: CrawlSpec<'_>, max_len: usize) -> ToolResult<Vec<(String, String)>> {
+pub(crate) async fn crawl_pages(spec: CrawlSpec<'_>, max_len: usize) -> ToolResult<Vec<(String, ToolResult<String>)>> {
     let builder = build_crawl_options(&spec)?;
     tokio::task::spawn_blocking(move || {
         let mut results = Vec::new();
         servo_fetch::blocking::crawl_each(&builder, |r| {
-            let text = match &r.outcome {
-                Ok(page) => paginate(&servo_fetch::sanitize::sanitize(&page.content), 0, max_len),
-                Err(e) => format!("[error] {e}"),
+            let content = match r.outcome {
+                Ok(page) => Ok(paginate(&servo_fetch::sanitize::sanitize(&page.content), 0, max_len)),
+                Err(e) => Err(ToolError::from(e)),
             };
-            results.push((r.url, text));
+            results.push((r.url, content));
         })
         .map_err(ToolError::from)?;
         Ok(results)
     })
     .await
-    .map_err(|e| ToolError::internal(format!("spawn_blocking failed: {e}")))?
+    .map_err(|e| ToolError::internal(format!("crawl task failed: {e}")))?
 }

--- a/crates/servo-fetch-cli/src/tools/error.rs
+++ b/crates/servo-fetch-cli/src/tools/error.rs
@@ -2,6 +2,7 @@
 
 use servo_fetch_types::ErrorKind;
 
+// MCP disposition and legacy HTTP/RPC error kind are intentionally independent.
 #[derive(Debug, Clone, Copy)]
 enum ToolErrorClass {
     InvalidInput(ErrorKind),

--- a/crates/servo-fetch-cli/src/tools/error.rs
+++ b/crates/servo-fetch-cli/src/tools/error.rs
@@ -2,51 +2,139 @@
 
 use servo_fetch_types::ErrorKind;
 
+#[derive(Debug, Clone, Copy)]
+enum ToolErrorClass {
+    InvalidInput(ErrorKind),
+    Operation(ErrorKind),
+    Internal(ErrorKind),
+}
+
 #[derive(Debug, thiserror::Error)]
 #[error("{message}")]
 pub(crate) struct ToolError {
-    kind: ErrorKind,
+    class: ToolErrorClass,
     message: String,
+    #[source]
+    source: Option<servo_fetch::Error>,
 }
 
 impl ToolError {
     pub(crate) fn internal(message: impl Into<String>) -> Self {
         Self {
-            kind: ErrorKind::Internal,
+            class: ToolErrorClass::Internal(ErrorKind::Internal),
             message: message.into(),
+            source: None,
         }
     }
 
     pub(crate) fn invalid_params(message: impl Into<String>) -> Self {
         Self {
-            kind: ErrorKind::InvalidParams,
+            class: ToolErrorClass::InvalidInput(ErrorKind::InvalidParams),
             message: message.into(),
+            source: None,
+        }
+    }
+
+    pub(crate) fn operation(message: impl Into<String>) -> Self {
+        Self {
+            class: ToolErrorClass::Operation(ErrorKind::Other),
+            message: message.into(),
+            source: None,
         }
     }
 
     pub(crate) fn kind(&self) -> ErrorKind {
-        self.kind
+        match self.class {
+            ToolErrorClass::InvalidInput(kind) | ToolErrorClass::Operation(kind) | ToolErrorClass::Internal(kind) => {
+                kind
+            }
+        }
+    }
+
+    pub(crate) fn is_operation(&self) -> bool {
+        matches!(self.class, ToolErrorClass::Operation(_))
+    }
+
+    pub(crate) fn is_internal(&self) -> bool {
+        matches!(self.class, ToolErrorClass::Internal(_))
     }
 }
 
 impl From<servo_fetch::Error> for ToolError {
     fn from(err: servo_fetch::Error) -> Self {
         use servo_fetch::Error as E;
-        let kind = match &err {
-            E::InvalidUrl { .. } => ErrorKind::InvalidUrl,
-            E::AddressNotAllowed { .. } => ErrorKind::AddressNotAllowed,
-            E::Cookies { .. } | E::Schema(_) | E::InvalidGlob(_) | E::InvalidHeader(_) => ErrorKind::InvalidParams,
-            E::Timeout { .. } => ErrorKind::Timeout,
-            E::JavaScript { .. } => ErrorKind::Javascript,
-            E::Engine { .. } | E::Screenshot { .. } => ErrorKind::Engine,
-            E::Extract(_) | E::Io(_) => ErrorKind::Internal,
-            _ => ErrorKind::Other,
+        use servo_fetch::extract::ExtractError;
+
+        let class = match &err {
+            E::InvalidUrl { .. } => ToolErrorClass::InvalidInput(ErrorKind::InvalidUrl),
+            E::AddressNotAllowed { .. } => ToolErrorClass::InvalidInput(ErrorKind::AddressNotAllowed),
+            E::Cookies { .. } | E::Schema(_) | E::InvalidGlob(_) | E::InvalidHeader(_) => {
+                ToolErrorClass::InvalidInput(ErrorKind::InvalidParams)
+            }
+            E::Extract(ExtractError::InvalidSelector) => ToolErrorClass::InvalidInput(ErrorKind::Internal),
+            E::Timeout { .. } => ToolErrorClass::Operation(ErrorKind::Timeout),
+            E::JavaScript { .. } => ToolErrorClass::Operation(ErrorKind::Javascript),
+            E::Engine { .. } | E::Screenshot { .. } => ToolErrorClass::Operation(ErrorKind::Engine),
+            E::OutputTooLarge { .. }
+            | E::SessionCancelled
+            | E::SessionAcquireTimeout { .. }
+            | E::UnsupportedSessionOperation { .. }
+            | E::SessionBrokerFull => ToolErrorClass::Operation(ErrorKind::Other),
+            E::WorkerProtocolTimeout { .. } | E::InvalidSessionConfig { .. } | E::WorkerUnavailable { .. } => {
+                ToolErrorClass::Internal(ErrorKind::Other)
+            }
+            _ => ToolErrorClass::Internal(ErrorKind::Internal),
         };
+        let message = err.to_string();
         Self {
-            kind,
-            message: err.to_string(),
+            class,
+            message,
+            source: Some(err),
         }
     }
 }
 
 pub(crate) type ToolResult<T> = Result<T, ToolError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn invalid_selector_is_input_but_formatting_failure_is_internal() {
+        let invalid_selector = ToolError::from(servo_fetch::Error::Extract(
+            servo_fetch::extract::ExtractError::InvalidSelector,
+        ));
+        assert_eq!(invalid_selector.kind(), ErrorKind::Internal);
+        assert!(!invalid_selector.is_internal());
+
+        let formatting = ToolError::from(servo_fetch::Error::Extract(servo_fetch::extract::ExtractError::Fmt(
+            std::fmt::Error,
+        )));
+        assert_eq!(formatting.kind(), ErrorKind::Internal);
+        assert!(formatting.is_internal());
+    }
+
+    #[test]
+    fn worker_unavailable_is_internal_with_legacy_other_kind() {
+        let error = ToolError::from(servo_fetch::Error::WorkerUnavailable {
+            source: std::io::Error::other("private worker transport detail").into(),
+        });
+
+        assert_eq!(error.kind(), ErrorKind::Other);
+        assert!(error.is_internal());
+    }
+
+    #[test]
+    fn servo_error_remains_in_source_chain() {
+        use std::error::Error as _;
+
+        let error = ToolError::from(servo_fetch::Error::WorkerUnavailable {
+            source: std::io::Error::other("worker transport failed").into(),
+        });
+        let source = error.source().expect("ToolError retains its servo-fetch source");
+
+        assert!(source.downcast_ref::<servo_fetch::Error>().is_some());
+        assert!(source.source().is_some());
+    }
+}

--- a/crates/servo-fetch-cli/src/tools/fetch.rs
+++ b/crates/servo-fetch-cli/src/tools/fetch.rs
@@ -51,6 +51,7 @@ pub(crate) struct BatchSpec<'a> {
 pub(crate) async fn batch_fetch_pages(spec: BatchSpec<'_>) -> ToolResult<Vec<(String, ToolResult<String>)>> {
     let mut set = JoinSet::new();
 
+    // Drain started `spawn_blocking` tasks, which cannot be aborted.
     for url in spec.urls {
         let permit = match fetch_semaphore().acquire().await {
             Ok(permit) => permit,
@@ -73,14 +74,13 @@ pub(crate) async fn batch_fetch_pages(spec: BatchSpec<'_>) -> ToolResult<Vec<(St
         });
     }
 
-    collect_batch_tasks(set, spec.urls.len()).await
+    collect_batch_tasks(set).await
 }
 
 async fn collect_batch_tasks(
     mut set: JoinSet<(String, ToolResult<String>)>,
-    capacity: usize,
 ) -> ToolResult<Vec<(String, ToolResult<String>)>> {
-    let mut results = Vec::with_capacity(capacity);
+    let mut results = Vec::with_capacity(set.len());
     while let Some(joined) = set.join_next().await {
         match joined {
             Ok(result) => results.push(result),
@@ -146,7 +146,7 @@ mod tests {
             panic!("intentional batch task panic");
         });
 
-        let mut collecting = Box::pin(collect_batch_tasks(set, 2));
+        let mut collecting = Box::pin(collect_batch_tasks(set));
         panicked_rx.await.expect("failing task panicked");
         assert!(
             tokio::time::timeout(Duration::from_millis(100), &mut collecting)

--- a/crates/servo-fetch-cli/src/tools/fetch.rs
+++ b/crates/servo-fetch-cli/src/tools/fetch.rs
@@ -48,11 +48,18 @@ pub(crate) struct BatchSpec<'a> {
     pub options: RequestOptions,
 }
 
-pub(crate) async fn batch_fetch_pages(spec: BatchSpec<'_>) -> Vec<(String, String)> {
+pub(crate) async fn batch_fetch_pages(spec: BatchSpec<'_>) -> ToolResult<Vec<(String, ToolResult<String>)>> {
     let mut set = JoinSet::new();
 
     for url in spec.urls {
-        let permit = fetch_semaphore().acquire().await.ok();
+        let permit = match fetch_semaphore().acquire().await {
+            Ok(permit) => permit,
+            Err(error) => {
+                let error = ToolError::internal(format!("fetch semaphore closed: {error}"));
+                set.shutdown().await;
+                return Err(error);
+            }
+        };
         let url = url.clone();
         let selector = spec.selector.map(String::from);
         let format = spec.format;
@@ -66,13 +73,25 @@ pub(crate) async fn batch_fetch_pages(spec: BatchSpec<'_>) -> Vec<(String, Strin
         });
     }
 
-    let mut results = Vec::with_capacity(spec.urls.len());
+    collect_batch_tasks(set, spec.urls.len()).await
+}
+
+async fn collect_batch_tasks(
+    mut set: JoinSet<(String, ToolResult<String>)>,
+    capacity: usize,
+) -> ToolResult<Vec<(String, ToolResult<String>)>> {
+    let mut results = Vec::with_capacity(capacity);
     while let Some(joined) = set.join_next().await {
-        if let Ok(pair) = joined {
-            results.push(pair);
+        match joined {
+            Ok(result) => results.push(result),
+            Err(error) => {
+                let error = ToolError::internal(format!("batch task failed: {error}"));
+                set.shutdown().await;
+                return Err(error);
+            }
         }
     }
-    results
+    Ok(results)
 }
 
 fn render_one(
@@ -82,16 +101,62 @@ fn render_one(
     max_len: usize,
     visibility: VisibilityPolicy,
     options: RequestOptions,
-) -> String {
-    let opts = match apply_options(content_options(url, format, visibility), options) {
-        Ok(opts) => opts,
-        Err(e) => return format!("[error] {e}"),
-    };
-    match servo_fetch::blocking::fetch(&opts) {
-        Ok(page) => match render_page(&page, url, format, selector) {
-            Ok(full) => paginate(&servo_fetch::sanitize::sanitize(&full), 0, max_len),
-            Err(e) => format!("[error] {e}"),
-        },
-        Err(e) => format!("[error] {e}"),
+) -> ToolResult<String> {
+    let opts = apply_options(content_options(url, format, visibility), options)?;
+    let page = servo_fetch::blocking::fetch(&opts).map_err(ToolError::from)?;
+    let full = render_page(&page, url, format, selector)?;
+    Ok(paginate(&servo_fetch::sanitize::sanitize(&full), 0, max_len))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Barrier};
+    use std::time::Duration;
+
+    use tokio::sync::oneshot;
+
+    use super::*;
+
+    struct PanicSignal(Option<oneshot::Sender<()>>);
+
+    impl Drop for PanicSignal {
+        fn drop(&mut self) {
+            if let Some(sender) = self.0.take() {
+                let _ = sender.send(());
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn batch_task_join_failure_waits_for_started_blocking_sibling() {
+        let start = Arc::new(Barrier::new(2));
+        let (panicked_tx, panicked_rx) = oneshot::channel();
+        let (release_tx, release_rx) = oneshot::channel();
+        let mut set = JoinSet::new();
+        let sibling_start = Arc::clone(&start);
+        set.spawn_blocking(move || {
+            sibling_start.wait();
+            release_rx.blocking_recv().expect("test releases blocking sibling");
+            ("blocked".to_string(), Ok("complete".to_string()))
+        });
+        let panic_start = Arc::clone(&start);
+        set.spawn_blocking(move || -> (String, ToolResult<String>) {
+            panic_start.wait();
+            let _signal = PanicSignal(Some(panicked_tx));
+            panic!("intentional batch task panic");
+        });
+
+        let mut collecting = Box::pin(collect_batch_tasks(set, 2));
+        panicked_rx.await.expect("failing task panicked");
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), &mut collecting)
+                .await
+                .is_err(),
+            "collector returned while a started blocking sibling was still running"
+        );
+
+        release_tx.send(()).expect("blocking sibling still running");
+        let error = collecting.await.expect_err("join failure must abort the batch");
+        assert!(error.is_internal());
     }
 }

--- a/crates/servo-fetch-cli/tests/mcp.rs
+++ b/crates/servo-fetch-cli/tests/mcp.rs
@@ -50,18 +50,42 @@ async fn initialize_returns_server_info() {
 }
 
 #[tokio::test]
-async fn list_tools_returns_expected_tools() {
+async fn list_tools_preserves_all_request_schemas() {
     let client = connect().await;
-    let tools = client.list_tools(None).await.unwrap();
+    let listed = client.list_tools(None).await.unwrap();
 
-    assert_eq!(tools.tools.len(), 6);
-    let names: Vec<&str> = tools.tools.iter().map(|t| t.name.as_ref()).collect();
-    assert!(names.contains(&"fetch"));
-    assert!(names.contains(&"batch_fetch"));
-    assert!(names.contains(&"screenshot"));
-    assert!(names.contains(&"execute_js"));
-    assert!(names.contains(&"crawl"));
-    assert!(names.contains(&"map"));
+    assert_eq!(listed.tools.len(), 6);
+    let expectations = [
+        ("fetch", &["url"][..], &["maxLength", "startIndex"][..]),
+        ("batch_fetch", &["urls"][..], &["maxLength", "settleMs"][..]),
+        ("screenshot", &["url"][..], &["fullPage", "userAgent"][..]),
+        ("execute_js", &["url", "expression"][..], &["settleMs"][..]),
+        ("crawl", &["url"][..], &["maxDepth", "delayMs", "maxLength"][..]),
+        ("map", &["url"][..], &["noFallback", "userAgent"][..]),
+    ];
+
+    for (name, required, properties) in expectations {
+        let tool = listed
+            .tools
+            .iter()
+            .find(|tool| tool.name == name)
+            .unwrap_or_else(|| panic!("missing {name} tool"));
+        let actual_required = tool.input_schema["required"]
+            .as_array()
+            .expect("schema required fields")
+            .iter()
+            .map(|field| field.as_str().expect("required field name"))
+            .collect::<std::collections::BTreeSet<_>>();
+        assert_eq!(
+            actual_required,
+            required.iter().copied().collect(),
+            "{name} required fields"
+        );
+        let actual_properties = tool.input_schema["properties"].as_object().expect("schema properties");
+        for property in properties {
+            assert!(actual_properties.contains_key(*property), "{name} missing {property}");
+        }
+    }
 }
 
 #[tokio::test]
@@ -71,6 +95,72 @@ async fn fetch_rejects_private_ip() {
         .call_tool(call_params("fetch", &serde_json::json!({"url": "http://127.0.0.1/"})))
         .await;
     assert_tool_error(result);
+}
+
+#[tokio::test]
+async fn unknown_tool_remains_invalid_params_protocol_error() {
+    let client = connect().await;
+    let error = client
+        .call_tool(call_params("unknown", &serde_json::json!({})))
+        .await
+        .expect_err("unknown tool should be a protocol error");
+
+    match error {
+        rmcp::ServiceError::McpError(error) => {
+            assert_eq!(error.code, rmcp::model::ErrorCode::INVALID_PARAMS);
+        }
+        other => panic!("expected MCP protocol error, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn malformed_arguments_for_all_tools_are_bounded_sanitized_tool_errors() {
+    let cases = [
+        ("fetch", serde_json::json!({"url": "https://example.com", "format": 1})),
+        (
+            "screenshot",
+            serde_json::json!({"url": "https://example.com", "fullPage": "yes"}),
+        ),
+        (
+            "execute_js",
+            serde_json::json!({"url": "https://example.com", "expression": 1}),
+        ),
+        ("batch_fetch", serde_json::json!({"urls": "https://example.com"})),
+        (
+            "crawl",
+            serde_json::json!({"url": "https://example.com", "limit": "many"}),
+        ),
+        (
+            "map",
+            serde_json::json!({"url": "https://example.com", "limit": "many"}),
+        ),
+    ];
+
+    let client = connect().await;
+    for (tool, arguments) in cases {
+        let result = client
+            .call_tool(call_params(tool, &arguments))
+            .await
+            .unwrap_or_else(|error| panic!("{tool} malformed arguments returned a protocol error: {error:?}"));
+        assert_eq!(result.is_error, Some(true), "{tool}");
+        assert!(serde_json::to_vec(&result).unwrap().len() <= 1_000_000, "{tool}");
+    }
+
+    let malformed = format!("bad\u{1b}[31mvisible{}", "x".repeat(1_100_000));
+    let result = client
+        .call_tool(call_params(
+            "fetch",
+            &serde_json::json!({"url": "https://example.com", "format": malformed}),
+        ))
+        .await
+        .expect("malformed fetch arguments should be an isError tool result");
+    let serialized = serde_json::to_vec(&result).unwrap();
+    let text = result.content[0].as_text().expect("text error block");
+    assert_eq!(result.is_error, Some(true));
+    assert!(serialized.len() <= 1_000_000);
+    assert!(!text.text.contains('\u{1b}'));
+    assert!(text.text.contains("visible"));
+    assert!(text.text.ends_with("<output truncated>"));
 }
 
 #[tokio::test]
@@ -149,6 +239,35 @@ async fn execute_js_returns_title() {
 }
 
 #[tokio::test]
+async fn batch_and_crawl_invalid_shared_options_remain_tool_errors() {
+    let cases = [
+        (
+            "batch_fetch",
+            serde_json::json!({
+                "urls": ["https://example.com"],
+                "headers": {"bad\nname": "value"}
+            }),
+        ),
+        (
+            "crawl",
+            serde_json::json!({
+                "url": "https://example.com",
+                "headers": {"bad\nname": "value"}
+            }),
+        ),
+    ];
+
+    let client = connect().await;
+    for (tool, arguments) in cases {
+        let result = client
+            .call_tool(call_params(tool, &arguments))
+            .await
+            .unwrap_or_else(|error| panic!("{tool} invalid input returned a protocol error: {error:?}"));
+        assert_eq!(result.is_error, Some(true), "{tool}");
+    }
+}
+
+#[tokio::test]
 async fn fetch_rejects_metadata_ip_in_pdf_probe() {
     let client = connect().await;
     let result = client
@@ -204,6 +323,41 @@ async fn crawl_rejects_file_scheme() {
         .call_tool(call_params("crawl", &serde_json::json!({"url": "file:///etc/passwd"})))
         .await;
     assert_tool_error(result);
+}
+
+#[tokio::test]
+#[ignore = "e2e: requires Servo engine"]
+async fn crawl_invalid_selector_is_a_tool_error() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/"))
+        .respond_with(mock_page("<html><body><p>content</p></body></html>"))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/robots.txt"))
+        .respond_with(ResponseTemplate::new(404))
+        .mount(&server)
+        .await;
+
+    let client = connect_loopback().await;
+    let result = client
+        .call_tool(call_params(
+            "crawl",
+            &serde_json::json!({
+                "url": server.uri(),
+                "selector": "[",
+                "limit": 1,
+                "delayMs": 0,
+                "timeout": 30
+            }),
+        ))
+        .await
+        .expect("invalid crawl selector should be a tool result");
+
+    assert_eq!(result.is_error, Some(true));
+    let text = result.content[0].as_text().expect("text error block");
+    assert!(text.text.contains("invalid CSS selector"));
 }
 
 #[tokio::test]

--- a/crates/servo-fetch-cli/tests/mcp.rs
+++ b/crates/servo-fetch-cli/tests/mcp.rs
@@ -50,7 +50,7 @@ async fn initialize_returns_server_info() {
 }
 
 #[tokio::test]
-async fn list_tools_preserves_all_request_schemas() {
+async fn list_tools_preserves_required_and_representative_camel_case_fields() {
     let client = connect().await;
     let listed = client.list_tools(None).await.unwrap();
 

--- a/crates/servo-fetch/src/crawl.rs
+++ b/crates/servo-fetch/src/crawl.rs
@@ -272,7 +272,7 @@ where
         move || crate::robots::RobotsRules::fetch(&seed, user_agent.as_deref(), &headers, timeout)
     })
     .await
-    .unwrap_or(RobotsPolicy::Unreachable);
+    .map_err(crate::worker::worker_error)?;
     run(plan, robots, &bridge::ServoFetcher, |event| {
         on_event(match event {
             CrawlRunEvent::Result(result) => CrawlSessionEvent::Result(CrawlResult::from_internal(result)),
@@ -483,7 +483,7 @@ pub(crate) async fn run(
 
     let concurrency = opts.concurrency.max(1);
 
-    loop {
+    let failure = 'crawl: loop {
         while in_flight.len() < concurrency && completed + in_flight.len() < opts.limit {
             let Some((url, depth)) = frontier.pop() else {
                 break;
@@ -495,16 +495,9 @@ pub(crate) async fn run(
         }
 
         let outcome = match in_flight.join_next().await {
-            None => break,
-            Some(Ok(o)) => o,
-            Some(Err(e)) if e.is_panic() => {
-                tracing::error!(err = %e, "crawl fetch task panicked");
-                continue;
-            }
-            Some(Err(e)) => {
-                tracing::warn!(err = %e, "crawl fetch task cancelled");
-                continue;
-            }
+            None => break None,
+            Some(Ok(outcome)) => outcome,
+            Some(Err(error)) => break Some(crate::worker::worker_error(error)),
         };
 
         let FetchOutcome {
@@ -516,7 +509,9 @@ pub(crate) async fn run(
         let page = match result {
             Ok(p) => p,
             Err(err) => {
-                on_event(CrawlRunEvent::Result(error_result(&url, depth, err, fetched_at)))?;
+                if let Err(error) = on_event(CrawlRunEvent::Result(error_result(&url, depth, err, fetched_at))) {
+                    break 'crawl Some(error);
+                }
                 completed += 1;
                 continue;
             }
@@ -530,13 +525,25 @@ pub(crate) async fn run(
         };
         match process_ok_fetch(&mut ctx, &url, depth, &page, budget_used, fetched_at) {
             event @ CrawlRunEvent::Result(_) => {
-                on_event(event)?;
+                if let Err(error) = on_event(event) {
+                    break 'crawl Some(error);
+                }
                 completed += 1;
             }
-            event @ CrawlRunEvent::Suppressed(_) => on_event(event)?,
+            event @ CrawlRunEvent::Suppressed(_) => {
+                if let Err(error) = on_event(event) {
+                    break 'crawl Some(error);
+                }
+            }
         }
+    };
+
+    if let Some(error) = failure {
+        in_flight.shutdown().await;
+        Err(error)
+    } else {
+        Ok(())
     }
-    Ok(())
 }
 
 fn spawn_fetch(
@@ -608,17 +615,18 @@ fn process_ok_fetch(
         .with_selector(ctx.opts.selector.as_deref());
 
     let content = if ctx.opts.json {
-        crate::extract::extract_article(&input)
-            .ok()
-            .and_then(|a| serde_json::to_string(&a).ok())
+        crate::extract::extract_article(&input).and_then(|article| serde_json::to_string(&article).map_err(Into::into))
     } else {
-        crate::extract::extract_text(&input).ok()
+        crate::extract::extract_text(&input)
+    };
+    let content = match content {
+        Ok(content) => content,
+        Err(error) => {
+            return CrawlRunEvent::Result(error_result(url, depth, error.into(), fetched_at));
+        }
     };
 
-    if content
-        .as_ref()
-        .is_some_and(|content| ctx.frontier.is_duplicate_content(content))
-    {
+    if ctx.frontier.is_duplicate_content(&content) {
         return CrawlRunEvent::Suppressed(SuppressedPage {
             url: url.to_string(),
             depth,
@@ -656,7 +664,7 @@ fn process_ok_fetch(
         depth,
         status: CrawlStatus::Ok,
         title,
-        content: content.map(|c| crate::sanitize::sanitize(&c).into_owned()),
+        content: Some(crate::sanitize::sanitize(&content).into_owned()),
         error: None,
         links_found,
         fetched_at,
@@ -687,7 +695,10 @@ fn error_result(url: &Url, depth: usize, error: crate::error::Error, fetched_at:
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
-    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::{Arc, Barrier, Mutex};
+
+    use tokio::sync::oneshot;
 
     use super::*;
 
@@ -772,6 +783,92 @@ mod tests {
         }
     }
 
+    struct PanicSignal(Option<oneshot::Sender<()>>);
+
+    impl Drop for PanicSignal {
+        fn drop(&mut self) {
+            if let Some(sender) = self.0.take() {
+                let _ = sender.send(());
+            }
+        }
+    }
+
+    struct ControlledFailureState {
+        start: Barrier,
+        panicked: Mutex<Option<oneshot::Sender<()>>>,
+        release: Mutex<Option<oneshot::Receiver<()>>>,
+        blocking_completed: AtomicBool,
+    }
+
+    #[derive(Clone)]
+    struct ControlledFailureFetcher(Arc<ControlledFailureState>);
+
+    impl PageFetcher for ControlledFailureFetcher {
+        fn fetch_page(&self, opts: bridge::FetchOptions<'_>) -> Result<bridge::ServoPage, bridge::EngineError> {
+            match Url::parse(opts.url).expect("test URL").path() {
+                "/" => Ok(bridge::ServoPage {
+                    html: page(&["/controlled", "/block"]),
+                    ..Default::default()
+                }),
+                "/block" => {
+                    self.0.start.wait();
+                    self.0
+                        .release
+                        .lock()
+                        .unwrap()
+                        .take()
+                        .expect("blocking task waits once")
+                        .blocking_recv()
+                        .expect("test releases blocking task");
+                    self.0.blocking_completed.store(true, Ordering::SeqCst);
+                    Ok(bridge::ServoPage {
+                        html: distinct_page("block"),
+                        ..Default::default()
+                    })
+                }
+                "/controlled" => {
+                    self.0.start.wait();
+                    let panicked = self.0.panicked.lock().unwrap().take();
+                    if panicked.is_some() {
+                        let _signal = PanicSignal(panicked);
+                        panic!("intentional crawl fetch panic");
+                    }
+                    Ok(bridge::ServoPage {
+                        html: distinct_page("controlled"),
+                        ..Default::default()
+                    })
+                }
+                path => panic!("unexpected test path {path}"),
+            }
+        }
+    }
+
+    fn controlled_fetcher(panicked: Option<oneshot::Sender<()>>) -> (ControlledFailureFetcher, oneshot::Sender<()>) {
+        let (release_tx, release) = oneshot::channel();
+        let fetcher = ControlledFailureFetcher(Arc::new(ControlledFailureState {
+            start: Barrier::new(2),
+            panicked: Mutex::new(panicked),
+            release: Mutex::new(Some(release)),
+            blocking_completed: AtomicBool::new(false),
+        }));
+        (fetcher, release_tx)
+    }
+
+    fn controlled_plan() -> CrawlPlan {
+        let mut plan = test_plan("https://example.com/");
+        plan.concurrency = 2;
+        plan
+    }
+
+    async fn assert_crawl_pending(crawling: &mut tokio::task::JoinHandle<crate::error::Result<()>>) {
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), crawling)
+                .await
+                .is_err(),
+            "crawl returned while a started blocking sibling was still running"
+        );
+    }
+
     fn page(links: &[&str]) -> String {
         use std::fmt::Write as _;
         let mut anchors = String::new();
@@ -842,19 +939,34 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn crawl_propagates_event_sink_failure() {
-        let root = "https://example.com/";
-        let fetcher = MockFetcher::new(&[(root, &page(&["/a"])), ("https://example.com/a", &distinct_page("a"))]);
-        let mut events = 0;
-        let error = run(test_plan(root), RobotsPolicy::Unavailable, &fetcher, |_| {
-            events += 1;
-            Err(crate::error::Error::engine("sink closed", None))
-        })
-        .await
-        .unwrap_err();
+    async fn crawl_event_sink_failure_waits_for_started_blocking_sibling() {
+        let (fetcher, release_tx) = controlled_fetcher(None);
+        let state = Arc::clone(&fetcher.0);
+        let (sink_tx, sink_rx) = oneshot::channel();
+        let mut sink_tx = Some(sink_tx);
+        let mut crawling = tokio::spawn(async move {
+            run(controlled_plan(), RobotsPolicy::Unavailable, &fetcher, |event| {
+                if matches!(event, CrawlRunEvent::Result(ref result) if result.url.ends_with("/controlled")) {
+                    sink_tx
+                        .take()
+                        .expect("one controlled event")
+                        .send(())
+                        .expect("test waits");
+                    Err(crate::error::Error::SessionCancelled)
+                } else {
+                    Ok(())
+                }
+            })
+            .await
+        });
 
-        assert_eq!(events, 1);
-        assert!(error.to_string().contains("sink closed"));
+        sink_rx.await.expect("sink failed after blocking sibling started");
+        assert_crawl_pending(&mut crawling).await;
+
+        release_tx.send(()).expect("blocking sibling still running");
+        let error = crawling.await.expect("crawl joins").expect_err("sink failure returned");
+        assert!(matches!(error, crate::error::Error::SessionCancelled));
+        assert!(state.blocking_completed.load(Ordering::SeqCst));
     }
 
     #[tokio::test]
@@ -879,6 +991,41 @@ mod tests {
             Some(crate::error::Error::Timeout { ref url, timeout })
                 if url == "https://example.com/" && timeout == Duration::from_secs(7)
         ));
+    }
+
+    #[tokio::test]
+    async fn crawl_preserves_invalid_selector_as_page_error() {
+        check(
+            &[("https://example.com/", &page(&[]))],
+            |o| o.selector = Some("[".to_string()),
+            |r| {
+                assert_eq!(r.len(), 1);
+                assert!(matches!(
+                    r[0].error,
+                    Some(crate::error::Error::Extract(
+                        crate::extract::ExtractError::InvalidSelector
+                    ))
+                ));
+            },
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn crawl_fetch_task_join_failure_waits_for_started_blocking_sibling() {
+        let (panicked_tx, panicked_rx) = oneshot::channel();
+        let (fetcher, release_tx) = controlled_fetcher(Some(panicked_tx));
+        let state = Arc::clone(&fetcher.0);
+        let mut crawling =
+            tokio::spawn(async move { run(controlled_plan(), RobotsPolicy::Unavailable, &fetcher, |_| Ok(())).await });
+
+        panicked_rx.await.expect("failing task panicked");
+        assert_crawl_pending(&mut crawling).await;
+
+        release_tx.send(()).expect("blocking sibling still running");
+        let error = crawling.await.expect("crawl joins").expect_err("join failure returned");
+        assert!(matches!(error, crate::error::Error::WorkerUnavailable { .. }));
+        assert!(state.blocking_completed.load(Ordering::SeqCst));
     }
 
     #[tokio::test]

--- a/crates/servo-fetch/src/crawl.rs
+++ b/crates/servo-fetch/src/crawl.rs
@@ -538,6 +538,7 @@ pub(crate) async fn run(
         }
     };
 
+    // Drain started `spawn_blocking` tasks, which cannot be aborted.
     if let Some(error) = failure {
         in_flight.shutdown().await;
         Err(error)


### PR DESCRIPTION
## Summary

- Return caller-correctable MCP failures as bounded, sanitized `isError` results while hiding internal details behind generic `-32603` errors.
- Preserve typed batch/crawl errors, drain in-flight blocking tasks on failure, and keep advertised schemas and HTTP/RPC contracts unchanged.

## Related issues

N/A

## Test Plan

- `cargo test-ci` — 546 passed
- `cargo test-e2e` — 22 passed

## Checklist

- [x] Ran `cargo +nightly fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
- [x] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed
- [x] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it