### PR TITLE
feat(mcp): run page tools in cancellable one-use isolated workers

### DIFF
--- a/crates/servo-fetch-cli/README.md
+++ b/crates/servo-fetch-cli/README.md
@@ -133,6 +133,8 @@ servo-fetch mcp                # stdio transport (for AI agents)
 servo-fetch mcp --port 8080    # Streamable HTTP transport
 ```
 
+`fetch`, `screenshot`, and `execute_js` each run in a fresh worker; cookies and storage do not carry over between calls.
+
 ### HTTP API server
 
 ```bash

--- a/crates/servo-fetch-cli/src/mcp.rs
+++ b/crates/servo-fetch-cli/src/mcp.rs
@@ -1,5 +1,6 @@
 //! MCP server — exposes Servo's web rendering capabilities to AI agents.
 
+mod executor;
 mod output;
 mod server;
 mod tools;
@@ -12,6 +13,10 @@ use rmcp::transport::streamable_http_server::{StreamableHttpServerConfig, Stream
 
 /// Start the MCP server on stdio or Streamable HTTP transport.
 pub(crate) async fn run(port: Option<u16>) -> anyhow::Result<()> {
+    let broker = servo_fetch::SessionBrokerConfig::default()
+        .queue_capacity(servo_fetch::SessionBrokerConfig::MAX_QUEUE_CAPACITY);
+    servo_fetch::configure_default_broker(broker)?;
+    tokio::task::spawn_blocking(servo_fetch::initialize_default_broker).await??;
     if let Some(port) = port {
         run_http(port).await
     } else {

--- a/crates/servo-fetch-cli/src/mcp/executor.rs
+++ b/crates/servo-fetch-cli/src/mcp/executor.rs
@@ -1,0 +1,112 @@
+//! Cancellable one-use browser-session execution for MCP tools.
+
+use std::future::Future;
+use std::pin::pin;
+
+use servo_fetch::{BrowserSession, BrowserSessionConfig, FetchOptions, Page, SessionCancellation};
+use tokio_util::sync::CancellationToken;
+
+use crate::tools::{ToolError, ToolResult};
+
+/// Result of a tool operation the MCP client may cancel mid-flight.
+#[derive(Debug)]
+pub(super) enum Outcome<T> {
+    Completed(T),
+    Cancelled,
+}
+
+enum Raced<T> {
+    Finished(T),
+    Interrupted(T),
+}
+
+/// Await `future`; on cancellation, signal the session so `future` observes it and still runs to completion.
+async fn race<T>(
+    token: &CancellationToken,
+    cancellation: &SessionCancellation,
+    future: impl Future<Output = T>,
+) -> Raced<T> {
+    let mut future = pin!(future);
+    tokio::select! {
+        biased;
+        () = token.cancelled() => {
+            cancellation.cancel();
+            Raced::Interrupted(future.await)
+        }
+        output = &mut future => Raced::Finished(output),
+    }
+}
+
+/// Fetch in a fresh isolated session; cancellation kills the worker tree and always returns promptly.
+pub(super) async fn fetch_in_session(
+    config: BrowserSessionConfig,
+    options: FetchOptions,
+    token: &CancellationToken,
+) -> Outcome<ToolResult<Page>> {
+    if token.is_cancelled() {
+        return Outcome::Cancelled;
+    }
+    let cancellation = SessionCancellation::new();
+    let mut session = match race(
+        token,
+        &cancellation,
+        BrowserSession::new_with_cancellation(config, &cancellation),
+    )
+    .await
+    {
+        Raced::Finished(Ok(session)) => session,
+        Raced::Finished(Err(error)) => return Outcome::Completed(Err(error.into())),
+        Raced::Interrupted(started) => {
+            if let Ok(session) = started {
+                force_close(session).await;
+            }
+            return Outcome::Cancelled;
+        }
+    };
+    let result = match race(token, &cancellation, session.fetch(&options)).await {
+        Raced::Finished(result) => result.map_err(ToolError::from),
+        Raced::Interrupted(_) => {
+            force_close(session).await;
+            return Outcome::Cancelled;
+        }
+    };
+    match race(token, &cancellation, session.close()).await {
+        Raced::Finished(Ok(())) => Outcome::Completed(result),
+        Raced::Finished(Err(cleanup)) => Outcome::Completed(match result {
+            Ok(_) => Err(cleanup.into()),
+            Err(error) => {
+                tracing::warn!(%cleanup, "session cleanup failed after operation error");
+                Err(error)
+            }
+        }),
+        Raced::Interrupted(closed) => {
+            if let Err(error) = closed
+                && !matches!(error, servo_fetch::Error::SessionCancelled)
+            {
+                tracing::warn!(%error, "session cleanup failed after cancellation");
+            }
+            Outcome::Cancelled
+        }
+    }
+}
+
+async fn force_close(session: BrowserSession) {
+    if let Err(error) = session.force_close().await {
+        tracing::warn!(%error, "session cleanup failed after cancellation");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn cancellation_signals_the_session_before_draining_the_operation() {
+        let token = CancellationToken::new();
+        let cancellation = SessionCancellation::new();
+        token.cancel();
+
+        let raced = race(&token, &cancellation, async { cancellation.is_cancelled() }).await;
+        assert!(matches!(raced, Raced::Interrupted(true)));
+    }
+}

--- a/crates/servo-fetch-cli/src/mcp/server.rs
+++ b/crates/servo-fetch-cli/src/mcp/server.rs
@@ -6,15 +6,20 @@ use std::marker::PhantomData;
 use base64::Engine as _;
 use rmcp::handler::server::router::tool::ToolRouter;
 use rmcp::handler::server::wrapper::Parameters;
-use rmcp::model::{CallToolResult, ContentBlock, JsonObject, ProtocolVersion, ServerCapabilities, ServerInfo};
+use rmcp::model::{
+    CallToolResult, ContentBlock, ErrorCode, JsonObject, ProtocolVersion, ServerCapabilities, ServerInfo,
+};
 use rmcp::schemars::{JsonSchema, Schema, SchemaGenerator};
+use rmcp::service::{RequestContext, RoleServer};
 use rmcp::{ErrorData, ServerHandler, tool, tool_handler, tool_router};
 use serde::de::DeserializeOwned;
 use servo_fetch::FetchOptions;
 use servo_fetch_types::{
     BatchFetchRequest, CrawlRequest, EvaluateRequest, FetchRequest, MapRequest, ScreenshotRequest,
 };
+use tokio_util::sync::CancellationToken;
 
+use super::executor::{self, Outcome};
 use super::{output, tools};
 use crate::tools::limits::{CRAWL_LIMIT, DEFAULT_MAX_LENGTH, MAX_BATCH_URLS, MAX_JS_LEN, clamp_count, to_len};
 
@@ -53,7 +58,7 @@ async fn complete_decoded_tool_call<T, F, Fut>(
 where
     T: DeserializeOwned,
     F: FnOnce(T) -> Fut,
-    Fut: Future<Output = Result<CallToolResult, tools::ToolError>>,
+    Fut: Future<Output = Result<Outcome<CallToolResult>, tools::ToolError>>,
 {
     let request = serde_json::from_value(serde_json::Value::Object(arguments.value)).map_err(|error| {
         tools::ToolError::invalid_params(output::bounded_text(format_args!(
@@ -89,8 +94,12 @@ impl ServoFetchMcp {
             open_world_hint = true
         )
     )]
-    async fn fetch(&self, Parameters(p): Parameters<RawArguments<FetchRequest>>) -> Result<CallToolResult, ErrorData> {
-        complete_decoded_tool_call("fetch", p, run_fetch).await
+    async fn fetch(
+        &self,
+        ctx: RequestContext<RoleServer>,
+        Parameters(p): Parameters<RawArguments<FetchRequest>>,
+    ) -> Result<CallToolResult, ErrorData> {
+        complete_decoded_tool_call("fetch", p, |p| run_fetch(p, ctx.ct)).await
     }
 
     #[tool(
@@ -104,9 +113,10 @@ impl ServoFetchMcp {
     )]
     async fn screenshot(
         &self,
+        ctx: RequestContext<RoleServer>,
         Parameters(p): Parameters<RawArguments<ScreenshotRequest>>,
     ) -> Result<CallToolResult, ErrorData> {
-        complete_decoded_tool_call("screenshot", p, run_screenshot).await
+        complete_decoded_tool_call("screenshot", p, |p| run_screenshot(p, ctx.ct)).await
     }
 
     #[tool(
@@ -120,9 +130,10 @@ impl ServoFetchMcp {
     )]
     async fn execute_js(
         &self,
+        ctx: RequestContext<RoleServer>,
         Parameters(p): Parameters<RawArguments<EvaluateRequest>>,
     ) -> Result<CallToolResult, ErrorData> {
-        complete_decoded_tool_call("execute_js", p, run_execute_js).await
+        complete_decoded_tool_call("execute_js", p, |p| run_execute_js(p, ctx.ct)).await
     }
 
     #[tool(
@@ -138,7 +149,10 @@ impl ServoFetchMcp {
         &self,
         Parameters(p): Parameters<RawArguments<BatchFetchRequest>>,
     ) -> Result<CallToolResult, ErrorData> {
-        complete_decoded_tool_call("batch_fetch", p, run_batch_fetch).await
+        complete_decoded_tool_call("batch_fetch", p, |p| async {
+            run_batch_fetch(p).await.map(Outcome::Completed)
+        })
+        .await
     }
 
     #[tool(
@@ -151,7 +165,7 @@ impl ServoFetchMcp {
         )
     )]
     async fn crawl(&self, Parameters(p): Parameters<RawArguments<CrawlRequest>>) -> Result<CallToolResult, ErrorData> {
-        complete_decoded_tool_call("crawl", p, run_crawl).await
+        complete_decoded_tool_call("crawl", p, |p| async { run_crawl(p).await.map(Outcome::Completed) }).await
     }
 
     #[tool(
@@ -164,18 +178,22 @@ impl ServoFetchMcp {
         )
     )]
     async fn map(&self, Parameters(p): Parameters<RawArguments<MapRequest>>) -> Result<CallToolResult, ErrorData> {
-        complete_decoded_tool_call("map", p, run_map).await
+        complete_decoded_tool_call("map", p, |p| async { run_map(p).await.map(Outcome::Completed) }).await
     }
 }
 
 const INTERNAL_ERROR_MESSAGE: &str = "Internal server error";
 
+// LSP's RequestCancelled; rmcp discards responses to cancelled requests, so clients never observe it.
+const REQUEST_CANCELLED: ErrorCode = ErrorCode(-32800);
+
 fn complete_tool_call(
     tool: &'static str,
-    result: Result<CallToolResult, tools::ToolError>,
+    result: Result<Outcome<CallToolResult>, tools::ToolError>,
 ) -> Result<CallToolResult, ErrorData> {
     match result {
-        Ok(result) => Ok(result),
+        Ok(Outcome::Completed(result)) => Ok(result),
+        Ok(Outcome::Cancelled) => Err(ErrorData::new(REQUEST_CANCELLED, "request cancelled", None)),
         Err(error) if error.is_internal() => {
             tracing::error!(tool, kind = ?error.kind(), error = ?error, "MCP tool internal failure");
             Err(ErrorData::internal_error(INTERNAL_ERROR_MESSAGE, None))
@@ -202,13 +220,45 @@ fn labeled_results(
     Ok(output.finish())
 }
 
-async fn run_fetch(p: FetchRequest) -> Result<CallToolResult, tools::ToolError> {
+/// Sessions reject PDF URLs, so those stay on the one-shot engine path until session fetch absorbs the PDF probe.
+fn looks_like_pdf_url(url: &str) -> bool {
+    url::Url::parse(url).is_ok_and(|url| {
+        url.path()
+            .rsplit('/')
+            .next()
+            .and_then(|last| last.rsplit_once('.'))
+            .is_some_and(|(_, ext)| ext.eq_ignore_ascii_case("pdf"))
+    })
+}
+
+/// Fetch in a one-use isolated worker, surfacing client cancellation as an outcome.
+async fn isolated_fetch(
+    url: &str,
+    opts: FetchOptions,
+    options: servo_fetch_types::RequestOptions,
+    ct: &CancellationToken,
+) -> Result<Outcome<servo_fetch::Page>, tools::ToolError> {
+    let (config, opts) = tools::ResolvedRequestOptions::try_from(options)?.into_session(url, opts);
+    Ok(match executor::fetch_in_session(config, opts, ct).await {
+        Outcome::Completed(page) => Outcome::Completed(page?),
+        Outcome::Cancelled => Outcome::Cancelled,
+    })
+}
+
+async fn run_fetch(p: FetchRequest, ct: CancellationToken) -> Result<Outcome<CallToolResult>, tools::ToolError> {
     let max_length = output::effective_item_length(to_len(p.max_length, DEFAULT_MAX_LENGTH), 1);
     let url = tools::validated_url(&p.url)?;
     tools::validate_selector(p.selector.as_deref())?;
     let format = p.format.unwrap_or_default();
     let opts = tools::content_options(&url, format, tools::visibility_policy(p.visibility));
-    let page = tools::fetch_with(tools::apply_options(opts, p.options)?).await?;
+    let page = if looks_like_pdf_url(&url) {
+        tools::fetch_with(tools::apply_options(opts, p.options)?).await?
+    } else {
+        match isolated_fetch(&url, opts, p.options, &ct).await? {
+            Outcome::Completed(page) => page,
+            Outcome::Cancelled => return Ok(Outcome::Cancelled),
+        }
+    };
     let full = tools::render_page(&page, &url, format, p.selector.as_deref())?;
     let content = tools::paginate(
         &servo_fetch::sanitize::sanitize(&full),
@@ -217,24 +267,32 @@ async fn run_fetch(p: FetchRequest) -> Result<CallToolResult, tools::ToolError> 
     );
     let mut output = output::TextOutput::success();
     output.push(content);
-    Ok(output.finish())
+    Ok(Outcome::Completed(output.finish()))
 }
 
-async fn run_screenshot(p: ScreenshotRequest) -> Result<CallToolResult, tools::ToolError> {
+async fn run_screenshot(
+    p: ScreenshotRequest,
+    ct: CancellationToken,
+) -> Result<Outcome<CallToolResult>, tools::ToolError> {
     let url = tools::validated_url(&p.url)?;
     let opts = FetchOptions::screenshot(&url, p.full_page.unwrap_or(false));
-    let page = tools::fetch_with(tools::apply_options(opts, p.options)?).await?;
+    let Outcome::Completed(page) = isolated_fetch(&url, opts, p.options, &ct).await? else {
+        return Ok(Outcome::Cancelled);
+    };
     let png = page
         .screenshot_png()
         .ok_or_else(|| tools::ToolError::internal("screenshot capture failed"))?;
     output::checked_base64_length(png.len(), output::MAX_MCP_SCREENSHOT_BASE64_BYTES)?;
-    Ok(CallToolResult::success(vec![ContentBlock::image(
+    Ok(Outcome::Completed(CallToolResult::success(vec![ContentBlock::image(
         base64::engine::general_purpose::STANDARD.encode(png),
         "image/png",
-    )]))
+    )])))
 }
 
-async fn run_execute_js(p: EvaluateRequest) -> Result<CallToolResult, tools::ToolError> {
+async fn run_execute_js(
+    p: EvaluateRequest,
+    ct: CancellationToken,
+) -> Result<Outcome<CallToolResult>, tools::ToolError> {
     if p.expression.len() > MAX_JS_LEN {
         return Err(tools::ToolError::invalid_params(format!(
             "expression exceeds {MAX_JS_LEN} character limit"
@@ -242,7 +300,9 @@ async fn run_execute_js(p: EvaluateRequest) -> Result<CallToolResult, tools::Too
     }
     let url = tools::validated_url(&p.url)?;
     let opts = FetchOptions::javascript(&url, &p.expression);
-    let page = tools::fetch_with(tools::apply_options(opts, p.options)?).await?;
+    let Outcome::Completed(page) = isolated_fetch(&url, opts, p.options, &ct).await? else {
+        return Ok(Outcome::Cancelled);
+    };
     let result = output::javascript_text(
         page.js_result.as_deref().unwrap_or_default(),
         page.console_messages
@@ -251,7 +311,7 @@ async fn run_execute_js(p: EvaluateRequest) -> Result<CallToolResult, tools::Too
     );
     let mut output = output::TextOutput::success();
     output.push(result);
-    Ok(output.finish())
+    Ok(Outcome::Completed(output.finish()))
 }
 
 async fn run_batch_fetch(p: BatchFetchRequest) -> Result<CallToolResult, tools::ToolError> {
@@ -425,7 +485,7 @@ mod tests {
         let error = complete_tool_call("fetch", Err(tools::ToolError::from(failure)))
             .expect_err("internal failure should be a JSON-RPC error");
 
-        assert_eq!(error.code, rmcp::model::ErrorCode::INTERNAL_ERROR);
+        assert_eq!(error.code, ErrorCode::INTERNAL_ERROR);
         assert_eq!(error.message, INTERNAL_ERROR_MESSAGE);
         assert_eq!(error.data, None);
         assert!(!serde_json::to_string(&error).unwrap().contains(detail));

--- a/crates/servo-fetch-cli/src/tools.rs
+++ b/crates/servo-fetch-cli/src/tools.rs
@@ -9,7 +9,7 @@ mod options;
 mod render;
 
 pub(crate) use crawl::{CrawlSpec, build_crawl_options, crawl_pages};
-pub(crate) use error::ToolError;
+pub(crate) use error::{ToolError, ToolResult};
 pub(crate) use fetch::{BatchSpec, batch_fetch_pages, fetch_with};
 pub(crate) use map::{MapSpec, build_map_options, map_with};
 pub(crate) use options::{

--- a/crates/servo-fetch-cli/src/tools/options.rs
+++ b/crates/servo-fetch-cli/src/tools/options.rs
@@ -3,7 +3,7 @@
 use std::collections::BTreeMap;
 use std::time::Duration;
 
-use servo_fetch::{CookieSpec, FetchOptions, HeaderMap, VisibilityPolicy};
+use servo_fetch::{BrowserSessionConfig, CookieSpec, FetchOptions, HeaderMap, VisibilityPolicy};
 use servo_fetch_types::{FetchFormat, RequestOptions, Visibility};
 
 use super::error::{ToolError, ToolResult};
@@ -75,6 +75,21 @@ impl TryFrom<RequestOptions> for ResolvedRequestOptions {
 }
 
 impl ResolvedRequestOptions {
+    /// Split into one-use session identity (UA, cookies) and per-fetch settings.
+    pub(crate) fn into_session(self, url: &str, opts: FetchOptions) -> (BrowserSessionConfig, FetchOptions) {
+        let mut config = BrowserSessionConfig::new();
+        if let Some(user_agent) = self.user_agent {
+            config = config.user_agent(user_agent);
+        }
+        if !self.cookies.is_empty() {
+            config = config.cookies(url, self.cookies);
+        }
+        (
+            config,
+            opts.timeout(self.timeout).settle(self.settle).headers(self.headers),
+        )
+    }
+
     /// Apply the settings to one fetch.
     pub(crate) fn apply(&self, opts: FetchOptions) -> FetchOptions {
         let mut opts = opts

--- a/crates/servo-fetch-cli/tests/mcp.rs
+++ b/crates/servo-fetch-cli/tests/mcp.rs
@@ -3,7 +3,7 @@
 use rmcp::ServiceExt;
 use rmcp::transport::TokioChildProcess;
 use tokio::process::Command;
-use wiremock::matchers::{method, path};
+use wiremock::matchers::{header, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 mod common;
@@ -34,6 +34,43 @@ fn call_params(name: &str, args: &serde_json::Value) -> rmcp::model::CallToolReq
 fn assert_tool_error<E: std::fmt::Debug>(result: Result<rmcp::model::CallToolResult, E>) {
     let result = result.expect("expected an isError tool result, not a protocol error");
     assert_eq!(result.is_error, Some(true), "expected isError tool result");
+}
+
+/// Direct `__worker` children of the MCP server process.
+#[cfg(unix)]
+fn worker_children(server: u32) -> Vec<i32> {
+    let output = std::process::Command::new("pgrep")
+        .args(["-P", &server.to_string(), "-f", "__worker"])
+        .output()
+        .expect("inspect worker processes");
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter_map(|line| line.trim().parse().ok())
+        .collect()
+}
+
+/// Wait until the PID is fully gone (reaped, not merely killed), like the library session tests.
+#[cfg(unix)]
+async fn wait_for_exit(pid: i32) {
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(15);
+    loop {
+        // SAFETY: signal 0 only probes the PID captured from our own MCP server's child.
+        #[allow(unsafe_code)]
+        let alive = unsafe { libc::kill(pid, 0) } == 0;
+        if !alive {
+            assert_eq!(
+                std::io::Error::last_os_error().raw_os_error(),
+                Some(libc::ESRCH),
+                "probing worker {pid} must fail only because it no longer exists"
+            );
+            return;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "worker {pid} survived cancellation"
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
 }
 
 #[tokio::test]
@@ -454,4 +491,136 @@ async fn batch_fetch_returns_multiple_results() {
             .iter()
             .any(|text| text.starts_with(&format!("URL: {}/b", server.uri())))
     );
+}
+
+#[tokio::test]
+#[ignore = "e2e: requires Servo engine"]
+async fn fetch_session_applies_user_agent_and_seeded_cookie() {
+    use std::io::Write as _;
+
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/identity"))
+        .and(header("user-agent", "McpSessionIdentity/1.0"))
+        .and(header("cookie", "mcp_session=seeded"))
+        .respond_with(mock_page("<html><body>session identity applied</body></html>"))
+        .expect(1)
+        .mount(&server)
+        .await;
+    let mut cookies = tempfile::NamedTempFile::new().expect("cookie file");
+    writeln!(cookies, "127.0.0.1\tFALSE\t/\tFALSE\t0\tmcp_session\tseeded").expect("cookie fixture");
+
+    let client = connect_loopback().await;
+    let result = client
+        .call_tool(call_params(
+            "fetch",
+            &serde_json::json!({
+                "url": format!("{}/identity", server.uri()),
+                "format": "text",
+                "userAgent": "McpSessionIdentity/1.0",
+                "cookiesFile": cookies.path(),
+                "timeout": 30
+            }),
+        ))
+        .await
+        .expect("session fetch succeeds with configured identity");
+    let text = result.content[0].as_text().expect("text content");
+    assert!(text.text.contains("session identity applied"));
+}
+
+#[cfg(unix)]
+#[tokio::test]
+#[ignore = "e2e: requires Servo engine"]
+async fn cancelled_fetch_kills_its_worker_and_frees_the_slot() {
+    use std::time::Duration;
+
+    use rmcp::model::{CallToolRequest, ClientRequest};
+    use rmcp::service::PeerRequestOptions;
+
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/slow"))
+        .respond_with(mock_page("<html><body>slow</body></html>").set_delay(Duration::from_secs(30)))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/fast"))
+        .respond_with(mock_page("<html><body>fast page</body></html>"))
+        .mount(&server)
+        .await;
+
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_servo-fetch"));
+    cmd.args(["mcp", "--allow-private-addresses"])
+        .env("SERVO_FETCH_MAX_WORKERS", "1")
+        .env("SERVO_FETCH_PREWARM", "0");
+    let transport = TokioChildProcess::new(cmd).unwrap();
+    let server_pid = transport.id().expect("MCP server pid");
+    let client = ().serve(transport).await.expect("MCP handshake failed");
+
+    let fetch = |path: &str| {
+        call_params(
+            "fetch",
+            &serde_json::json!({"url": format!("{}/{path}", server.uri()), "format": "text", "timeout": 30}),
+        )
+    };
+    let slow = client
+        .peer()
+        .send_cancellable_request(
+            ClientRequest::CallToolRequest(CallToolRequest::new(fetch("slow"))),
+            PeerRequestOptions::no_options(),
+        )
+        .await
+        .expect("start slow fetch");
+    tokio::time::timeout(Duration::from_secs(15), async {
+        while !server
+            .received_requests()
+            .await
+            .is_some_and(|requests| requests.iter().any(|request| request.url.path() == "/slow"))
+        {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    })
+    .await
+    .expect("the worker navigates to the slow page before cancellation");
+    let worker = match worker_children(server_pid).as_slice() {
+        [worker] => *worker,
+        workers => panic!("expected exactly one in-flight worker, found {workers:?}"),
+    };
+
+    slow.cancel(None).await.expect("send cancellation");
+    wait_for_exit(worker).await;
+
+    let result = tokio::time::timeout(Duration::from_secs(15), client.call_tool(fetch("fast")))
+        .await
+        .expect("freed slot admits the follow-up fetch")
+        .expect("follow-up fetch succeeds");
+    let text = result.content[0].as_text().expect("text content");
+    assert!(text.text.contains("fast page"));
+}
+
+#[tokio::test]
+#[ignore = "e2e: requires Servo engine"]
+async fn pdf_suffix_serving_html_still_renders_through_the_one_shot_path() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/report.pdf"))
+        .respond_with(mock_page("<html><body>rendered fallback</body></html>"))
+        .mount(&server)
+        .await;
+
+    let client = connect_loopback().await;
+    let result = client
+        .call_tool(call_params(
+            "fetch",
+            &serde_json::json!({"url": format!("{}/report.pdf", server.uri()), "format": "text", "timeout": 30}),
+        ))
+        .await
+        .expect("PDF-suffixed URL is fetched");
+    assert_ne!(
+        result.is_error,
+        Some(true),
+        "PDF URLs must not be rejected by the session path"
+    );
+    let text = result.content[0].as_text().expect("text content");
+    assert!(text.text.contains("rendered fallback"));
 }

--- a/crates/servo-fetch/src/lib.rs
+++ b/crates/servo-fetch/src/lib.rs
@@ -52,7 +52,7 @@ pub use map::{MapOptions, MappedUrl, map};
 pub use net::{NetworkPolicy, validate_url};
 pub use session::{
     BrowserSession, BrowserSessionConfig, SessionBroker, SessionBrokerConfig, SessionCancellation, WorkerCommand,
-    configure_default_broker, set_default_worker_command,
+    configure_default_broker, initialize_default_broker, set_default_worker_command,
 };
 pub use visibility::{VisibilityFlags, VisibilityPolicy};
 #[doc(hidden)]

--- a/crates/servo-fetch/src/session.rs
+++ b/crates/servo-fetch/src/session.rs
@@ -21,7 +21,6 @@ use crate::worker::wire::{CrawlWire, FetchWire, MAX_WIRE_CRAWL_CONCURRENCY, MAX_
 use crate::worker::worker_error;
 use crate::{CrawlOptions, CrawlResult, NetworkPolicy};
 const MAX_SESSIONS: usize = 64;
-const MAX_QUEUE_CAPACITY: usize = 1024;
 const MAX_ACQUIRE_TIMEOUT: Duration = Duration::from_secs(3600);
 
 #[cfg(test)]
@@ -120,6 +119,11 @@ pub fn configure_default_broker(mut config: SessionBrokerConfig) -> Result<()> {
         .map_err(|_| worker_error("default session broker is already configured"))
 }
 
+/// Initialize the process-wide broker now (including prewarm) instead of on the first session.
+pub fn initialize_default_broker() -> Result<()> {
+    default_broker().map(|_| ())
+}
+
 /// Capacity and startup policy for a [`SessionBroker`].
 #[derive(Debug, Clone)]
 #[non_exhaustive]
@@ -137,6 +141,9 @@ pub struct SessionBrokerConfig {
 }
 
 impl SessionBrokerConfig {
+    /// Upper bound on callers allowed to wait for a session slot.
+    pub const MAX_QUEUE_CAPACITY: usize = 1024;
+
     /// Set the maximum number of simultaneously-live sessions.
     #[must_use]
     pub fn max_sessions(mut self, max_sessions: usize) -> Self {
@@ -176,7 +183,7 @@ impl SessionBrokerConfig {
         if self.max_sessions == 0 || self.max_sessions > MAX_SESSIONS {
             return Err(invalid_config("max_sessions must be between 1 and 64"));
         }
-        if self.queue_capacity > MAX_QUEUE_CAPACITY {
+        if self.queue_capacity > Self::MAX_QUEUE_CAPACITY {
             return Err(invalid_config("queue_capacity must not exceed 1024"));
         }
         if self.prewarm > self.max_sessions {
@@ -199,7 +206,7 @@ impl Default for SessionBrokerConfig {
             .clamp(1, MAX_SESSIONS);
         let queue_capacity = env_usize("SERVO_FETCH_SESSION_QUEUE")
             .unwrap_or_else(|| max_sessions.saturating_mul(2))
-            .min(MAX_QUEUE_CAPACITY);
+            .min(Self::MAX_QUEUE_CAPACITY);
         let prewarm = env_usize("SERVO_FETCH_PREWARM").unwrap_or(0).min(max_sessions);
         let acquire_timeout = Duration::from_secs(
             env_usize("SERVO_FETCH_ACQUIRE_TIMEOUT_SECS")


### PR DESCRIPTION
## Summary

The MCP `fetch`, `screenshot`, and `execute_js` tools ran on the shared warm engine, so state could carry over between calls and cancelling a request only made rmcp drop the response while the fetch kept running.

## Test Plan

- `cargo test-ci`: all passed
- `cargo test-e2e`: all passed

## Checklist

- [x] Ran `cargo +nightly fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
- [x] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed
- [x] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it