### PR TITLE
refactor(tools): resolve request options once at the handler boundary

### DIFF
--- a/crates/servo-fetch-cli/src/mcp/server.rs
+++ b/crates/servo-fetch-cli/src/mcp/server.rs
@@ -277,7 +277,7 @@ async fn run_batch_fetch(p: BatchFetchRequest) -> Result<CallToolResult, tools::
         selector: p.selector.as_deref(),
         max_len,
         visibility: tools::visibility_policy(p.visibility),
-        options: p.options,
+        options: tools::ResolvedRequestOptions::try_from(p.options)?,
     })
     .await?;
     labeled_results(results)

--- a/crates/servo-fetch-cli/src/mcp/tools.rs
+++ b/crates/servo-fetch-cli/src/mcp/tools.rs
@@ -4,8 +4,9 @@ use rmcp::model::CallToolResult;
 
 use super::output::TextOutput;
 pub(super) use crate::tools::{
-    BatchSpec, CrawlSpec, MapSpec, ToolError, apply_options, batch_fetch_pages, build_map_options, content_options,
-    crawl_pages, fetch_with, map_with, paginate, render_page, validate_selector, validated_url, visibility_policy,
+    BatchSpec, CrawlSpec, MapSpec, ResolvedRequestOptions, ToolError, apply_options, batch_fetch_pages,
+    build_map_options, content_options, crawl_pages, fetch_with, map_with, paginate, render_page, validate_selector,
+    validated_url, visibility_policy,
 };
 
 /// Build an `isError` tool result carrying the failure message for the model to react to.

--- a/crates/servo-fetch-cli/src/serve/handlers.rs
+++ b/crates/servo-fetch-cli/src/serve/handlers.rs
@@ -104,7 +104,7 @@ pub(super) async fn batch_fetch(Json(req): Json<BatchFetchRequest>) -> Result<Ax
         selector: req.selector.as_deref(),
         max_len: to_len(req.max_length, DEFAULT_MAX_LENGTH),
         visibility: tools::visibility_policy(req.visibility),
-        options: req.options,
+        options: tools::ResolvedRequestOptions::try_from(req.options)?,
     })
     .await?;
     let results = raw.into_iter().map(flatten_page_result).collect();

--- a/crates/servo-fetch-cli/src/tools.rs
+++ b/crates/servo-fetch-cli/src/tools.rs
@@ -13,7 +13,7 @@ pub(crate) use error::ToolError;
 pub(crate) use fetch::{BatchSpec, batch_fetch_pages, fetch_with};
 pub(crate) use map::{MapSpec, build_map_options, map_with};
 pub(crate) use options::{
-    apply_options, build_headers, content_options, resolve_settle, resolve_timeout, validate_selector, validated_url,
-    visibility_policy,
+    ResolvedRequestOptions, apply_options, build_headers, content_options, resolve_settle, resolve_timeout,
+    validate_selector, validated_url, visibility_policy,
 };
 pub(crate) use render::{clamp_js_output, paginate, paginate_opt, render_page};

--- a/crates/servo-fetch-cli/src/tools/fetch.rs
+++ b/crates/servo-fetch-cli/src/tools/fetch.rs
@@ -3,12 +3,12 @@
 use std::sync::OnceLock;
 
 use servo_fetch::{FetchOptions, Page, VisibilityPolicy};
-use servo_fetch_types::{FetchFormat, RequestOptions};
+use servo_fetch_types::FetchFormat;
 use tokio::sync::Semaphore;
 use tokio::task::{JoinSet, spawn_blocking};
 
 use super::error::{ToolError, ToolResult};
-use super::options::{apply_options, content_options};
+use super::options::{ResolvedRequestOptions, content_options};
 use super::render::{paginate, render_page};
 
 const DEFAULT_MAX_CONCURRENT_FETCHES: usize = 4;
@@ -45,7 +45,7 @@ pub(crate) struct BatchSpec<'a> {
     pub selector: Option<&'a str>,
     pub max_len: usize,
     pub visibility: VisibilityPolicy,
-    pub options: RequestOptions,
+    pub options: ResolvedRequestOptions,
 }
 
 pub(crate) async fn batch_fetch_pages(spec: BatchSpec<'_>) -> ToolResult<Vec<(String, ToolResult<String>)>> {
@@ -65,11 +65,10 @@ pub(crate) async fn batch_fetch_pages(spec: BatchSpec<'_>) -> ToolResult<Vec<(St
         let selector = spec.selector.map(String::from);
         let format = spec.format;
         let max_len = spec.max_len;
-        let visibility = spec.visibility;
-        let options = spec.options.clone();
+        let opts = spec.options.apply(content_options(&url, format, spec.visibility));
         set.spawn_blocking(move || {
             let _permit = permit;
-            let text = render_one(&url, format, selector.as_deref(), max_len, visibility, options);
+            let text = render_one(&url, format, selector.as_deref(), max_len, &opts);
             (url, text)
         });
     }
@@ -99,11 +98,9 @@ fn render_one(
     format: FetchFormat,
     selector: Option<&str>,
     max_len: usize,
-    visibility: VisibilityPolicy,
-    options: RequestOptions,
+    opts: &FetchOptions,
 ) -> ToolResult<String> {
-    let opts = apply_options(content_options(url, format, visibility), options)?;
-    let page = servo_fetch::blocking::fetch(&opts).map_err(ToolError::from)?;
+    let page = servo_fetch::blocking::fetch(opts).map_err(ToolError::from)?;
     let full = render_page(&page, url, format, selector)?;
     Ok(paginate(&servo_fetch::sanitize::sanitize(&full), 0, max_len))
 }

--- a/crates/servo-fetch-cli/src/tools/options.rs
+++ b/crates/servo-fetch-cli/src/tools/options.rs
@@ -37,16 +37,56 @@ pub(crate) fn resolve_settle(ms: Option<u64>) -> Duration {
 
 /// Apply the common request options (timeout, settle, UA, cookies, headers).
 pub(crate) fn apply_options(opts: FetchOptions, options: RequestOptions) -> ToolResult<FetchOptions> {
-    let mut opts = opts
-        .timeout(resolve_timeout(options.timeout))
-        .settle(resolve_settle(options.settle_ms));
-    if let Some(ua) = options.user_agent {
-        opts = opts.user_agent(ua);
+    Ok(ResolvedRequestOptions::try_from(options)?.apply(opts))
+}
+
+/// Shared request settings resolved once per call and applied to every URL.
+#[derive(Clone, Debug)]
+pub(crate) struct ResolvedRequestOptions {
+    timeout: Duration,
+    settle: Duration,
+    user_agent: Option<String>,
+    cookies: Vec<CookieSpec>,
+    headers: HeaderMap,
+}
+
+impl TryFrom<RequestOptions> for ResolvedRequestOptions {
+    type Error = ToolError;
+
+    fn try_from(options: RequestOptions) -> ToolResult<Self> {
+        let RequestOptions {
+            timeout,
+            settle_ms,
+            user_agent,
+            cookies_file,
+            headers,
+        } = options;
+        Ok(Self {
+            timeout: resolve_timeout(timeout),
+            settle: resolve_settle(settle_ms),
+            user_agent,
+            cookies: match cookies_file {
+                Some(path) => load_cookies(&path)?,
+                None => Vec::new(),
+            },
+            headers: build_headers(headers)?,
+        })
     }
-    if let Some(path) = options.cookies_file {
-        opts = opts.cookies(load_cookies(&path)?);
+}
+
+impl ResolvedRequestOptions {
+    /// Apply the settings to one fetch.
+    pub(crate) fn apply(&self, opts: FetchOptions) -> FetchOptions {
+        let mut opts = opts
+            .timeout(self.timeout)
+            .settle(self.settle)
+            .cookies(self.cookies.clone())
+            .headers(self.headers.clone());
+        if let Some(user_agent) = &self.user_agent {
+            opts = opts.user_agent(user_agent.clone());
+        }
+        opts
     }
-    Ok(opts.headers(build_headers(options.headers)?))
 }
 
 /// Load and validate a Netscape-format cookies.txt file.
@@ -82,4 +122,50 @@ pub(crate) fn validate_selector(selector: Option<&str>) -> ToolResult<()> {
         )));
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write as _;
+
+    use tempfile::NamedTempFile;
+
+    use super::*;
+
+    #[test]
+    fn settings_resolve_every_shared_setting_once() {
+        let mut cookies = NamedTempFile::new().expect("cookie file");
+        writeln!(cookies, ".example.com\tTRUE\t/\tFALSE\t0\tsession\tsecret").expect("cookie fixture");
+        let mut headers = BTreeMap::new();
+        headers.insert("X-Test".to_string(), "kept".to_string());
+
+        let settings = ResolvedRequestOptions::try_from(RequestOptions {
+            timeout: Some(7),
+            settle_ms: Some(11),
+            user_agent: Some("test-agent".to_string()),
+            cookies_file: Some(cookies.path().to_string_lossy().into_owned()),
+            headers: Some(headers),
+        })
+        .expect("options are valid");
+
+        assert_eq!(settings.timeout, Duration::from_secs(7));
+        assert_eq!(settings.settle, Duration::from_millis(11));
+        assert_eq!(settings.user_agent.as_deref(), Some("test-agent"));
+        assert_eq!(settings.cookies.len(), 1);
+        assert_eq!(settings.headers["x-test"], "kept");
+    }
+
+    #[test]
+    fn settings_from_a_missing_cookie_file_fail() {
+        let error = ResolvedRequestOptions::try_from(RequestOptions {
+            timeout: None,
+            settle_ms: None,
+            user_agent: None,
+            cookies_file: Some("/nonexistent/cookies.txt".to_string()),
+            headers: None,
+        })
+        .unwrap_err();
+
+        assert!(error.to_string().contains("cookie"));
+    }
 }


### PR DESCRIPTION
## Summary

`batch_fetch` re-parsed the shared `RequestOptions` once per URL inside the worker loop: the cookies file was read from disk N times, headers were re-validated N times, and a config mistake (e.g. a broken cookies file) surfaced as N identical per-URL errors instead of one input error.

## Test Plan

- `cargo test-ci`: all passed
- `cargo test-doc`, `cargo test-e2e`: all passed

## Checklist

- [x] Ran `cargo +nightly fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
- [ ] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed
- [x] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it