### PR TITLE
feat(session): fetch PDFs inside sessions on a single async HTTP stack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6521,7 +6521,6 @@ dependencies = [
  "thiserror 2.0.20",
  "tokio",
  "tracing",
- "ureq",
  "url",
  "windows-sys 0.61.2",
  "wiremock",
@@ -6538,6 +6537,7 @@ dependencies = [
  "clap",
  "console",
  "futures-util",
+ "httparse",
  "humantime",
  "image",
  "indicatif",
@@ -6558,7 +6558,6 @@ dependencies = [
  "tower-http 0.7.0",
  "tracing",
  "tracing-subscriber",
- "ureq",
  "url",
  "wiremock",
 ]
@@ -8976,35 +8975,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
-name = "ureq"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "972d7902c8735f2695410b8aed7df6ed12a47394aa1c8d7af49f0497b731a94d"
-dependencies = [
- "base64 0.23.1",
- "flate2",
- "log",
- "percent-encoding",
- "rustls",
- "rustls-pki-types",
- "ureq-proto",
- "utf8-zero",
- "webpki-roots",
-]
-
-[[package]]
-name = "ureq-proto"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da5f78b09e6941e1a0f2e30e695e4b120377b54d5e0aec11b594bb57b3971613"
-dependencies = [
- "base64 0.23.1",
- "http 1.5.0",
- "httparse",
- "log",
-]
-
-[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9074,12 +9044,6 @@ name = "utf8-width"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1292c0d970b54115d14f2492fe0170adf21d68a1de108eebc51c1df4f346a091"
-
-[[package]]
-name = "utf8-zero"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ futures-util = "0.3"
 globset = "0.4"
 htmd = "0.5"
 http = "1"
+httparse = "1"
 humantime = "2"
 image = { version = "0.25", default-features = false, features = ["png"] }
 indicatif = "0.18"
@@ -57,7 +58,6 @@ tower = "0.5"
 tower-http = { version = "0.7", features = ["trace", "request-id"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "tracing-log"] }
-ureq = { version = "3", default-features = false, features = ["gzip", "rustls-no-provider", "rustls-webpki-roots"] }
 url = "2"
 windows-sys = { version = "=0.61.2", features = ["Win32_Foundation", "Win32_Security", "Win32_System_Diagnostics_ToolHelp", "Win32_System_JobObjects", "Win32_System_Threading"] }
 wiremock = "0.6"

--- a/crates/servo-fetch-cli/Cargo.toml
+++ b/crates/servo-fetch-cli/Cargo.toml
@@ -58,9 +58,9 @@ tokio = { workspace = true, features = ["macros", "signal", "io-std", "io-util",
 tokio-util = { workspace = true }
 tower = { workspace = true }
 tower-http = { workspace = true }
+httparse = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
-ureq = { workspace = true }
 url = { workspace = true }
 
 [dev-dependencies]

--- a/crates/servo-fetch-cli/src/commands/healthcheck.rs
+++ b/crates/servo-fetch-cli/src/commands/healthcheck.rs
@@ -1,30 +1,65 @@
 //! `/health` probe subcommand.
 
-use std::time::Duration;
+use std::io::{Read as _, Write as _};
+use std::net::{SocketAddr, TcpStream};
+use std::time::{Duration, Instant};
 
 use anyhow::{Context as _, Result, bail};
+use axum::http::StatusCode;
 
 use crate::cli::HealthcheckArgs;
 
 const TIMEOUT: Duration = Duration::from_secs(2);
+const MAX_HEAD_BYTES: usize = 8 * 1024;
+const MAX_HEADERS: usize = 32;
 
 pub(crate) fn run(args: &HealthcheckArgs) -> Result<()> {
     probe(args.port)
 }
 
+/// Loopback probe; a full HTTP client is unnecessary for a container health check.
 fn probe(port: u16) -> Result<()> {
-    let agent = ureq::Agent::new_with_config(
-        ureq::config::Config::builder()
-            .proxy(None)
-            .max_redirects(0)
-            .timeout_global(Some(TIMEOUT))
-            .build(),
-    );
     let url = format!("http://127.0.0.1:{port}/health");
-    match agent.get(&url).call() {
-        Ok(_) => Ok(()),
-        Err(ureq::Error::StatusCode(code)) => bail!("GET {url}: status {code}"),
-        Err(e) => Err(e).with_context(|| format!("GET {url}")),
+    let status = status(port).with_context(|| format!("GET {url}"))?;
+    if status.is_success() {
+        Ok(())
+    } else {
+        bail!("GET {url}: status {}", status.as_u16())
+    }
+}
+
+fn status(port: u16) -> Result<StatusCode> {
+    let started = Instant::now();
+    let address = SocketAddr::from(([127, 0, 0, 1], port));
+    let mut stream = TcpStream::connect_timeout(&address, TIMEOUT)?;
+    let remaining = TIMEOUT
+        .checked_sub(started.elapsed())
+        .filter(|left| !left.is_zero())
+        .context("connecting consumed the probe timeout")?;
+    stream.set_read_timeout(Some(remaining))?;
+    stream.set_write_timeout(Some(remaining))?;
+    write!(
+        stream,
+        "GET /health HTTP/1.1\r\nHost: 127.0.0.1:{port}\r\nConnection: close\r\n\r\n"
+    )?;
+
+    let mut head = [0; MAX_HEAD_BYTES];
+    let mut filled = 0;
+    loop {
+        let read = stream.read(&mut head[filled..])?;
+        if read == 0 {
+            bail!("connection closed before a complete response head");
+        }
+        filled += read;
+        let mut headers = [httparse::EMPTY_HEADER; MAX_HEADERS];
+        let mut response = httparse::Response::new(&mut headers);
+        if let httparse::Status::Complete(_) = response.parse(&head[..filled])? {
+            let code = response.code.context("status line without a status code")?;
+            return Ok(StatusCode::from_u16(code)?);
+        }
+        if filled == head.len() {
+            bail!("response head exceeds {MAX_HEAD_BYTES} bytes");
+        }
     }
 }
 
@@ -83,6 +118,20 @@ mod tests {
         let result = probe(port);
         responder.join().unwrap();
         assert!(result.is_ok(), "{result:?}");
+    }
+
+    #[test]
+    fn probe_rejects_malformed_or_truncated_heads() {
+        for response in [
+            &b"garbage 200\r\n\r\n"[..],
+            b"HTTP/1.1 200 OK\r\n",
+            b"HTTP/1.1 20 OK\r\n\r\n",
+        ] {
+            let (port, responder) = spawn_responder(response);
+            let result = probe(port);
+            responder.join().unwrap();
+            assert!(result.is_err(), "{response:?} must not report healthy");
+        }
     }
 
     #[test]

--- a/crates/servo-fetch-cli/src/mcp/server.rs
+++ b/crates/servo-fetch-cli/src/mcp/server.rs
@@ -228,17 +228,6 @@ fn labeled_results(
     Ok(output.finish())
 }
 
-/// Sessions reject PDF URLs, so those stay on the one-shot engine path until session fetch absorbs the PDF probe.
-fn looks_like_pdf_url(url: &str) -> bool {
-    url::Url::parse(url).is_ok_and(|url| {
-        url.path()
-            .rsplit('/')
-            .next()
-            .and_then(|last| last.rsplit_once('.'))
-            .is_some_and(|(_, ext)| ext.eq_ignore_ascii_case("pdf"))
-    })
-}
-
 /// Fetch in a one-use isolated worker, surfacing client cancellation as an outcome.
 async fn isolated_fetch(
     url: &str,
@@ -259,13 +248,8 @@ async fn run_fetch(p: FetchRequest, ct: CancellationToken) -> Result<Outcome<Cal
     tools::validate_selector(p.selector.as_deref())?;
     let format = p.format.unwrap_or_default();
     let opts = tools::content_options(&url, format, tools::visibility_policy(p.visibility));
-    let page = if looks_like_pdf_url(&url) {
-        tools::fetch_with(tools::apply_options(opts, p.options)?).await?
-    } else {
-        match isolated_fetch(&url, opts, p.options, &ct).await? {
-            Outcome::Completed(page) => page,
-            Outcome::Cancelled => return Ok(Outcome::Cancelled),
-        }
+    let Outcome::Completed(page) = isolated_fetch(&url, opts, p.options, &ct).await? else {
+        return Ok(Outcome::Cancelled);
     };
     let content = tools::page_text(
         &page,

--- a/crates/servo-fetch-cli/src/mcp/tools.rs
+++ b/crates/servo-fetch-cli/src/mcp/tools.rs
@@ -4,8 +4,8 @@ use rmcp::model::CallToolResult;
 
 use super::output::TextOutput;
 pub(super) use crate::tools::{
-    CrawlSpec, MapSpec, ResolvedRequestOptions, ToolError, apply_options, build_crawl_options, build_map_options,
-    content_options, fetch_with, map_with, page_text, paginate, validate_selector, validated_url, visibility_policy,
+    CrawlSpec, MapSpec, ResolvedRequestOptions, ToolError, build_crawl_options, build_map_options, content_options,
+    map_with, page_text, paginate, validate_selector, validated_url, visibility_policy,
 };
 
 /// Build an `isError` tool result carrying the failure message for the model to react to.

--- a/crates/servo-fetch-cli/tests/common.rs
+++ b/crates/servo-fetch-cli/tests/common.rs
@@ -23,3 +23,37 @@ pub fn slow_page(
     };
     (arrivals, responder)
 }
+
+/// A minimal single-page PDF whose only content is `text`, for exercising PDF extraction end to end.
+pub fn pdf_with_text(text: &str) -> Vec<u8> {
+    use std::io::Write as _;
+
+    let escaped = text.replace('\\', r"\\").replace('(', r"\(").replace(')', r"\)");
+    let stream = format!("BT\n/F1 18 Tf\n72 720 Td\n({escaped}) Tj\nET\n");
+    let objects = [
+        "<< /Type /Catalog /Pages 2 0 R >>".to_string(),
+        "<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_string(),
+        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>"
+            .to_string(),
+        "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>".to_string(),
+        format!("<< /Length {} >>\nstream\n{stream}endstream", stream.len()),
+    ];
+    let mut pdf = b"%PDF-1.4\n".to_vec();
+    let mut offsets = Vec::with_capacity(objects.len());
+    for (index, object) in objects.iter().enumerate() {
+        offsets.push(pdf.len());
+        write!(&mut pdf, "{} 0 obj\n{object}\nendobj\n", index + 1).expect("write PDF object");
+    }
+    let xref = pdf.len();
+    write!(&mut pdf, "xref\n0 {}\n0000000000 65535 f \n", objects.len() + 1).expect("write PDF xref header");
+    for offset in offsets {
+        writeln!(&mut pdf, "{offset:010} 00000 n ").expect("write PDF xref entry");
+    }
+    write!(
+        &mut pdf,
+        "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{xref}\n%%EOF\n",
+        objects.len() + 1
+    )
+    .expect("write PDF trailer");
+    pdf
+}

--- a/crates/servo-fetch-cli/tests/mcp.rs
+++ b/crates/servo-fetch-cli/tests/mcp.rs
@@ -7,7 +7,7 @@ use wiremock::matchers::{header, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 mod common;
-use common::{mock_page, slow_page};
+use common::{mock_page, pdf_with_text, slow_page};
 
 async fn connect() -> rmcp::service::RunningService<rmcp::RoleClient, impl rmcp::service::Service<rmcp::RoleClient>> {
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_servo-fetch"));
@@ -622,7 +622,7 @@ async fn cancelled_crawl_kills_its_worker_and_frees_the_slot() {
 
 #[tokio::test]
 #[ignore = "e2e: requires Servo engine"]
-async fn pdf_suffix_serving_html_still_renders_through_the_one_shot_path() {
+async fn pdf_suffix_serving_html_falls_back_to_rendering() {
     let server = MockServer::start().await;
     Mock::given(method("GET"))
         .and(path("/report.pdf"))
@@ -645,4 +645,32 @@ async fn pdf_suffix_serving_html_still_renders_through_the_one_shot_path() {
     );
     let text = result.content[0].as_text().expect("text content");
     assert!(text.text.contains("rendered fallback"));
+}
+
+#[tokio::test]
+#[ignore = "e2e: requires Servo engine"]
+async fn fetch_extracts_pdf_text_through_the_session_path() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/report.pdf"))
+        .and(header("user-agent", "McpPdf/1.0"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(pdf_with_text("session pdf text"), "application/pdf"))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = connect_loopback().await;
+    let result = client
+        .call_tool(call_params(
+            "fetch",
+            &serde_json::json!({"url": format!("{}/report.pdf", server.uri()), "format": "text", "userAgent": "McpPdf/1.0"}),
+        ))
+        .await
+        .expect("PDF fetch succeeds");
+    let text = result.content[0].as_text().expect("text content");
+    assert!(
+        text.text.contains("session pdf text"),
+        "PDF text is extracted: {}",
+        text.text
+    );
 }

--- a/crates/servo-fetch-cli/tests/session.rs
+++ b/crates/servo-fetch-cli/tests/session.rs
@@ -4,7 +4,8 @@ use std::sync::Once;
 use std::time::Duration;
 
 use servo_fetch::{
-    BrowserSessionConfig, FetchOptions, NetworkPolicy, SessionBroker, SessionBrokerConfig, WorkerCommand,
+    BrowserSessionConfig, FetchOptions, NetworkPolicy, SessionBroker, SessionBrokerConfig, SessionCancellation,
+    WorkerCommand,
 };
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer};
@@ -103,4 +104,84 @@ async fn cancelling_fetch_kills_worker_and_releases_capacity() {
         .expect("cancelled worker should release its broker permit")
         .expect("replacement session starts");
     replacement.close().await.unwrap();
+}
+
+#[tokio::test]
+#[ignore = "e2e: requires Servo engine"]
+async fn cancelling_a_pdf_probe_closes_the_socket_promptly() {
+    use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+    use tokio::net::TcpListener;
+    use tokio::sync::oneshot;
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind PDF fixture");
+    let address = listener.local_addr().expect("PDF fixture address");
+    let (partial_tx, partial_rx) = oneshot::channel();
+    let (closed_tx, closed_rx) = oneshot::channel();
+    let fixture = tokio::spawn(async move {
+        let (mut socket, _) = listener.accept().await.expect("accept PDF request");
+        let mut byte = [0_u8; 1];
+        let mut request = Vec::new();
+        while !request.ends_with(b"\r\n\r\n") {
+            socket.read_exact(&mut byte).await.expect("read PDF request");
+            request.push(byte[0]);
+        }
+        socket
+            .write_all(b"HTTP/1.1 200 OK\r\ncontent-type: application/pdf\r\ncontent-length: 1048576\r\n\r\n%PDF-1.4\n")
+            .await
+            .expect("write partial PDF response");
+        socket.flush().await.expect("flush partial PDF response");
+        partial_tx.send(()).expect("report partial PDF body");
+        closed_tx
+            .send(socket.read(&mut byte).await)
+            .expect("report client disconnect");
+    });
+
+    let broker = broker(1, 1);
+    let cancellation = SessionCancellation::new();
+    let mut session = broker
+        .session_with_cancellation(BrowserSessionConfig::new(), &cancellation)
+        .await
+        .expect("session starts");
+    let fetch = tokio::spawn(async move {
+        session
+            .fetch(&FetchOptions::new(&format!("http://{address}/slow.pdf")).timeout(Duration::from_secs(30)))
+            .await
+    });
+    partial_rx.await.expect("probe reaches the partial PDF body");
+    cancellation.cancel();
+
+    let outcome = tokio::time::timeout(Duration::from_secs(1), fetch)
+        .await
+        .expect("cancelled PDF fetch returns promptly")
+        .expect("fetch task completes");
+    assert!(
+        matches!(outcome, Err(servo_fetch::Error::SessionCancelled)),
+        "{outcome:?}"
+    );
+    match closed_rx.await.expect("fixture reports client disconnect") {
+        Ok(0) => {}
+        Err(error)
+            if matches!(
+                error.kind(),
+                std::io::ErrorKind::ConnectionReset | std::io::ErrorKind::BrokenPipe
+            ) => {}
+        other => panic!("cancelled probe must close its socket, observed {other:?}"),
+    }
+    fixture.await.expect("PDF fixture completes");
+}
+
+#[tokio::test]
+#[ignore = "e2e: requires Servo engine"]
+async fn cancelled_session_rejects_pdf_fetches_without_touching_the_network() {
+    let broker = broker(1, 1);
+    let mut session = broker
+        .session(BrowserSessionConfig::new())
+        .await
+        .expect("session starts");
+    session.cancel();
+    let result = session.fetch(&FetchOptions::new("http://127.0.0.1:9/closed.pdf")).await;
+    assert!(
+        result.is_err(),
+        "a cancelled session must not probe PDFs on the host: {result:?}"
+    );
 }

--- a/crates/servo-fetch/Cargo.toml
+++ b/crates/servo-fetch/Cargo.toml
@@ -40,7 +40,6 @@ thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }
-ureq = { workspace = true }
 quick-xml = { workspace = true }
 flate2 = { workspace = true }
 humantime = { workspace = true }

--- a/crates/servo-fetch/src/cookies.rs
+++ b/crates/servo-fetch/src/cookies.rs
@@ -309,6 +309,16 @@ fn cookie_for(
     Some((url, builder.build()))
 }
 
+/// The subset of `specs` that [`seed`] would store for `target`; the host must never send more.
+pub(crate) fn seedable(target: &Url, specs: &[CookieSpec]) -> Vec<CookieSpec> {
+    let policy = crate::bridge::engine_policy();
+    specs
+        .iter()
+        .filter(|spec| cookie_for(target, spec, policy).is_some())
+        .cloned()
+        .collect()
+}
+
 pub(crate) fn request_header(target: &Url, specs: &[CookieSpec]) -> Option<http::HeaderValue> {
     let request_path = target.path();
     let secure = is_secure_context(target);

--- a/crates/servo-fetch/src/crawl.rs
+++ b/crates/servo-fetch/src/crawl.rs
@@ -4,7 +4,7 @@ use std::collections::{HashSet, VecDeque};
 use std::hash::{DefaultHasher, Hash, Hasher};
 use std::time::{Duration, SystemTime};
 
-use tokio::task::{JoinSet, spawn_blocking};
+use tokio::task::JoinSet;
 use tokio::time::{MissedTickBehavior, interval};
 use url::Url;
 
@@ -264,15 +264,9 @@ where
 {
     net::ensure_crypto_provider();
     let plan = build_crawl_plan(opts)?;
-    let robots = spawn_blocking({
-        let seed = plan.seed.clone();
-        let user_agent = plan.robots_user_agent.clone();
-        let headers = plan.headers.clone();
-        let timeout = Duration::from_secs(plan.timeout_secs);
-        move || crate::robots::RobotsRules::fetch(&seed, user_agent.as_deref(), &headers, timeout)
-    })
-    .await
-    .map_err(crate::worker::worker_error)?;
+    let client = crate::transfer::client()?;
+    let headers = crate::transfer::Headers::new(&plan.headers, plan.robots_user_agent.as_deref());
+    let robots = crate::robots::fetch(&client, &plan.seed, &headers, Duration::from_secs(plan.timeout_secs)).await;
     run(plan, robots, &bridge::ServoFetcher, |event| {
         on_event(match event {
             CrawlRunEvent::Result(result) => CrawlSessionEvent::Result(CrawlResult::from_internal(result)),

--- a/crates/servo-fetch/src/fetch.rs
+++ b/crates/servo-fetch/src/fetch.rs
@@ -359,15 +359,22 @@ pub(crate) fn fetch_in_process_blocking(opts: &FetchOptions) -> crate::error::Re
 
 /// Fetch a single page via the embedded Servo engine (blocking).
 pub fn fetch_blocking(opts: &FetchOptions) -> crate::error::Result<Page> {
-    if let Some(pdf_page) = pre_fetch(opts)? {
-        return Ok(pdf_page);
+    let target = prepare(opts)?;
+    if wants_pdf_probe(opts) {
+        let probe = probe_pdf(&target, opts);
+        if let Some(pdf_page) = crate::runtime::block_on(probe).map_err(|error| Error::engine(error, None))?? {
+            return Ok(pdf_page);
+        }
     }
     fetch_servo_blocking(opts)
 }
 
 /// Fetch a single page via the embedded Servo engine.
 pub async fn fetch(opts: &FetchOptions) -> crate::error::Result<Page> {
-    if let Some(pdf_page) = pre_fetch_async(opts).await? {
+    let target = prepare(opts)?;
+    if wants_pdf_probe(opts)
+        && let Some(pdf_page) = probe_pdf(&target, opts).await?
+    {
         return Ok(pdf_page);
     }
     let bridge_opts = build_bridge_options(opts);
@@ -407,23 +414,24 @@ pub async fn text(url: &str) -> crate::error::Result<String> {
     Ok(fetch(&FetchOptions::new(url)).await?.inner_text)
 }
 
-fn pre_fetch(opts: &FetchOptions) -> crate::error::Result<Option<Page>> {
+/// Synchronous preflight shared by every fetch entry point: crypto init and URL validation.
+fn prepare(opts: &FetchOptions) -> crate::error::Result<url::Url> {
     crate::net::ensure_crypto_provider();
-    crate::net::validate_url(&opts.url)?;
+    crate::net::validate_url(&opts.url)
+}
 
-    if matches!(opts.mode, FetchMode::Content { .. }) {
-        let headers = pdf_headers(opts)?;
-        if let Some(bytes) = crate::pdf::probe(
-            &opts.url,
-            opts.effective_timeout().as_secs().max(1),
-            opts.user_agent.as_deref(),
-            &headers,
-        ) {
-            return Ok(Some(pdf_page(&bytes)));
-        }
-    }
+/// Content fetches of `.pdf` URLs are probed directly instead of being rendered.
+pub(crate) fn wants_pdf_probe(opts: &FetchOptions) -> bool {
+    matches!(opts.mode, FetchMode::Content { .. }) && crate::pdf::looks_like_pdf_url(&opts.url)
+}
 
-    Ok(None)
+async fn probe_pdf(target: &url::Url, opts: &FetchOptions) -> crate::error::Result<Option<Page>> {
+    let headers = pdf_headers(opts)?;
+    let headers = crate::transfer::Headers::new(&headers, opts.user_agent.as_deref());
+    Ok(crate::pdf::probe(target, &headers, opts.effective_timeout())
+        .await
+        .as_deref()
+        .map(pdf_page))
 }
 
 fn pdf_headers(opts: &FetchOptions) -> crate::error::Result<http::HeaderMap> {
@@ -440,14 +448,7 @@ fn pdf_headers(opts: &FetchOptions) -> crate::error::Result<http::HeaderMap> {
     Ok(headers)
 }
 
-async fn pre_fetch_async(opts: &FetchOptions) -> crate::error::Result<Option<Page>> {
-    let options = opts.clone();
-    tokio::task::spawn_blocking(move || pre_fetch(&options))
-        .await
-        .map_err(|error| Error::engine(error, Some(opts.url.clone())))?
-}
-
-fn pdf_page(bytes: &[u8]) -> Page {
+pub(crate) fn pdf_page(bytes: &[u8]) -> Page {
     let text = crate::extract::extract_pdf(bytes);
     Page {
         html: String::new(),

--- a/crates/servo-fetch/src/lib.rs
+++ b/crates/servo-fetch/src/lib.rs
@@ -40,7 +40,8 @@ pub(crate) mod scope;
 pub(crate) mod screenshot;
 pub(crate) mod session;
 pub(crate) mod sys;
-mod worker;
+pub(crate) mod transfer;
+pub(crate) mod worker;
 
 pub use client::{Client, ClientBuilder, ScreenshotOptions};
 pub use cookies::{CookieSpec, load_cookies};

--- a/crates/servo-fetch/src/map.rs
+++ b/crates/servo-fetch/src/map.rs
@@ -5,12 +5,10 @@ use std::io::Read as _;
 use std::ops::ControlFlow;
 use std::time::Duration;
 
-use futures_util::StreamExt as _;
-use reqwest::header::USER_AGENT;
 use tokio::time::Instant;
 use url::Url;
 
-use crate::robots::{ROBOTS_MAX_BYTES, RobotsPolicy, classify_response, product_token, robots_url};
+use crate::robots::RobotsPolicy;
 use crate::scope::{is_same_site, matches_scope, normalize_url};
 use crate::{bridge, net};
 
@@ -135,7 +133,7 @@ pub async fn map(opts: &MapOptions) -> crate::error::Result<Vec<MappedUrl>> {
         no_fallback: opts.no_fallback,
         headers: opts.headers.clone(),
     };
-    let mut traversal = MapTraversal::new(config, build_client()?, build_sitemap_client()?);
+    let mut traversal = MapTraversal::new(config, crate::transfer::client()?, crate::transfer::raw_client()?);
     let mut urls = Vec::new();
     while let Some(url) = traversal.next_url().await {
         urls.push(url);
@@ -153,6 +151,12 @@ struct MapConfig {
     timeout: Duration,
     no_fallback: bool,
     headers: http::HeaderMap,
+}
+
+impl MapConfig {
+    fn headers(&self) -> crate::transfer::Headers {
+        crate::transfer::Headers::new(&self.headers, self.user_agent.as_deref())
+    }
 }
 
 enum MapPhase {
@@ -241,7 +245,7 @@ impl MapTraversal {
 
     /// Fetch robots.txt and seed the sitemap queue.
     async fn bootstrap_robots(&mut self) -> ControlFlow<MappedUrl> {
-        let robots = fetch_robots(&self.client, &self.opts).await;
+        let robots = crate::robots::fetch(&self.client, &self.opts.seed, &self.opts.headers(), self.opts.timeout).await;
         let queue = discover_sitemaps(&robots, &self.opts.seed)
             .into_iter()
             .map(|url| (url, 0))
@@ -358,59 +362,6 @@ fn discover_sitemaps(robots: &RobotsPolicy, seed: &Url) -> Vec<Url> {
     urls
 }
 
-fn build_client() -> crate::error::Result<reqwest::Client> {
-    build_client_with(reqwest::Client::builder())
-}
-
-fn build_sitemap_client() -> crate::error::Result<reqwest::Client> {
-    build_client_with(reqwest::Client::builder().no_gzip())
-}
-
-fn build_client_with(builder: reqwest::ClientBuilder) -> crate::error::Result<reqwest::Client> {
-    net::ensure_crypto_provider();
-    builder
-        .redirect(reqwest::redirect::Policy::none())
-        .build()
-        .map_err(|error| crate::Error::engine(error, None))
-}
-
-fn request(client: &reqwest::Client, url: &Url, opts: &MapConfig) -> reqwest::RequestBuilder {
-    let request = client
-        .get(url.clone())
-        .timeout(opts.timeout)
-        .headers(opts.headers.clone());
-    if opts.headers.contains_key(USER_AGENT) {
-        request
-    } else {
-        request.header(
-            USER_AGENT,
-            opts.user_agent
-                .as_deref()
-                .unwrap_or_else(|| bridge::default_user_agent()),
-        )
-    }
-}
-
-async fn fetch_robots(client: &reqwest::Client, opts: &MapConfig) -> RobotsPolicy {
-    let Some(url) = robots_url(&opts.seed) else {
-        return RobotsPolicy::Unreachable;
-    };
-    let Ok(response) = request(client, &url, opts).send().await else {
-        return RobotsPolicy::Unreachable;
-    };
-    let status = response.status().as_u16();
-    let body = if (400..600).contains(&status) {
-        None
-    } else {
-        collect_bounded(response, ROBOTS_MAX_BYTES).await
-    };
-    let user_agent = opts
-        .user_agent
-        .as_deref()
-        .unwrap_or_else(|| bridge::default_user_agent());
-    classify_response(status, body.as_deref(), product_token(user_agent))
-}
-
 async fn fetch_following_redirects(
     client: &reqwest::Client,
     url: &Url,
@@ -419,7 +370,7 @@ async fn fetch_following_redirects(
 ) -> Option<reqwest::Response> {
     let mut current = url.clone();
     for _ in 0..MAP_MAX_REDIRECTS {
-        let response = request(client, &current, opts).send().await.ok()?;
+        let response = opts.headers().get(client, &current, opts.timeout).send().await.ok()?;
         let status = response.status().as_u16();
         if matches!(status, 301 | 302 | 303 | 307 | 308) {
             let location = response.headers().get("location")?.to_str().ok()?;
@@ -438,22 +389,6 @@ async fn fetch_following_redirects(
         return Some(response);
     }
     None
-}
-
-async fn collect_bounded(response: reqwest::Response, max_bytes: u64) -> Option<Vec<u8>> {
-    let mut body = Vec::new();
-    let mut chunks = response.bytes_stream();
-    while let Some(chunk) = chunks.next().await {
-        let chunk = chunk.ok()?;
-        let next_len = u64::try_from(body.len())
-            .ok()?
-            .checked_add(u64::try_from(chunk.len()).ok()?)?;
-        if next_len > max_bytes {
-            return None;
-        }
-        body.extend_from_slice(&chunk);
-    }
-    Some(body)
 }
 
 async fn fetch_sitemap(client: &reqwest::Client, url: &Url, opts: &MapConfig) -> Option<String> {
@@ -475,7 +410,7 @@ async fn fetch_sitemap(client: &reqwest::Client, url: &Url, opts: &MapConfig) ->
             .get("content-encoding")
             .and_then(|value| value.to_str().ok())
             .is_some_and(|value| value.contains("gzip"));
-    let bytes = collect_bounded(response, MAP_SITEMAP_MAX_BYTES).await?;
+    let bytes = crate::transfer::collect_bounded(response, MAP_SITEMAP_MAX_BYTES).await?;
 
     if is_gzip {
         let mut decoded = Vec::new();
@@ -520,7 +455,7 @@ fn looks_like_html(bytes: &[u8]) -> bool {
 
 async fn fetch_html(client: &reqwest::Client, url: &Url, opts: &MapConfig) -> Option<String> {
     let response = fetch_following_redirects(client, url, url, opts).await?;
-    let bytes = collect_bounded(response, MAP_HTML_MAX_BYTES).await?;
+    let bytes = crate::transfer::collect_bounded(response, MAP_HTML_MAX_BYTES).await?;
     Some(String::from_utf8_lossy(&bytes).into_owned())
 }
 
@@ -911,10 +846,7 @@ mod tests {
         use wiremock::matchers::{method, path};
         use wiremock::{Mock, MockServer, ResponseTemplate};
 
-        use crate::map::{
-            MapConfig, MapTraversal, MappedUrl, build_client, build_sitemap_client, collect_bounded, extract_links,
-            fetch_html, fetch_sitemap, parse_sitemap,
-        };
+        use crate::map::{MapConfig, MapTraversal, MappedUrl, extract_links, fetch_html, fetch_sitemap, parse_sitemap};
 
         fn gzip(body: &[u8]) -> Vec<u8> {
             let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
@@ -932,7 +864,7 @@ mod tests {
                 .mount(&server)
                 .await;
 
-            let client = build_sitemap_client().unwrap();
+            let client = crate::transfer::raw_client().unwrap();
             let config = super::test_config(&server.uri());
             let url = Url::parse(&format!("{}/sitemap.xml", server.uri())).unwrap();
             let body = fetch_sitemap(&client, &url, &config).await;
@@ -953,7 +885,7 @@ mod tests {
                 .mount(&server)
                 .await;
 
-            let client = build_sitemap_client().unwrap();
+            let client = crate::transfer::raw_client().unwrap();
             let config = super::test_config(&server.uri());
             let url = Url::parse(&format!("{}/sitemap.xml", server.uri())).unwrap();
             let body = fetch_sitemap(&client, &url, &config).await;
@@ -970,7 +902,7 @@ mod tests {
                 .mount(&server)
                 .await;
 
-            let client = build_sitemap_client().unwrap();
+            let client = crate::transfer::raw_client().unwrap();
             let config = super::test_config(&server.uri());
             let url = Url::parse(&format!("{}/sitemap.xml", server.uri())).unwrap();
             let body = fetch_sitemap(&client, &url, &config).await;
@@ -990,7 +922,7 @@ mod tests {
                 .mount(&server)
                 .await;
 
-            let client = build_sitemap_client().unwrap();
+            let client = crate::transfer::raw_client().unwrap();
             let config = super::test_config(&server.uri());
             let url = Url::parse(&format!("{}/sitemap.xml.gz", server.uri())).unwrap();
             let body = fetch_sitemap(&client, &url, &config).await;
@@ -1013,7 +945,7 @@ mod tests {
                 .mount(&server)
                 .await;
 
-            let client = build_sitemap_client().unwrap();
+            let client = crate::transfer::raw_client().unwrap();
             let config = super::test_config(&server.uri());
             let url = Url::parse(&format!("{}/sitemap.xml.gz", server.uri())).unwrap();
             let body = fetch_sitemap(&client, &url, &config).await;
@@ -1040,35 +972,10 @@ mod tests {
                 .mount(&server)
                 .await;
 
-            let client = build_sitemap_client().unwrap();
+            let client = crate::transfer::raw_client().unwrap();
             let config = super::test_config(&server.uri());
             let url = Url::parse(&format!("{}/sitemap.xml", server.uri())).unwrap();
             let body = fetch_sitemap(&client, &url, &config).await;
-
-            assert!(body.is_none());
-        }
-
-        #[tokio::test]
-        async fn collect_bounded_rejects_compressed_body_over_limit() {
-            let server = MockServer::start().await;
-            let compressed = gzip(b"compressed sitemap body");
-            Mock::given(method("GET"))
-                .and(path("/sitemap.xml"))
-                .respond_with(
-                    ResponseTemplate::new(200)
-                        .insert_header("content-encoding", "gzip")
-                        .set_body_raw(compressed.clone(), "application/xml"),
-                )
-                .mount(&server)
-                .await;
-
-            let response = build_sitemap_client()
-                .unwrap()
-                .get(format!("{}/sitemap.xml", server.uri()))
-                .send()
-                .await
-                .unwrap();
-            let body = collect_bounded(response, compressed.len() as u64 - 1).await;
 
             assert!(body.is_none());
         }
@@ -1085,7 +992,7 @@ mod tests {
                 .mount(&server)
                 .await;
 
-            let client = build_client().unwrap();
+            let client = crate::transfer::client().unwrap();
             let seed = Url::parse(&server.uri()).unwrap();
             let config = super::test_config(&server.uri());
             let html = fetch_html(&client, &seed, &config).await.unwrap();
@@ -1137,7 +1044,11 @@ mod tests {
                     no_fallback: false,
                     headers: http::HeaderMap::new(),
                 };
-                let mut traversal = MapTraversal::new(config, build_client().unwrap(), build_sitemap_client().unwrap());
+                let mut traversal = MapTraversal::new(
+                    config,
+                    crate::transfer::client().unwrap(),
+                    crate::transfer::raw_client().unwrap(),
+                );
                 traversal.next_url().await
             });
             partial_rx.await.expect("map reaches the partial robots body");
@@ -1172,7 +1083,11 @@ mod tests {
                 headers: http::HeaderMap::new(),
             };
             configure(&mut config);
-            let mut traversal = MapTraversal::new(config, build_client().unwrap(), build_sitemap_client().unwrap());
+            let mut traversal = MapTraversal::new(
+                config,
+                crate::transfer::client().unwrap(),
+                crate::transfer::raw_client().unwrap(),
+            );
             let mut entries = Vec::new();
             while let Some(entry) = traversal.next_url().await {
                 entries.push(entry);
@@ -1208,32 +1123,6 @@ mod tests {
             assert_eq!(entries.len(), 2);
             assert!(entries.iter().any(|e| e.url.ends_with("/page1")));
             assert!(entries.iter().any(|e| e.url.ends_with("/page2")));
-        }
-
-        #[tokio::test]
-        async fn run_parses_redirect_status_robots_body() {
-            let server = MockServer::start().await;
-            Mock::given(method("GET"))
-                .and(path("/robots.txt"))
-                .respond_with(
-                    ResponseTemplate::new(302)
-                        .set_body_raw(b"User-agent: *\nAllow: /".to_vec(), "text/plain; charset=utf-8"),
-                )
-                .mount(&server)
-                .await;
-            let sitemap = format!("<urlset><url><loc>{}/allowed</loc></url></urlset>", server.uri());
-            Mock::given(method("GET"))
-                .and(path("/sitemap.xml"))
-                .respond_with(
-                    ResponseTemplate::new(200).set_body_raw(sitemap.into_bytes(), "application/xml; charset=utf-8"),
-                )
-                .mount(&server)
-                .await;
-
-            let entries = check_run(&server, |_| {}).await;
-
-            assert_eq!(entries.len(), 1);
-            assert!(entries[0].url.ends_with("/allowed"));
         }
 
         #[tokio::test]

--- a/crates/servo-fetch/src/pdf.rs
+++ b/crates/servo-fetch/src/pdf.rs
@@ -1,22 +1,24 @@
-//! Bounded PDF retrieval for one-shot fetches.
+//! Bounded PDF retrieval that bypasses the browser engine.
 
 use std::time::Duration;
 
-use anyhow::{Context as _, Result};
+use crate::transfer;
 
 const MAX_PDF_BYTES: u64 = 50 * 1024 * 1024;
 
-/// Return PDF bytes when the resource is a PDF, `None` otherwise.
-pub(crate) fn probe(
-    url: &str,
-    timeout_secs: u64,
-    user_agent: Option<&str>,
-    headers: &http::HeaderMap,
-) -> Option<Vec<u8>> {
-    if !looks_like_pdf_url(url) {
+/// GET a validated URL and return its bytes when the server serves a PDF, `None` otherwise.
+pub(crate) async fn probe(target: &url::Url, headers: &transfer::Headers, timeout: Duration) -> Option<Vec<u8>> {
+    let client = transfer::client().ok()?;
+    let response = headers.get(&client, target, timeout).send().await.ok()?;
+    let is_pdf = response
+        .headers()
+        .get(http::header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|value| value.to_ascii_lowercase().starts_with("application/pdf"));
+    if !response.status().is_success() || !is_pdf {
         return None;
     }
-    fetch_bytes(url, Duration::from_secs(timeout_secs), user_agent, headers).ok()
+    transfer::collect_bounded(response, MAX_PDF_BYTES).await
 }
 
 pub(crate) fn looks_like_pdf_url(url: &str) -> bool {
@@ -29,42 +31,17 @@ pub(crate) fn looks_like_pdf_url(url: &str) -> bool {
     })
 }
 
-fn fetch_bytes(url: &str, timeout: Duration, user_agent: Option<&str>, headers: &http::HeaderMap) -> Result<Vec<u8>> {
-    let agent = build_agent(timeout, user_agent);
-    let mut request = agent.get(url);
-    for (name, value) in headers {
-        request = request.header(name.clone(), value.clone());
-    }
-    let response = request.call().with_context(|| format!("PDF GET failed for {url}"))?;
-    let is_pdf = response
-        .headers()
-        .get("content-type")
-        .and_then(|value| value.to_str().ok())
-        .is_some_and(|value| value.to_ascii_lowercase().starts_with("application/pdf"));
-    if !is_pdf {
-        anyhow::bail!("response is not a PDF");
-    }
-    response
-        .into_body()
-        .with_config()
-        .limit(MAX_PDF_BYTES)
-        .read_to_vec()
-        .context("PDF body read failed")
-}
-
-fn build_agent(timeout: Duration, user_agent: Option<&str>) -> ureq::Agent {
-    let mut config = ureq::config::Config::builder()
-        .max_redirects(0)
-        .timeout_global(Some(timeout));
-    if let Some(user_agent) = user_agent {
-        config = config.user_agent(user_agent);
-    }
-    ureq::Agent::new_with_config(config.build())
-}
-
 #[cfg(test)]
 mod tests {
+    use wiremock::matchers::{header, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
     use super::*;
+
+    async fn probe_default(url: String) -> Option<Vec<u8>> {
+        let headers = transfer::Headers::new(&http::HeaderMap::new(), None);
+        probe(&url::Url::parse(&url).unwrap(), &headers, Duration::from_secs(5)).await
+    }
 
     #[test]
     fn url_suffix_detection() {
@@ -77,175 +54,110 @@ mod tests {
         assert!(!looks_like_pdf_url("not a url"));
     }
 
-    #[test]
-    fn probe_skips_non_pdf_urls_without_network() {
-        // No network traffic because suffix check fails first.
-        assert!(probe("https://example.com/page.html", 1, None, &http::HeaderMap::new()).is_none());
-    }
-
-    #[test]
-    fn probe_returns_none_for_unresolvable_host() {
-        // Suffix matches, but GET fails quickly.
-        assert!(probe("http://invalid.invalid/foo.pdf", 1, None, &http::HeaderMap::new()).is_none());
-    }
-
-    mod integration {
-        use wiremock::matchers::{header, method, path};
-        use wiremock::{Mock, MockServer, ResponseTemplate};
-
-        use crate::pdf::probe;
-
-        async fn run_probe_with(
-            url: String,
-            timeout: u64,
-            user_agent: Option<&'static str>,
-            headers: http::HeaderMap,
-        ) -> Option<Vec<u8>> {
-            tokio::task::spawn_blocking(move || probe(&url, timeout, user_agent, &headers))
-                .await
-                .unwrap()
-        }
-
-        async fn run_probe(url: String, timeout: u64) -> Option<Vec<u8>> {
-            run_probe_with(url, timeout, None, http::HeaderMap::new()).await
-        }
-
-        #[tokio::test]
-        async fn returns_bytes_when_get_is_pdf() {
-            let server = MockServer::start().await;
-            Mock::given(method("GET"))
-                .and(path("/doc.pdf"))
-                .respond_with(ResponseTemplate::new(200).set_body_raw(b"%PDF-1.4 minimal".to_vec(), "application/pdf"))
-                .mount(&server)
-                .await;
-
-            let bytes = run_probe(format!("{}/doc.pdf", server.uri()), 5).await;
-            assert_eq!(bytes.as_deref(), Some(&b"%PDF-1.4 minimal"[..]));
-        }
-
-        #[tokio::test]
-        async fn sends_request_context_to_get() {
-            let server = MockServer::start().await;
-            let required = || {
-                Mock::given(header("user-agent", "TestBot/1.0"))
-                    .and(header("authorization", "Bearer test"))
-                    .and(header("cookie", "sid=seed"))
-                    .and(path("/protected.pdf"))
-            };
-            required()
-                .and(method("GET"))
-                .respond_with(ResponseTemplate::new(200).set_body_raw(b"PDF".to_vec(), "application/pdf"))
-                .mount(&server)
-                .await;
-            let mut headers = http::HeaderMap::new();
-            headers.insert(
-                http::header::AUTHORIZATION,
-                http::HeaderValue::from_static("Bearer test"),
-            );
-            headers.insert(http::header::COOKIE, http::HeaderValue::from_static("sid=seed"));
-
-            let bytes = run_probe_with(
-                format!("{}/protected.pdf", server.uri()),
-                5,
-                Some("TestBot/1.0"),
-                headers,
-            )
+    #[tokio::test]
+    async fn sends_request_context_to_get() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/protected.pdf"))
+            .and(header("user-agent", "TestBot/1.0"))
+            .and(header("authorization", "Bearer test"))
+            .and(header("cookie", "sid=seed"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(b"PDF".to_vec(), "application/pdf"))
+            .expect(1)
+            .mount(&server)
             .await;
-            assert_eq!(bytes.as_deref(), Some(&b"PDF"[..]));
-        }
+        let mut headers = http::HeaderMap::new();
+        headers.insert("authorization", "Bearer test".parse().unwrap());
+        headers.insert("cookie", "sid=seed".parse().unwrap());
+        let url = url::Url::parse(&format!("{}/protected.pdf", server.uri())).unwrap();
+        let headers = transfer::Headers::new(&headers, Some("TestBot/1.0"));
+        let bytes = probe(&url, &headers, Duration::from_secs(5)).await;
+        assert_eq!(bytes.as_deref(), Some(&b"PDF"[..]));
+    }
 
-        #[tokio::test]
-        async fn returns_none_when_get_says_html() {
-            let server = MockServer::start().await;
-            Mock::given(method("GET"))
-                .and(path("/lying.pdf"))
-                .respond_with(ResponseTemplate::new(200).insert_header("content-type", "text/html"))
-                .mount(&server)
-                .await;
-
-            assert!(run_probe(format!("{}/lying.pdf", server.uri()), 5).await.is_none());
-        }
-
-        #[tokio::test]
-        async fn returns_none_when_get_lacks_content_type() {
-            let server = MockServer::start().await;
-            Mock::given(method("GET"))
-                .and(path("/no-ct.pdf"))
-                .respond_with(ResponseTemplate::new(200))
-                .mount(&server)
-                .await;
-
-            assert!(run_probe(format!("{}/no-ct.pdf", server.uri()), 5).await.is_none());
-        }
-
-        #[tokio::test]
-        async fn returns_none_when_get_returns_404() {
-            let server = MockServer::start().await;
-            Mock::given(method("GET"))
-                .and(path("/missing.pdf"))
-                .respond_with(ResponseTemplate::new(404))
-                .mount(&server)
-                .await;
-
-            assert!(run_probe(format!("{}/missing.pdf", server.uri()), 5).await.is_none());
-        }
-
-        #[tokio::test]
-        async fn skips_non_pdf_url_without_any_request() {
-            let server = MockServer::start().await;
-            Mock::given(method("GET"))
-                .respond_with(ResponseTemplate::new(500))
-                .expect(0)
-                .mount(&server)
-                .await;
-
-            assert!(run_probe(format!("{}/page.html", server.uri()), 5).await.is_none());
-        }
-
-        #[tokio::test]
-        async fn accepts_content_type_with_parameter() {
-            let server = MockServer::start().await;
-            Mock::given(method("GET"))
-                .and(path("/x.pdf"))
-                .respond_with(
-                    ResponseTemplate::new(200).set_body_raw(b"PDF".to_vec(), "application/pdf; charset=binary"),
-                )
-                .mount(&server)
-                .await;
-
-            assert_eq!(
-                run_probe(format!("{}/x.pdf", server.uri()), 5).await.as_deref(),
-                Some(&b"PDF"[..]),
-            );
-        }
-
-        #[tokio::test]
-        async fn does_not_follow_redirects() {
-            // Disable redirects to prevent SSRF bypass.
-            let server = MockServer::start().await;
-            Mock::given(method("GET"))
-                .and(path("/redirect.pdf"))
-                .respond_with(ResponseTemplate::new(302).insert_header("location", "https://example.com/"))
-                .mount(&server)
-                .await;
-
+    #[tokio::test]
+    async fn returns_none_for_html_missing_content_type_or_error_status() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/html.pdf"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(b"<html/>".to_vec(), "text/html"))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/untyped.pdf"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(b"%PDF-1.4".to_vec()))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/missing.pdf"))
+            .respond_with(ResponseTemplate::new(404).set_body_raw(b"%PDF-1.4".to_vec(), "application/pdf"))
+            .mount(&server)
+            .await;
+        for path_name in ["html.pdf", "untyped.pdf", "missing.pdf"] {
             assert!(
-                run_probe(format!("{}/redirect.pdf", server.uri()), 5).await.is_none(),
-                "302 must not be followed (SSRF gate)",
+                probe_default(format!("{}/{path_name}", server.uri())).await.is_none(),
+                "{path_name} must not be treated as a PDF"
             );
         }
+    }
 
-        #[tokio::test]
-        async fn probe_uses_single_get_request() {
-            let server = MockServer::start().await;
-            Mock::given(method("GET"))
-                .and(path("/big.pdf"))
-                .respond_with(ResponseTemplate::new(200).set_body_raw(b"PDF".to_vec(), "application/pdf"))
-                .expect(1)
-                .mount(&server)
-                .await;
+    #[tokio::test]
+    async fn returns_none_when_the_connection_fails() {
+        let closed = std::net::TcpListener::bind("127.0.0.1:0")
+            .unwrap()
+            .local_addr()
+            .unwrap();
+        assert!(probe_default(format!("http://{closed}/foo.pdf")).await.is_none());
+    }
 
-            let _ = run_probe(format!("{}/big.pdf", server.uri()), 5).await;
+    #[tokio::test]
+    async fn dropping_probe_mid_body_closes_the_socket() {
+        use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+        use tokio::net::TcpListener;
+        use tokio::sync::oneshot;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind PDF fixture");
+        let address = listener.local_addr().expect("PDF fixture address");
+        let (partial_tx, partial_rx) = oneshot::channel();
+        let (closed_tx, closed_rx) = oneshot::channel();
+        let fixture = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.expect("accept PDF request");
+            let mut request = Vec::new();
+            let mut byte = [0_u8; 1];
+            while !request.ends_with(b"\r\n\r\n") {
+                socket.read_exact(&mut byte).await.expect("read PDF request");
+                request.push(byte[0]);
+            }
+            socket
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\ncontent-type: application/pdf\r\ncontent-length: 1048576\r\n\r\n%PDF-1.4\n",
+                )
+                .await
+                .expect("write partial PDF response");
+            socket.flush().await.expect("flush partial PDF response");
+            partial_tx.send(()).expect("report partial PDF body");
+            let observed = socket.read(&mut byte).await;
+            closed_tx.send(observed).expect("report client disconnect");
+        });
+
+        let probing = tokio::spawn(probe_default(format!("http://{address}/slow.pdf")));
+        partial_rx.await.expect("probe reaches the partial PDF body");
+        probing.abort();
+        assert!(probing.await.expect_err("probe task is cancelled").is_cancelled());
+
+        let observed = tokio::time::timeout(Duration::from_secs(1), closed_rx)
+            .await
+            .expect("cancelled probe closes its socket promptly")
+            .expect("fixture reports client disconnect");
+        match observed {
+            Ok(0) => {}
+            Err(error)
+                if matches!(
+                    error.kind(),
+                    std::io::ErrorKind::ConnectionReset | std::io::ErrorKind::BrokenPipe
+                ) => {}
+            other => panic!("cancelled probe must close its response socket, observed {other:?}"),
         }
+        fixture.await.expect("PDF fixture task completes");
     }
 }

--- a/crates/servo-fetch/src/robots.rs
+++ b/crates/servo-fetch/src/robots.rs
@@ -4,8 +4,6 @@ use std::time::Duration;
 
 use url::Url;
 
-use crate::bridge;
-
 pub(crate) const ROBOTS_MAX_BYTES: u64 = 512 * 1024;
 
 /// Outcome of `RobotsRules::fetch`.
@@ -33,44 +31,6 @@ pub(crate) struct RobotsRules {
 }
 
 impl RobotsRules {
-    pub(crate) fn fetch(
-        seed: &Url,
-        user_agent: Option<&str>,
-        headers: &http::HeaderMap,
-        timeout: Duration,
-    ) -> RobotsPolicy {
-        let Some(url) = robots_url(seed) else {
-            return RobotsPolicy::Unreachable;
-        };
-        let ua = user_agent.unwrap_or_else(|| bridge::default_user_agent());
-        let agent = ureq::Agent::new_with_config(
-            ureq::config::Config::builder()
-                .max_redirects(0)
-                .http_status_as_error(false)
-                .timeout_global(Some(timeout))
-                .user_agent(ua)
-                .build(),
-        );
-        let mut req = agent.get(url.as_str());
-        for (name, value) in headers {
-            req = req.header(name.clone(), value.clone());
-        }
-        let Ok(resp) = req.call() else {
-            return RobotsPolicy::Unreachable;
-        };
-        let status = resp.status().as_u16();
-        let body = if (400..600).contains(&status) {
-            None
-        } else {
-            resp.into_body()
-                .with_config()
-                .limit(ROBOTS_MAX_BYTES)
-                .read_to_vec()
-                .ok()
-        };
-        classify_response(status, body.as_deref(), product_token(ua))
-    }
-
     fn parse(body: &str, product_token: &str) -> Self {
         let mut rules = Vec::new();
         let mut sitemaps = Vec::new();
@@ -117,9 +77,30 @@ impl RobotsRules {
     }
 }
 
+/// Fetch and classify robots.txt for `seed`; 4xx means no rules, 5xx/network errors mean disallow.
+pub(crate) async fn fetch(
+    client: &reqwest::Client,
+    seed: &Url,
+    headers: &crate::transfer::Headers,
+    timeout: Duration,
+) -> RobotsPolicy {
+    let Some(url) = robots_url(seed) else {
+        return RobotsPolicy::Unreachable;
+    };
+    let Ok(response) = headers.get(client, &url, timeout).send().await else {
+        return RobotsPolicy::Unreachable;
+    };
+    let status = response.status();
+    let body = if status.is_client_error() || status.is_server_error() {
+        None
+    } else {
+        crate::transfer::collect_bounded(response, ROBOTS_MAX_BYTES).await
+    };
+    classify_response(status.as_u16(), body.as_deref(), product_token(headers.user_agent()))
+}
+
 pub(crate) fn classify_response(status: u16, body: Option<&[u8]>, product_token: &str) -> RobotsPolicy {
     match status {
-        // Stricter than RFC 9309/Google on auth-gated robots.txt: 401/403 read as "not welcome".
         401 | 403 | 429 | 500..=599 => RobotsPolicy::Unreachable,
         400..=499 => RobotsPolicy::Unavailable,
         _ => body
@@ -189,7 +170,7 @@ fn pattern_match_len(pattern: &str, path: &str) -> usize {
 
 #[cfg(test)]
 mod tests {
-    use wiremock::matchers::{header, method, path};
+    use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     use super::*;
@@ -344,11 +325,9 @@ mod tests {
         }
 
         async fn call(seed: Url, user_agent: Option<&'static str>) -> RobotsPolicy {
-            tokio::task::spawn_blocking(move || {
-                RobotsRules::fetch(&seed, user_agent, &http::HeaderMap::new(), Duration::from_secs(5))
-            })
-            .await
-            .unwrap()
+            let client = crate::transfer::client().unwrap();
+            let headers = crate::transfer::Headers::new(&http::HeaderMap::new(), user_agent);
+            fetch(&client, &seed, &headers, Duration::from_secs(5)).await
         }
 
         #[tokio::test]
@@ -410,22 +389,6 @@ mod tests {
             let oversized = "a".repeat(size);
             let (_server, seed) = serve(200, &oversized).await;
             assert!(matches!(call(seed, None).await, RobotsPolicy::Unreachable));
-        }
-
-        #[tokio::test]
-        async fn sends_caller_provided_user_agent() {
-            let server = MockServer::start().await;
-            Mock::given(method("GET"))
-                .and(path("/robots.txt"))
-                .and(header("user-agent", "CustomBot/9.9"))
-                .respond_with(
-                    ResponseTemplate::new(200).set_body_raw(b"User-agent: *\n".to_vec(), "text/plain; charset=utf-8"),
-                )
-                .expect(1)
-                .mount(&server)
-                .await;
-            let seed = Url::parse(&server.uri()).unwrap();
-            let _ = call(seed, Some("CustomBot/9.9")).await;
         }
     }
 }

--- a/crates/servo-fetch/src/session.rs
+++ b/crates/servo-fetch/src/session.rs
@@ -15,7 +15,7 @@ use self::supervisor::{
 };
 use crate::cookies::{CookieSpec, CookieWire};
 use crate::error::{Error, Result};
-use crate::fetch::{FetchMode, FetchOptions, Page};
+use crate::fetch::{FetchOptions, Page};
 use crate::worker::protocol::InitializeSession;
 use crate::worker::wire::{CrawlWire, FetchWire, MAX_WIRE_CRAWL_CONCURRENCY, MAX_WIRE_DURATION};
 use crate::worker::worker_error;
@@ -499,6 +499,10 @@ impl SessionBroker {
             return Err(cancelled_error());
         }
         let user_agent = config.user_agent.clone();
+        let cookies = match config.cookie_scope.as_deref().map(url::Url::parse) {
+            Some(Ok(scope)) => crate::cookies::seedable(&scope, &config.cookies),
+            _ => Vec::new(),
+        };
         let initialization = InitializeSession {
             permissive_network: crate::bridge::engine_policy() == NetworkPolicy::PERMISSIVE,
             user_agent: config.user_agent,
@@ -511,6 +515,8 @@ impl SessionBroker {
         Ok(BrowserSession {
             supervisor: Some(supervisor),
             user_agent,
+            cookies,
+            cancellation: cancellation.clone(),
         })
     }
 }
@@ -558,6 +564,8 @@ impl Drop for AcquisitionGuard {
 pub struct BrowserSession {
     supervisor: Option<SupervisorHandle>,
     user_agent: Option<String>,
+    cookies: Vec<CookieSpec>,
+    cancellation: SessionCancellation,
 }
 
 impl BrowserSession {
@@ -629,7 +637,13 @@ impl BrowserSession {
     /// Fetch in this logical session. Per-request UA/cookies are rejected.
     pub async fn fetch(&mut self, opts: &FetchOptions) -> Result<Page> {
         validate_session_fetch(opts)?;
-        crate::net::validate_url(&opts.url)?;
+        self.supervisor_mut()?;
+        let target = crate::net::validate_url(&opts.url)?;
+        if crate::fetch::wants_pdf_probe(opts)
+            && let Some(page) = self.probe_pdf(&target, opts).await?
+        {
+            return Ok(page);
+        }
         let (reply, receive) = response_channel();
         let command = SupervisorCommand::Fetch {
             request: FetchWire::from_options(opts),
@@ -644,10 +658,32 @@ impl BrowserSession {
         self.finish_operation(wire.into_page(screenshot))
     }
 
+    /// PDFs never reach the worker: probe on the host with the session's seeded identity, racing cancellation.
+    async fn probe_pdf(&self, target: &url::Url, opts: &FetchOptions) -> Result<Option<Page>> {
+        let mut headers = opts.headers.clone();
+        if let Some(cookie) = crate::cookies::request_header(target, &self.cookies) {
+            headers.insert(http::header::COOKIE, cookie);
+        }
+        let headers = crate::transfer::Headers::new(&headers, self.user_agent.as_deref());
+        let probe = crate::pdf::probe(target, &headers, opts.effective_timeout());
+        tokio::select! {
+            biased;
+            () = self.cancellation.cancelled() => Err(cancelled_error()),
+            bytes = probe => Ok(bytes.as_deref().map(crate::fetch::pdf_page)),
+        }
+    }
+
     /// Blocking fetch in this logical session.
     pub fn fetch_blocking(&mut self, opts: &FetchOptions) -> Result<Page> {
         validate_session_fetch(opts)?;
-        crate::net::validate_url(&opts.url)?;
+        self.supervisor_mut()?;
+        let target = crate::net::validate_url(&opts.url)?;
+        if crate::fetch::wants_pdf_probe(opts) {
+            let probe = self.probe_pdf(&target, opts);
+            if let Some(page) = crate::runtime::block_on(probe).map_err(|error| worker_error(error.to_string()))?? {
+                return Ok(page);
+            }
+        }
         let (reply, receive) = response_channel();
         self.supervisor_mut()?.send(SupervisorCommand::Fetch {
             request: FetchWire::from_options(opts),
@@ -797,12 +833,6 @@ fn validate_session_fetch(opts: &FetchOptions) -> Result<()> {
     validate_immutable_settings(opts.user_agent.as_ref(), &opts.cookies, &opts.headers)?;
     validate_operation_duration("fetch timeout", opts.effective_timeout())?;
     validate_operation_duration("fetch settle", opts.effective_settle())?;
-    if matches!(opts.mode, FetchMode::Content { .. }) && crate::pdf::looks_like_pdf_url(&opts.url) {
-        return Err(Error::UnsupportedSessionOperation {
-            operation: "PDF extraction",
-            reason: "session-aware PDF networking is unavailable; use the one-shot fetch API",
-        });
-    }
     Ok(())
 }
 

--- a/crates/servo-fetch/src/session/tests.rs
+++ b/crates/servo-fetch/src/session/tests.rs
@@ -270,14 +270,7 @@ fn broker_rejects_invalid_configuration() {
 
 #[test]
 fn session_rejects_per_request_state_bypasses() {
-    let options = FetchOptions::new("https://example.com/protected.pdf");
-    assert!(matches!(
-        validate_session_fetch(&options),
-        Err(Error::UnsupportedSessionOperation {
-            operation: "PDF extraction",
-            ..
-        })
-    ));
+    assert!(validate_session_fetch(&FetchOptions::new("https://example.com/report.pdf")).is_ok());
 
     let mut fetch = FetchOptions::new("https://example.com");
     fetch

--- a/crates/servo-fetch/src/transfer.rs
+++ b/crates/servo-fetch/src/transfer.rs
@@ -1,0 +1,182 @@
+//! Shared reqwest client for transfers that bypass the browser engine (robots.txt, sitemaps, PDFs).
+
+use std::time::Duration;
+
+use futures_util::StreamExt as _;
+use reqwest::header::USER_AGENT;
+use url::Url;
+
+use crate::{bridge, net};
+
+/// Build a client with the default transfer policy.
+pub(crate) fn client() -> crate::error::Result<reqwest::Client> {
+    build(reqwest::Client::builder())
+}
+
+/// Like [`client`], but bodies arrive undecoded for callers that must decompress exactly once themselves.
+pub(crate) fn raw_client() -> crate::error::Result<reqwest::Client> {
+    build(reqwest::Client::builder().no_gzip())
+}
+
+/// Redirects are disabled for every client; callers follow them manually so each hop is validated.
+fn build(builder: reqwest::ClientBuilder) -> crate::error::Result<reqwest::Client> {
+    net::ensure_crypto_provider();
+    builder
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .map_err(|error| crate::Error::engine(error, None))
+}
+
+/// Request headers guaranteed to carry a User-Agent: an explicit header wins, then the option, then the engine default.
+#[derive(Clone, Debug)]
+pub(crate) struct Headers(http::HeaderMap);
+
+impl Headers {
+    pub(crate) fn new(base: &http::HeaderMap, user_agent: Option<&str>) -> Self {
+        let mut headers = base.clone();
+        if !headers.contains_key(USER_AGENT)
+            && let Ok(value) = http::HeaderValue::from_str(user_agent.unwrap_or_else(|| bridge::default_user_agent()))
+        {
+            headers.insert(USER_AGENT, value);
+        }
+        Self(headers)
+    }
+
+    /// The User-Agent these headers announce.
+    pub(crate) fn user_agent(&self) -> &str {
+        self.0
+            .get(USER_AGENT)
+            .and_then(|value| value.to_str().ok())
+            .unwrap_or_else(|| bridge::default_user_agent())
+    }
+
+    /// Start a GET with these headers and the given deadline.
+    pub(crate) fn get(&self, client: &reqwest::Client, url: &Url, timeout: Duration) -> reqwest::RequestBuilder {
+        client.get(url.clone()).timeout(timeout).headers(self.0.clone())
+    }
+}
+
+/// Collect a body up to `max_bytes`; larger bodies yield `None` without buffering the excess.
+pub(crate) async fn collect_bounded(response: reqwest::Response, max_bytes: u64) -> Option<Vec<u8>> {
+    let mut body = Vec::new();
+    let mut chunks = response.bytes_stream();
+    while let Some(chunk) = chunks.next().await {
+        let chunk = chunk.ok()?;
+        let next_len = u64::try_from(body.len())
+            .ok()?
+            .checked_add(u64::try_from(chunk.len()).ok()?)?;
+        if next_len > max_bytes {
+            return None;
+        }
+        body.extend_from_slice(&chunk);
+    }
+    Some(body)
+}
+
+#[cfg(test)]
+mod tests {
+    use wiremock::matchers::{header, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use super::*;
+
+    fn target(server: &MockServer, path_name: &str) -> Url {
+        Url::parse(&format!("{}{path_name}", server.uri())).unwrap()
+    }
+
+    fn with_agent(base: &http::HeaderMap, user_agent: Option<&str>) -> Headers {
+        Headers::new(base, user_agent)
+    }
+
+    #[tokio::test]
+    async fn clients_never_follow_redirects() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/hop"))
+            .respond_with(ResponseTemplate::new(302).insert_header("location", "/elsewhere"))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/elsewhere"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(0)
+            .mount(&server)
+            .await;
+
+        let headers = http::HeaderMap::new();
+        let response = with_agent(&headers, None)
+            .get(&client().unwrap(), &target(&server, "/hop"), Duration::from_secs(5))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(response.status(), 302, "the caller decides whether to follow");
+    }
+
+    #[tokio::test]
+    async fn user_agent_falls_back_to_the_engine_default_unless_a_header_overrides_it() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/default"))
+            .and(header("user-agent", bridge::default_user_agent()))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/header"))
+            .and(header("user-agent", "FromHeader/1.0"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/option"))
+            .and(header("user-agent", "FromOption/1.0"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let client = client().unwrap();
+        let none = http::HeaderMap::new();
+        let mut overriding = http::HeaderMap::new();
+        overriding.insert(USER_AGENT, "FromHeader/1.0".parse().unwrap());
+
+        let by_default = with_agent(&none, None).get(&client, &target(&server, "/default"), Duration::from_secs(5));
+        let by_header = with_agent(&overriding, Some("Ignored/0")).get(
+            &client,
+            &target(&server, "/header"),
+            Duration::from_secs(5),
+        );
+        let by_option =
+            with_agent(&none, Some("FromOption/1.0")).get(&client, &target(&server, "/option"), Duration::from_secs(5));
+        assert_eq!(by_default.send().await.unwrap().status(), 200);
+        assert_eq!(by_header.send().await.unwrap().status(), 200);
+        assert_eq!(by_option.send().await.unwrap().status(), 200);
+    }
+
+    #[tokio::test]
+    async fn bounded_collection_stops_at_the_limit() {
+        async fn collect(server: &MockServer, limit: u64) -> Option<Vec<u8>> {
+            let headers = http::HeaderMap::new();
+            let response = with_agent(&headers, None)
+                .get(&client().unwrap(), &target(server, "/body"), Duration::from_secs(5))
+                .send()
+                .await
+                .unwrap();
+            collect_bounded(response, limit).await
+        }
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/body"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(vec![b'x'; 64]))
+            .mount(&server)
+            .await;
+        assert_eq!(collect(&server, 64).await.map(|body| body.len()), Some(64));
+        assert_eq!(
+            collect(&server, 63).await,
+            None,
+            "one byte over the limit rejects the body"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Sessions rejected `.pdf` URLs (`UnsupportedSessionOperation`), so MCP `fetch` kept a temporary detour onto the shared warm engine for PDFs — no isolation, no cancellation, no session identity. Two commits:

- `refactor(transfer)`: one async HTTP stack. A new `transfer` module owns the client policy (no redirects, `Headers` newtype with the effective User-Agent, bounded bodies); robots and PDF fetching move onto it, `ureq` is dropped, and the one-shot probe no longer leaks URL credentials as `Authorization`.
- `feat(session)`: `BrowserSession::fetch` probes PDFs on the host with the seeded identity (UA + scope-filtered cookies), racing cancellation and refusing once closed. The rejection and the CLI detour are gone; page-set cookies stay in the worker and do not reach PDF requests.

## Test Plan

- `cargo test-ci`: all passed
- `cargo test-e2e`: all passed

## Checklist

- [x] Ran `cargo +nightly fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
- [ ] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed
- [x] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it