### PR TITLE
feat(mcp): make every page tool cancellable in isolated workers

### DIFF
--- a/crates/servo-fetch-cli/README.md
+++ b/crates/servo-fetch-cli/README.md
@@ -133,7 +133,7 @@ servo-fetch mcp                # stdio transport (for AI agents)
 servo-fetch mcp --port 8080    # Streamable HTTP transport
 ```
 
-`fetch`, `screenshot`, and `execute_js` each run in a fresh worker; cookies and storage do not carry over between calls.
+Page tools (`fetch`, `batch_fetch`, `crawl`, `screenshot`, `execute_js`) run in fresh workers; cookies and storage do not carry over between calls.
 
 ### HTTP API server
 

--- a/crates/servo-fetch-cli/src/mcp.rs
+++ b/crates/servo-fetch-cli/src/mcp.rs
@@ -15,17 +15,18 @@ use rmcp::transport::streamable_http_server::{StreamableHttpServerConfig, Stream
 pub(crate) async fn run(port: Option<u16>) -> anyhow::Result<()> {
     let broker = servo_fetch::SessionBrokerConfig::default()
         .queue_capacity(servo_fetch::SessionBrokerConfig::MAX_QUEUE_CAPACITY);
+    let session_capacity = broker.session_capacity();
     servo_fetch::configure_default_broker(broker)?;
     tokio::task::spawn_blocking(servo_fetch::initialize_default_broker).await??;
     if let Some(port) = port {
-        run_http(port).await
+        run_http(port, session_capacity).await
     } else {
-        run_stdio().await
+        run_stdio(session_capacity).await
     }
 }
 
-async fn run_stdio() -> anyhow::Result<()> {
-    let service = server::ServoFetchMcp::new()
+async fn run_stdio(session_capacity: usize) -> anyhow::Result<()> {
+    let service = server::ServoFetchMcp::new(session_capacity)
         .serve(rmcp::transport::stdio())
         .await
         .map_err(|e| anyhow::anyhow!("MCP server failed to start: {e}"))?;
@@ -36,9 +37,9 @@ async fn run_stdio() -> anyhow::Result<()> {
     Ok(())
 }
 
-async fn run_http(port: u16) -> anyhow::Result<()> {
+async fn run_http(port: u16, session_capacity: usize) -> anyhow::Result<()> {
     let service = StreamableHttpService::new(
-        || Ok(server::ServoFetchMcp::new()),
+        move || Ok(server::ServoFetchMcp::new(session_capacity)),
         LocalSessionManager::default().into(),
         StreamableHttpServerConfig::default(),
     );

--- a/crates/servo-fetch-cli/src/mcp/executor.rs
+++ b/crates/servo-fetch-cli/src/mcp/executor.rs
@@ -3,7 +3,10 @@
 use std::future::Future;
 use std::pin::pin;
 
-use servo_fetch::{BrowserSession, BrowserSessionConfig, FetchOptions, Page, SessionCancellation};
+use futures_util::{StreamExt as _, stream};
+use servo_fetch::{
+    BrowserSession, BrowserSessionConfig, CrawlOptions, CrawlResult, FetchOptions, Page, SessionCancellation,
+};
 use tokio_util::sync::CancellationToken;
 
 use crate::tools::{ToolError, ToolResult};
@@ -37,12 +40,51 @@ async fn race<T>(
     }
 }
 
-/// Fetch in a fresh isolated session; cancellation kills the worker tree and always returns promptly.
+/// Fetch in a fresh isolated session.
 pub(super) async fn fetch_in_session(
     config: BrowserSessionConfig,
     options: FetchOptions,
     token: &CancellationToken,
 ) -> Outcome<ToolResult<Page>> {
+    in_session(config, token, async |session| session.fetch(&options).await).await
+}
+
+/// Crawl in a fresh isolated session.
+pub(super) async fn crawl_in_session(
+    config: BrowserSessionConfig,
+    options: CrawlOptions,
+    token: &CancellationToken,
+) -> Outcome<ToolResult<Vec<CrawlResult>>> {
+    in_session(config, token, async |session| session.crawl(&options).await).await
+}
+
+/// Fetch each URL in its own session, at most `concurrency` at a time, yielding in completion order.
+pub(super) async fn batch_fetch_in_sessions(
+    jobs: Vec<(String, BrowserSessionConfig, FetchOptions)>,
+    concurrency: usize,
+    token: &CancellationToken,
+) -> Outcome<Vec<(String, ToolResult<Page>)>> {
+    let results: Vec<_> = stream::iter(jobs)
+        .map(|(url, config, options)| async move { (url, fetch_in_session(config, options, token).await) })
+        .buffer_unordered(concurrency.max(1))
+        .collect()
+        .await;
+    let mut pages = Vec::with_capacity(results.len());
+    for (url, outcome) in results {
+        match outcome {
+            Outcome::Completed(page) => pages.push((url, page)),
+            Outcome::Cancelled => return Outcome::Cancelled,
+        }
+    }
+    Outcome::Completed(pages)
+}
+
+/// Run one operation in a fresh isolated session; cancellation kills the worker tree and always returns promptly.
+async fn in_session<T>(
+    config: BrowserSessionConfig,
+    token: &CancellationToken,
+    operation: impl AsyncFnOnce(&mut BrowserSession) -> servo_fetch::Result<T>,
+) -> Outcome<ToolResult<T>> {
     if token.is_cancelled() {
         return Outcome::Cancelled;
     }
@@ -63,7 +105,7 @@ pub(super) async fn fetch_in_session(
             return Outcome::Cancelled;
         }
     };
-    let result = match race(token, &cancellation, session.fetch(&options)).await {
+    let result = match race(token, &cancellation, operation(&mut session)).await {
         Raced::Finished(result) => result.map_err(ToolError::from),
         Raced::Interrupted(_) => {
             force_close(session).await;

--- a/crates/servo-fetch-cli/src/mcp/server.rs
+++ b/crates/servo-fetch-cli/src/mcp/server.rs
@@ -75,13 +75,15 @@ where
 pub(crate) struct ServoFetchMcp {
     #[allow(dead_code)]
     tool_router: ToolRouter<Self>,
+    session_capacity: usize,
 }
 
 #[tool_router]
 impl ServoFetchMcp {
-    pub(crate) fn new() -> Self {
+    pub(crate) fn new(session_capacity: usize) -> Self {
         Self {
             tool_router: Self::tool_router(),
+            session_capacity,
         }
     }
 
@@ -147,12 +149,10 @@ impl ServoFetchMcp {
     )]
     async fn batch_fetch(
         &self,
+        ctx: RequestContext<RoleServer>,
         Parameters(p): Parameters<RawArguments<BatchFetchRequest>>,
     ) -> Result<CallToolResult, ErrorData> {
-        complete_decoded_tool_call("batch_fetch", p, |p| async {
-            run_batch_fetch(p).await.map(Outcome::Completed)
-        })
-        .await
+        complete_decoded_tool_call("batch_fetch", p, |p| run_batch_fetch(p, self.session_capacity, ctx.ct)).await
     }
 
     #[tool(
@@ -164,8 +164,12 @@ impl ServoFetchMcp {
             open_world_hint = true
         )
     )]
-    async fn crawl(&self, Parameters(p): Parameters<RawArguments<CrawlRequest>>) -> Result<CallToolResult, ErrorData> {
-        complete_decoded_tool_call("crawl", p, |p| async { run_crawl(p).await.map(Outcome::Completed) }).await
+    async fn crawl(
+        &self,
+        ctx: RequestContext<RoleServer>,
+        Parameters(p): Parameters<RawArguments<CrawlRequest>>,
+    ) -> Result<CallToolResult, ErrorData> {
+        complete_decoded_tool_call("crawl", p, |p| run_crawl(p, ctx.ct)).await
     }
 
     #[tool(
@@ -177,8 +181,12 @@ impl ServoFetchMcp {
             open_world_hint = true
         )
     )]
-    async fn map(&self, Parameters(p): Parameters<RawArguments<MapRequest>>) -> Result<CallToolResult, ErrorData> {
-        complete_decoded_tool_call("map", p, |p| async { run_map(p).await.map(Outcome::Completed) }).await
+    async fn map(
+        &self,
+        ctx: RequestContext<RoleServer>,
+        Parameters(p): Parameters<RawArguments<MapRequest>>,
+    ) -> Result<CallToolResult, ErrorData> {
+        complete_decoded_tool_call("map", p, |p| run_map(p, ctx.ct)).await
     }
 }
 
@@ -259,12 +267,14 @@ async fn run_fetch(p: FetchRequest, ct: CancellationToken) -> Result<Outcome<Cal
             Outcome::Cancelled => return Ok(Outcome::Cancelled),
         }
     };
-    let full = tools::render_page(&page, &url, format, p.selector.as_deref())?;
-    let content = tools::paginate(
-        &servo_fetch::sanitize::sanitize(&full),
+    let content = tools::page_text(
+        &page,
+        &url,
+        format,
+        p.selector.as_deref(),
         to_len(p.start_index, 0),
         max_length,
-    );
+    )?;
     let mut output = output::TextOutput::success();
     output.push(content);
     Ok(Outcome::Completed(output.finish()))
@@ -314,7 +324,11 @@ async fn run_execute_js(
     Ok(Outcome::Completed(output.finish()))
 }
 
-async fn run_batch_fetch(p: BatchFetchRequest) -> Result<CallToolResult, tools::ToolError> {
+async fn run_batch_fetch(
+    p: BatchFetchRequest,
+    session_capacity: usize,
+    ct: CancellationToken,
+) -> Result<Outcome<CallToolResult>, tools::ToolError> {
     let requested_max_length = to_len(p.max_length, DEFAULT_MAX_LENGTH);
     if p.urls.is_empty() {
         return Err(tools::ToolError::invalid_params("urls must not be empty"));
@@ -326,49 +340,70 @@ async fn run_batch_fetch(p: BatchFetchRequest) -> Result<CallToolResult, tools::
     }
     tools::validate_selector(p.selector.as_deref())?;
     let max_len = output::effective_item_length(requested_max_length, p.urls.len());
-    let validated: Vec<String> = p
+    let format = p.format.unwrap_or_default();
+    let visibility = tools::visibility_policy(p.visibility);
+    let options = tools::ResolvedRequestOptions::try_from(p.options)?;
+    let jobs = p
         .urls
         .iter()
-        .map(|u| tools::validated_url(u))
-        .collect::<Result<_, _>>()?;
-    let results = tools::batch_fetch_pages(tools::BatchSpec {
-        urls: &validated,
-        format: p.format.unwrap_or_default(),
-        selector: p.selector.as_deref(),
-        max_len,
-        visibility: tools::visibility_policy(p.visibility),
-        options: tools::ResolvedRequestOptions::try_from(p.options)?,
-    })
-    .await?;
-    labeled_results(results)
+        .map(|u| {
+            let url = tools::validated_url(u)?;
+            let opts = tools::content_options(&url, format, visibility);
+            let (config, opts) = options.clone().into_session(&url, opts);
+            Ok((url, config, opts))
+        })
+        .collect::<Result<Vec<_>, tools::ToolError>>()?;
+    let Outcome::Completed(pages) = executor::batch_fetch_in_sessions(jobs, session_capacity, &ct).await else {
+        return Ok(Outcome::Cancelled);
+    };
+    let selector = p.selector.as_deref();
+    let results = pages
+        .into_iter()
+        .map(|(url, page)| {
+            let text = page.and_then(|page| tools::page_text(&page, &url, format, selector, 0, max_len));
+            (url, text)
+        })
+        .collect();
+    labeled_results(results).map(Outcome::Completed)
 }
 
-async fn run_crawl(p: CrawlRequest) -> Result<CallToolResult, tools::ToolError> {
+async fn run_crawl(p: CrawlRequest, ct: CancellationToken) -> Result<Outcome<CallToolResult>, tools::ToolError> {
     let requested_max_length = to_len(p.max_length, DEFAULT_MAX_LENGTH);
     let page_limit = clamp_count(p.limit, CRAWL_LIMIT);
     let max_len = output::effective_item_length(requested_max_length, page_limit);
     let url = tools::validated_url(&p.url)?;
     tools::validate_selector(p.selector.as_deref())?;
-    let results = tools::crawl_pages(
-        tools::CrawlSpec {
-            url: &url,
-            limit: p.limit,
-            max_depth: p.max_depth,
-            format: p.format.unwrap_or_default(),
-            selector: p.selector.as_deref(),
-            include: p.include.as_deref(),
-            exclude: p.exclude.as_deref(),
-            concurrency: p.concurrency,
-            delay_ms: p.delay_ms,
-            options: p.options,
-        },
-        max_len,
-    )
-    .await?;
-    labeled_results(results)
+    let spec = tools::CrawlSpec {
+        url: &url,
+        limit: p.limit,
+        max_depth: p.max_depth,
+        format: p.format.unwrap_or_default(),
+        selector: p.selector.as_deref(),
+        include: p.include.as_deref(),
+        exclude: p.exclude.as_deref(),
+        concurrency: p.concurrency,
+        delay_ms: p.delay_ms,
+        options: tools::ResolvedRequestOptions::try_from(p.options)?,
+    };
+    let crawl = tools::build_crawl_options(&spec);
+    let (config, opts) = spec.options.into_crawl_session(&url, crawl);
+    let Outcome::Completed(results) = executor::crawl_in_session(config, opts, &ct).await else {
+        return Ok(Outcome::Cancelled);
+    };
+    let results = results?
+        .into_iter()
+        .map(|result| {
+            let content = result
+                .outcome
+                .map(|page| tools::paginate(&servo_fetch::sanitize::sanitize(&page.content), 0, max_len))
+                .map_err(tools::ToolError::from);
+            (result.url, content)
+        })
+        .collect();
+    labeled_results(results).map(Outcome::Completed)
 }
 
-async fn run_map(p: MapRequest) -> Result<CallToolResult, tools::ToolError> {
+async fn run_map(p: MapRequest, ct: CancellationToken) -> Result<Outcome<CallToolResult>, tools::ToolError> {
     let url = tools::validated_url(&p.url)?;
     let opts = tools::build_map_options(tools::MapSpec {
         url: &url,
@@ -380,10 +415,13 @@ async fn run_map(p: MapRequest) -> Result<CallToolResult, tools::ToolError> {
         timeout: p.timeout,
         headers: p.headers,
     })?;
-    let text = output::map_text(tools::map_with(opts).await?.into_iter().map(|entry| entry.url));
+    let Some(entries) = ct.run_until_cancelled(tools::map_with(opts)).await else {
+        return Ok(Outcome::Cancelled);
+    };
+    let text = output::map_text(entries?.into_iter().map(|entry| entry.url));
     let mut output = output::TextOutput::success();
     output.push(text);
-    Ok(output.finish())
+    Ok(Outcome::Completed(output.finish()))
 }
 
 #[tool_handler]
@@ -412,7 +450,7 @@ mod tests {
 
     #[test]
     fn server_info_has_name_and_version() {
-        let server = ServoFetchMcp::new();
+        let server = ServoFetchMcp::new(1);
         let info = server.get_info();
         assert!(info.server_info.name.contains("servo-fetch"));
         assert!(!info.server_info.version.is_empty());

--- a/crates/servo-fetch-cli/src/mcp/tools.rs
+++ b/crates/servo-fetch-cli/src/mcp/tools.rs
@@ -4,9 +4,8 @@ use rmcp::model::CallToolResult;
 
 use super::output::TextOutput;
 pub(super) use crate::tools::{
-    BatchSpec, CrawlSpec, MapSpec, ResolvedRequestOptions, ToolError, apply_options, batch_fetch_pages,
-    build_map_options, content_options, crawl_pages, fetch_with, map_with, paginate, render_page, validate_selector,
-    validated_url, visibility_policy,
+    CrawlSpec, MapSpec, ResolvedRequestOptions, ToolError, apply_options, build_crawl_options, build_map_options,
+    content_options, fetch_with, map_with, page_text, paginate, validate_selector, validated_url, visibility_policy,
 };
 
 /// Build an `isError` tool result carrying the failure message for the model to react to.

--- a/crates/servo-fetch-cli/src/rpc/dispatch.rs
+++ b/crates/servo-fetch-cli/src/rpc/dispatch.rs
@@ -224,7 +224,7 @@ async fn crawl(params: Value, id: &RequestId, tx: &UnboundedSender<String>) -> R
     let url = tools::validated_url(&req.url)?;
     tools::validate_selector(req.selector.as_deref())?;
 
-    let opts = tools::build_crawl_options(&tools::CrawlSpec {
+    let spec = tools::CrawlSpec {
         url: &url,
         limit: req.limit,
         max_depth: req.max_depth,
@@ -234,8 +234,9 @@ async fn crawl(params: Value, id: &RequestId, tx: &UnboundedSender<String>) -> R
         exclude: req.exclude.as_deref(),
         concurrency: req.concurrency,
         delay_ms: req.delay_ms,
-        options: req.options,
-    })?;
+        options: tools::ResolvedRequestOptions::try_from(req.options)?,
+    };
+    let opts = spec.options.apply_crawl(tools::build_crawl_options(&spec));
 
     // Stream each page as a `$/progress` notification. Buffering is bounded by
     // the crawl `limit`; the run loop cancels by dropping this future.

--- a/crates/servo-fetch-cli/src/serve/handlers.rs
+++ b/crates/servo-fetch-cli/src/serve/handlers.rs
@@ -126,7 +126,7 @@ pub(super) async fn crawl(Json(req): Json<CrawlRequest>) -> Result<AxumJson<Craw
             exclude: req.exclude.as_deref(),
             concurrency: req.concurrency,
             delay_ms: req.delay_ms,
-            options: req.options,
+            options: tools::ResolvedRequestOptions::try_from(req.options)?,
         },
         to_len(req.max_length, DEFAULT_MAX_LENGTH),
     )

--- a/crates/servo-fetch-cli/src/tools.rs
+++ b/crates/servo-fetch-cli/src/tools.rs
@@ -16,4 +16,4 @@ pub(crate) use options::{
     ResolvedRequestOptions, apply_options, build_headers, content_options, resolve_settle, resolve_timeout,
     validate_selector, validated_url, visibility_policy,
 };
-pub(crate) use render::{clamp_js_output, paginate, paginate_opt, render_page};
+pub(crate) use render::{clamp_js_output, page_text, paginate, paginate_opt, render_page};

--- a/crates/servo-fetch-cli/src/tools/crawl.rs
+++ b/crates/servo-fetch-cli/src/tools/crawl.rs
@@ -2,11 +2,11 @@
 
 use std::time::Duration;
 
-use servo_fetch_types::{FetchFormat, RequestOptions};
+use servo_fetch_types::FetchFormat;
 
 use super::error::{ToolError, ToolResult};
 use super::limits::{CRAWL_CONCURRENCY, CRAWL_DEPTH, CRAWL_LIMIT, clamp_count};
-use super::options::{build_headers, glob_refs, load_cookies, resolve_settle, resolve_timeout};
+use super::options::{ResolvedRequestOptions, glob_refs};
 use super::render::paginate;
 
 pub(crate) struct CrawlSpec<'a> {
@@ -19,16 +19,14 @@ pub(crate) struct CrawlSpec<'a> {
     pub exclude: Option<&'a [String]>,
     pub concurrency: Option<u64>,
     pub delay_ms: Option<u64>,
-    pub options: RequestOptions,
+    pub options: ResolvedRequestOptions,
 }
 
-/// Build the engine crawl options shared by the streaming and collecting paths.
-pub(crate) fn build_crawl_options(spec: &CrawlSpec<'_>) -> ToolResult<servo_fetch::CrawlOptions> {
+/// Build the crawl-specific engine options; request settings are applied by the caller.
+pub(crate) fn build_crawl_options(spec: &CrawlSpec<'_>) -> servo_fetch::CrawlOptions {
     let mut builder = servo_fetch::CrawlOptions::new(spec.url)
         .limit(clamp_count(spec.limit, CRAWL_LIMIT))
         .max_depth(clamp_count(spec.max_depth, CRAWL_DEPTH))
-        .timeout(resolve_timeout(spec.options.timeout))
-        .settle(resolve_settle(spec.options.settle_ms))
         .concurrency(clamp_count(spec.concurrency, CRAWL_CONCURRENCY))
         .delay(resolve_delay(spec.delay_ms))
         .json(matches!(spec.format, FetchFormat::Json));
@@ -41,13 +39,7 @@ pub(crate) fn build_crawl_options(spec: &CrawlSpec<'_>) -> ToolResult<servo_fetc
     if let Some(globs) = spec.exclude.filter(|g| !g.is_empty()) {
         builder = builder.exclude(&glob_refs(globs));
     }
-    if let Some(ua) = spec.options.user_agent.as_deref() {
-        builder = builder.user_agent(ua);
-    }
-    if let Some(path) = spec.options.cookies_file.as_deref() {
-        builder = builder.cookies(load_cookies(path)?);
-    }
-    Ok(builder.headers(build_headers(spec.options.headers.clone())?))
+    builder
 }
 
 /// Resolve the dispatch interval: `Some(0)` disables it, `None` uses the 500ms default.
@@ -60,7 +52,7 @@ fn resolve_delay(delay_ms: Option<u64>) -> Option<Duration> {
 }
 
 pub(crate) async fn crawl_pages(spec: CrawlSpec<'_>, max_len: usize) -> ToolResult<Vec<(String, ToolResult<String>)>> {
-    let builder = build_crawl_options(&spec)?;
+    let builder = spec.options.apply_crawl(build_crawl_options(&spec));
     tokio::task::spawn_blocking(move || {
         let mut results = Vec::new();
         servo_fetch::blocking::crawl_each(&builder, |r| {

--- a/crates/servo-fetch-cli/src/tools/fetch.rs
+++ b/crates/servo-fetch-cli/src/tools/fetch.rs
@@ -9,7 +9,7 @@ use tokio::task::{JoinSet, spawn_blocking};
 
 use super::error::{ToolError, ToolResult};
 use super::options::{ResolvedRequestOptions, content_options};
-use super::render::{paginate, render_page};
+use super::render::page_text;
 
 const DEFAULT_MAX_CONCURRENT_FETCHES: usize = 4;
 const MAX_ALLOWED_CONCURRENCY: usize = 16;
@@ -101,8 +101,7 @@ fn render_one(
     opts: &FetchOptions,
 ) -> ToolResult<String> {
     let page = servo_fetch::blocking::fetch(opts).map_err(ToolError::from)?;
-    let full = render_page(&page, url, format, selector)?;
-    Ok(paginate(&servo_fetch::sanitize::sanitize(&full), 0, max_len))
+    page_text(&page, url, format, selector, 0, max_len)
 }
 
 #[cfg(test)]

--- a/crates/servo-fetch-cli/src/tools/map.rs
+++ b/crates/servo-fetch-cli/src/tools/map.rs
@@ -10,10 +10,7 @@ use super::options::{build_headers, glob_refs, resolve_timeout};
 
 /// Run a built map on the engine, returning sitemap entries (URL plus `lastmod`).
 pub(crate) async fn map_with(opts: MapOptions) -> ToolResult<Vec<MappedUrl>> {
-    tokio::task::spawn_blocking(move || servo_fetch::blocking::map(&opts))
-        .await
-        .map_err(|e| ToolError::internal(e.to_string()))?
-        .map_err(ToolError::from)
+    servo_fetch::map(&opts).await.map_err(ToolError::from)
 }
 
 pub(crate) struct MapSpec<'a> {

--- a/crates/servo-fetch-cli/src/tools/options.rs
+++ b/crates/servo-fetch-cli/src/tools/options.rs
@@ -3,7 +3,7 @@
 use std::collections::BTreeMap;
 use std::time::Duration;
 
-use servo_fetch::{BrowserSessionConfig, CookieSpec, FetchOptions, HeaderMap, VisibilityPolicy};
+use servo_fetch::{BrowserSessionConfig, CookieSpec, CrawlOptions, FetchOptions, HeaderMap, VisibilityPolicy};
 use servo_fetch_types::{FetchFormat, RequestOptions, Visibility};
 
 use super::error::{ToolError, ToolResult};
@@ -77,17 +77,27 @@ impl TryFrom<RequestOptions> for ResolvedRequestOptions {
 impl ResolvedRequestOptions {
     /// Split into one-use session identity (UA, cookies) and per-fetch settings.
     pub(crate) fn into_session(self, url: &str, opts: FetchOptions) -> (BrowserSessionConfig, FetchOptions) {
-        let mut config = BrowserSessionConfig::new();
-        if let Some(user_agent) = self.user_agent {
-            config = config.user_agent(user_agent);
+        let opts = opts.timeout(self.timeout).settle(self.settle).headers(self.headers);
+        (session_identity(url, self.user_agent, self.cookies), opts)
+    }
+
+    /// Crawl counterpart of [`Self::into_session`].
+    pub(crate) fn into_crawl_session(self, url: &str, opts: CrawlOptions) -> (BrowserSessionConfig, CrawlOptions) {
+        let opts = opts.timeout(self.timeout).settle(self.settle).headers(self.headers);
+        (session_identity(url, self.user_agent, self.cookies), opts)
+    }
+
+    /// Crawl counterpart of [`Self::apply`].
+    pub(crate) fn apply_crawl(&self, opts: CrawlOptions) -> CrawlOptions {
+        let mut opts = opts
+            .timeout(self.timeout)
+            .settle(self.settle)
+            .cookies(self.cookies.clone())
+            .headers(self.headers.clone());
+        if let Some(user_agent) = &self.user_agent {
+            opts = opts.user_agent(user_agent.clone());
         }
-        if !self.cookies.is_empty() {
-            config = config.cookies(url, self.cookies);
-        }
-        (
-            config,
-            opts.timeout(self.timeout).settle(self.settle).headers(self.headers),
-        )
+        opts
     }
 
     /// Apply the settings to one fetch.
@@ -102,6 +112,17 @@ impl ResolvedRequestOptions {
         }
         opts
     }
+}
+
+fn session_identity(url: &str, user_agent: Option<String>, cookies: Vec<CookieSpec>) -> BrowserSessionConfig {
+    let mut config = BrowserSessionConfig::new();
+    if let Some(user_agent) = user_agent {
+        config = config.user_agent(user_agent);
+    }
+    if !cookies.is_empty() {
+        config = config.cookies(url, cookies);
+    }
+    config
 }
 
 /// Load and validate a Netscape-format cookies.txt file.

--- a/crates/servo-fetch-cli/src/tools/render.rs
+++ b/crates/servo-fetch-cli/src/tools/render.rs
@@ -8,6 +8,19 @@ use servo_fetch_types::FetchFormat;
 use super::error::{ToolError, ToolResult};
 use super::limits::{DEFAULT_MAX_LENGTH, MAX_JS_OUTPUT_LEN, to_len};
 
+/// Render, sanitize, and paginate a fetched page into the text returned to the caller.
+pub(crate) fn page_text(
+    page: &Page,
+    url: &str,
+    format: FetchFormat,
+    selector: Option<&str>,
+    start: usize,
+    max_len: usize,
+) -> ToolResult<String> {
+    let full = render_page(page, url, format, selector)?;
+    Ok(paginate(&servo_fetch::sanitize::sanitize(&full), start, max_len))
+}
+
 /// Render a fetched page to its pre-pagination string for the requested format.
 pub(crate) fn render_page<'a>(
     page: &'a Page,

--- a/crates/servo-fetch-cli/tests/common.rs
+++ b/crates/servo-fetch-cli/tests/common.rs
@@ -2,8 +2,24 @@
 
 #![allow(dead_code, unreachable_pub)]
 
-use wiremock::ResponseTemplate;
+use std::time::Duration;
+
+use tokio::sync::mpsc;
+use wiremock::{Request, ResponseTemplate};
 
 pub fn mock_page(html: impl Into<String>) -> ResponseTemplate {
     ResponseTemplate::new(200).set_body_raw(html.into().into_bytes(), "text/html; charset=utf-8")
+}
+
+/// A slow page whose responder reports each arriving request, so tests can act mid-fetch.
+pub fn slow_page(
+    html: &'static str,
+    delay: Duration,
+) -> (mpsc::UnboundedReceiver<()>, impl Fn(&Request) -> ResponseTemplate) {
+    let (arrived, arrivals) = mpsc::unbounded_channel();
+    let responder = move |_: &Request| {
+        let _ = arrived.send(());
+        mock_page(html).set_delay(delay)
+    };
+    (arrivals, responder)
 }

--- a/crates/servo-fetch-cli/tests/mcp.rs
+++ b/crates/servo-fetch-cli/tests/mcp.rs
@@ -7,7 +7,7 @@ use wiremock::matchers::{header, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 mod common;
-use common::mock_page;
+use common::{mock_page, slow_page};
 
 async fn connect() -> rmcp::service::RunningService<rmcp::RoleClient, impl rmcp::service::Service<rmcp::RoleClient>> {
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_servo-fetch"));
@@ -528,74 +528,96 @@ async fn fetch_session_applies_user_agent_and_seeded_cookie() {
     assert!(text.text.contains("session identity applied"));
 }
 
+/// Cancel `tool` while `workers` isolated workers are mid-fetch; every worker must exit and the slots must free up.
 #[cfg(unix)]
-#[tokio::test]
-#[ignore = "e2e: requires Servo engine"]
-async fn cancelled_fetch_kills_its_worker_and_frees_the_slot() {
+async fn cancel_kills_workers(tool: &str, arguments: serde_json::Value, workers: usize, server: &MockServer) {
     use std::time::Duration;
 
     use rmcp::model::{CallToolRequest, ClientRequest};
     use rmcp::service::PeerRequestOptions;
 
-    let server = MockServer::start().await;
+    let (mut arrivals, slow) = slow_page("<html><body>slow</body></html>", Duration::from_secs(30));
     Mock::given(method("GET"))
         .and(path("/slow"))
-        .respond_with(mock_page("<html><body>slow</body></html>").set_delay(Duration::from_secs(30)))
-        .mount(&server)
+        .respond_with(slow)
+        .mount(server)
         .await;
     Mock::given(method("GET"))
         .and(path("/fast"))
         .respond_with(mock_page("<html><body>fast page</body></html>"))
-        .mount(&server)
+        .mount(server)
         .await;
 
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_servo-fetch"));
     cmd.args(["mcp", "--allow-private-addresses"])
-        .env("SERVO_FETCH_MAX_WORKERS", "1")
+        .env("SERVO_FETCH_MAX_WORKERS", workers.to_string())
         .env("SERVO_FETCH_PREWARM", "0");
     let transport = TokioChildProcess::new(cmd).unwrap();
     let server_pid = transport.id().expect("MCP server pid");
     let client = ().serve(transport).await.expect("MCP handshake failed");
 
-    let fetch = |path: &str| {
-        call_params(
-            "fetch",
-            &serde_json::json!({"url": format!("{}/{path}", server.uri()), "format": "text", "timeout": 30}),
-        )
-    };
     let slow = client
         .peer()
         .send_cancellable_request(
-            ClientRequest::CallToolRequest(CallToolRequest::new(fetch("slow"))),
+            ClientRequest::CallToolRequest(CallToolRequest::new(call_params(tool, &arguments))),
             PeerRequestOptions::no_options(),
         )
         .await
-        .expect("start slow fetch");
-    tokio::time::timeout(Duration::from_secs(15), async {
-        while !server
-            .received_requests()
+        .expect("start slow call");
+    for _ in 0..workers {
+        tokio::time::timeout(Duration::from_secs(15), arrivals.recv())
             .await
-            .is_some_and(|requests| requests.iter().any(|request| request.url.path() == "/slow"))
-        {
-            tokio::time::sleep(Duration::from_millis(50)).await;
-        }
-    })
-    .await
-    .expect("the worker navigates to the slow page before cancellation");
-    let worker = match worker_children(server_pid).as_slice() {
-        [worker] => *worker,
-        workers => panic!("expected exactly one in-flight worker, found {workers:?}"),
-    };
+            .expect("every worker navigates to the slow page before cancellation");
+    }
+    let pids = worker_children(server_pid);
+    assert_eq!(pids.len(), workers, "one in-flight worker per slot, found {pids:?}");
 
     slow.cancel(None).await.expect("send cancellation");
-    wait_for_exit(worker).await;
+    for pid in pids {
+        wait_for_exit(pid).await;
+    }
 
-    let result = tokio::time::timeout(Duration::from_secs(15), client.call_tool(fetch("fast")))
+    let fast = call_params(
+        "fetch",
+        &serde_json::json!({"url": format!("{}/fast", server.uri()), "format": "text", "timeout": 30}),
+    );
+    let result = tokio::time::timeout(Duration::from_secs(15), client.call_tool(fast))
         .await
-        .expect("freed slot admits the follow-up fetch")
+        .expect("freed slots admit the follow-up fetch")
         .expect("follow-up fetch succeeds");
     let text = result.content[0].as_text().expect("text content");
-    assert!(text.text.contains("fast page"));
+    assert!(text.text.contains("fast page"), "follow-up fetch renders the fast page");
+}
+
+#[cfg(unix)]
+#[tokio::test]
+#[ignore = "e2e: requires Servo engine"]
+async fn cancelled_fetch_kills_its_worker_and_frees_the_slot() {
+    let server = MockServer::start().await;
+    let args = serde_json::json!({"url": format!("{}/slow", server.uri()), "format": "text", "timeout": 30});
+    cancel_kills_workers("fetch", args, 1, &server).await;
+}
+
+#[cfg(unix)]
+#[tokio::test]
+#[ignore = "e2e: requires Servo engine"]
+async fn cancelled_batch_fetch_kills_every_worker_and_frees_the_slots() {
+    let server = MockServer::start().await;
+    let args = serde_json::json!({
+        "urls": [format!("{}/slow?a", server.uri()), format!("{}/slow?b", server.uri())],
+        "format": "text",
+        "timeout": 30
+    });
+    cancel_kills_workers("batch_fetch", args, 2, &server).await;
+}
+
+#[cfg(unix)]
+#[tokio::test]
+#[ignore = "e2e: requires Servo engine"]
+async fn cancelled_crawl_kills_its_worker_and_frees_the_slot() {
+    let server = MockServer::start().await;
+    let args = serde_json::json!({"url": format!("{}/slow", server.uri()), "limit": 1, "timeout": 30});
+    cancel_kills_workers("crawl", args, 1, &server).await;
 }
 
 #[tokio::test]

--- a/crates/servo-fetch-cli/tests/session.rs
+++ b/crates/servo-fetch-cli/tests/session.rs
@@ -1,17 +1,16 @@
 //! Strong logical browser-session isolation, capacity, and cancellation E2E tests.
 
-use std::sync::{Arc, Once};
+use std::sync::Once;
 use std::time::Duration;
 
 use servo_fetch::{
     BrowserSessionConfig, FetchOptions, NetworkPolicy, SessionBroker, SessionBrokerConfig, WorkerCommand,
 };
-use tokio::sync::Notify;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer};
 
 mod common;
-use common::mock_page;
+use common::{mock_page, slow_page};
 
 static INIT: Once = Once::new();
 
@@ -77,16 +76,10 @@ async fn logical_sessions_isolate_cookie_state() {
 #[ignore = "e2e: requires Servo engine"]
 async fn cancelling_fetch_kills_worker_and_releases_capacity() {
     let server = MockServer::start().await;
-    let navigated = Arc::new(Notify::new());
+    let (mut arrivals, slow) = slow_page("<!doctype html><html><body>slow</body></html>", Duration::from_secs(10));
     Mock::given(method("GET"))
         .and(path("/slow"))
-        .respond_with({
-            let navigated = Arc::clone(&navigated);
-            move |_: &wiremock::Request| {
-                navigated.notify_one();
-                mock_page("<!doctype html><html><body>slow</body></html>").set_delay(Duration::from_secs(10))
-            }
-        })
+        .respond_with(slow)
         .mount(&server)
         .await;
     let broker = broker(1, 1);
@@ -99,7 +92,7 @@ async fn cancelling_fetch_kills_worker_and_releases_capacity() {
             .fetch(&FetchOptions::new(&url).timeout(Duration::from_secs(30)))
             .await
     });
-    tokio::time::timeout(Duration::from_secs(15), navigated.notified())
+    tokio::time::timeout(Duration::from_secs(15), arrivals.recv())
         .await
         .expect("the worker navigates to the slow page before cancellation");
     task.abort();

--- a/crates/servo-fetch/src/session.rs
+++ b/crates/servo-fetch/src/session.rs
@@ -144,6 +144,12 @@ impl SessionBrokerConfig {
     /// Upper bound on callers allowed to wait for a session slot.
     pub const MAX_QUEUE_CAPACITY: usize = 1024;
 
+    /// Maximum number of simultaneously-live sessions this configuration allows.
+    #[must_use]
+    pub fn session_capacity(&self) -> usize {
+        self.max_sessions
+    }
+
     /// Set the maximum number of simultaneously-live sessions.
     #[must_use]
     pub fn max_sessions(mut self, max_sessions: usize) -> Self {


### PR DESCRIPTION
## Summary

Follow-up to #466: `batch_fetch`, `crawl`, and `map` still ran on the shared warm engine with no cancellation, so every MCP tool now honors `notifications/cancelled` and page tools no longer share state between calls.

## Test Plan

- `cargo test-ci`: all passed
- `cargo test-e2e`: all passed

## Checklist

- [x] Ran `cargo +nightly fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
- [x] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed
- [x] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it