### PR TITLE
fix(tests): abort the session fetch only once the slow navigation arrives

### DIFF
--- a/crates/servo-fetch-cli/tests/session.rs
+++ b/crates/servo-fetch-cli/tests/session.rs
@@ -1,13 +1,17 @@
 //! Strong logical browser-session isolation, capacity, and cancellation E2E tests.
 
-use std::sync::Once;
+use std::sync::{Arc, Once};
 use std::time::Duration;
 
 use servo_fetch::{
     BrowserSessionConfig, FetchOptions, NetworkPolicy, SessionBroker, SessionBrokerConfig, WorkerCommand,
 };
+use tokio::sync::Notify;
 use wiremock::matchers::{method, path};
-use wiremock::{Mock, MockServer, ResponseTemplate};
+use wiremock::{Mock, MockServer};
+
+mod common;
+use common::mock_page;
 
 static INIT: Once = Once::new();
 
@@ -22,17 +26,10 @@ fn broker(max_sessions: usize, queue_capacity: usize) -> SessionBroker {
     SessionBroker::new(config).expect("broker starts")
 }
 
-async fn page(server: &MockServer, path_name: &str, delay: Option<Duration>) {
-    let mut response = ResponseTemplate::new(200).set_body_raw(
-        b"<!doctype html><html><body>session test</body></html>".to_vec(),
-        "text/html; charset=utf-8",
-    );
-    if let Some(delay) = delay {
-        response = response.set_delay(delay);
-    }
+async fn page(server: &MockServer, path_name: &str) {
     Mock::given(method("GET"))
         .and(path(path_name))
-        .respond_with(response)
+        .respond_with(mock_page("<!doctype html><html><body>session test</body></html>"))
         .mount(server)
         .await;
 }
@@ -41,7 +38,7 @@ async fn page(server: &MockServer, path_name: &str, delay: Option<Duration>) {
 #[ignore = "e2e: requires Servo engine"]
 async fn logical_sessions_isolate_cookie_state() {
     let server = MockServer::start().await;
-    page(&server, "/", None).await;
+    page(&server, "/").await;
     let broker = broker(2, 2);
 
     let mut first = broker.session(BrowserSessionConfig::new()).await.unwrap();
@@ -80,7 +77,18 @@ async fn logical_sessions_isolate_cookie_state() {
 #[ignore = "e2e: requires Servo engine"]
 async fn cancelling_fetch_kills_worker_and_releases_capacity() {
     let server = MockServer::start().await;
-    page(&server, "/slow", Some(Duration::from_secs(10))).await;
+    let navigated = Arc::new(Notify::new());
+    Mock::given(method("GET"))
+        .and(path("/slow"))
+        .respond_with({
+            let navigated = Arc::clone(&navigated);
+            move |_: &wiremock::Request| {
+                navigated.notify_one();
+                mock_page("<!doctype html><html><body>slow</body></html>").set_delay(Duration::from_secs(10))
+            }
+        })
+        .mount(&server)
+        .await;
     let broker = broker(1, 1);
     let url = format!("{}/slow", server.uri());
     let task_broker = broker.clone();
@@ -91,7 +99,9 @@ async fn cancelling_fetch_kills_worker_and_releases_capacity() {
             .fetch(&FetchOptions::new(&url).timeout(Duration::from_secs(30)))
             .await
     });
-    tokio::time::sleep(Duration::from_millis(300)).await;
+    tokio::time::timeout(Duration::from_secs(15), navigated.notified())
+        .await
+        .expect("the worker navigates to the slow page before cancellation");
     task.abort();
     let _ = task.await;
 


### PR DESCRIPTION
## Summary

`cancelling_fetch_kills_worker_and_releases_capacity` aborted the fetch task after a fixed `sleep(300ms)`. That never failed, but on a slow runner the abort could land during session startup instead of mid-fetch, so the test passed without exercising the behavior in its name.

## Test Plan

- `cargo test-e2e`: all passed

## Checklist

- [x] Ran `cargo +nightly fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
- [ ] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed
- [x] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it