### PR TITLE
fix(tests): make Node E2E hermetic with a suite-scoped local server

### DIFF
--- a/bindings/node/test/e2e.test.ts
+++ b/bindings/node/test/e2e.test.ts
@@ -1,24 +1,28 @@
 import { describe, expect, it } from "vitest";
 
+import { useLocalServer } from "./helpers/local-server.js";
+
 const e2e = process.env.SERVO_FETCH_E2E === "1";
-const URL = process.env.SERVO_FETCH_TEST_URL ?? "https://example.com";
 
 describe.runIf(e2e)("real binary E2E", () => {
+  const server = useLocalServer();
+  const pageUrl = () => process.env.SERVO_FETCH_TEST_URL ?? server.url;
+
   it("reports a semver version", async () => {
     const { version } = await import("../src/index.js");
     expect(await version()).toMatch(/^\d+\.\d+\.\d+/);
   });
 
-  it("fetches a real URL and renders non-empty markdown", async () => {
+  it("fetches a page and renders non-empty markdown", async () => {
     const { fetch } = await import("../src/index.js");
-    const markdown = await fetch(URL);
+    const markdown = await fetch(pageUrl());
     expect(typeof markdown).toBe("string");
     expect(markdown.length).toBeGreaterThan(0);
   });
 
   it("crawl output still matches the CrawlResult type", async () => {
     const { crawlAll } = await import("../src/index.js");
-    const [first] = await crawlAll(URL, { limit: 1 });
+    const [first] = await crawlAll(pageUrl(), { limit: 1 });
     expect(first?.ok).toBe(true);
     if (first?.ok) {
       expect(typeof first.url).toBe("string");
@@ -43,7 +47,7 @@ describe.runIf(e2e)("real binary E2E", () => {
     const { Session } = await import("../src/index.js");
     const session = await Session.open();
     try {
-      const markdown = await session.fetch(URL);
+      const markdown = await session.fetch(pageUrl());
       expect(typeof markdown).toBe("string");
       expect(markdown.length).toBeGreaterThan(0);
     } finally {
@@ -58,7 +62,7 @@ describe.runIf(e2e)("real binary E2E", () => {
     await session.close();
     await session.close();
     expect(session.isClosed()).toBe(true);
-    const err = await session.fetch(URL).then(
+    const err = await session.fetch(pageUrl()).then(
       () => null,
       (e: unknown) => e,
     );
@@ -71,7 +75,7 @@ describe.runIf(e2e)("real binary E2E", () => {
     const { shutdown } = await import("../src/rpc-client.js");
     const stale = await Session.open();
     shutdown();
-    const err = await stale.fetch(URL).then(
+    const err = await stale.fetch(pageUrl()).then(
       () => null,
       (e: unknown) => e,
     );

--- a/bindings/node/test/helpers/local-server.ts
+++ b/bindings/node/test/helpers/local-server.ts
@@ -1,0 +1,50 @@
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { afterAll, beforeAll } from "vitest";
+
+const PAGE =
+  "<!doctype html><html>" +
+  '<head><meta charset="utf-8"><title>servo-fetch e2e</title></head>' +
+  "<body><h1>Hermetic fixture</h1><p>Served by the suite-scoped local test server.</p></body>" +
+  "</html>";
+
+export interface LocalServer {
+  /** Base URL of the suite-scoped local page, available once the suite starts. */
+  readonly url: string;
+}
+
+/** Serve a minimal valid page from 127.0.0.1 for the current suite. */
+export function useLocalServer(): LocalServer {
+  const ctx = { url: "" };
+  let server: Server | undefined;
+  let previousAllowPrivate: string | undefined;
+  beforeAll(async () => {
+    const created = createServer((_request, response) => {
+      response.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+      response.end(PAGE);
+    });
+    await new Promise<void>((resolve) => created.listen(0, "127.0.0.1", resolve));
+    server = created;
+    const { port } = created.address() as AddressInfo;
+    ctx.url = `http://127.0.0.1:${port}/`;
+    // The spawned CLI inherits this and lifts the SSRF loopback block for the suite.
+    previousAllowPrivate = process.env.SERVO_FETCH_ALLOW_PRIVATE;
+    process.env.SERVO_FETCH_ALLOW_PRIVATE = "1";
+  });
+  afterAll(async () => {
+    if (previousAllowPrivate === undefined) {
+      delete process.env.SERVO_FETCH_ALLOW_PRIVATE;
+    } else {
+      process.env.SERVO_FETCH_ALLOW_PRIVATE = previousAllowPrivate;
+    }
+    if (!server) {
+      return;
+    }
+    const listening = server;
+    listening.closeAllConnections();
+    await new Promise<void>((resolve, reject) => {
+      listening.close((error) => (error ? reject(error) : resolve()));
+    });
+  });
+  return ctx;
+}

--- a/bindings/node/vitest.config.ts
+++ b/bindings/node/vitest.config.ts
@@ -5,5 +5,6 @@ export default defineConfig({
     environment: "node",
     include: ["src/**/*.test.ts", "test/**/*.test.ts"],
     testTimeout: 20_000,
+    retry: process.env.CI ? 2 : 0,
   },
 });


### PR DESCRIPTION
## Summary

The Node E2E suite fetched `https://example.com` over the real internet as a merge gate. A single slow request from a shared GitHub runner exceeds the 20s vitest timeout.

## Test Plan

- `pnpm test`: all passed
- `SERVO_FETCH_E2E=1 SERVO_FETCH_BINARY_PATH=target/debug/servo-fetch pnpm run test:e2e`: all passed

## Checklist

- [ ] Ran `cargo +nightly fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
- [ ] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed
- [x] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it