### PR TITLE
fix(docker): wire the healthcheck into the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,5 +41,7 @@ EXPOSE 3000
 ENV XDG_CACHE_HOME=/tmp
 ENV XDG_RUNTIME_DIR=/tmp/runtime-servo
 
+HEALTHCHECK --timeout=5s CMD ["servo-fetch", "healthcheck", "--port", "3000"]
+
 ENTRYPOINT ["servo-fetch"]
 CMD ["serve", "--host", "0.0.0.0", "--port", "3000"]


### PR DESCRIPTION
## Summary

The CLI README states the image "includes a `HEALTHCHECK` against `/health`", but the Dockerfile never declared one. This wires the existing `servo-fetch healthcheck` subcommand as the image health check in exec form. Only `--timeout` is set: the probe bounds itself to 2s, so Docker's timeout merely guards against the binary failing to start; interval and retries stay at Docker defaults, and no `--start-period` is needed because `serve` binds first and `/health` is a static 200.

## Test Plan

`docker buildx build --check` passes with no warnings.

## Checklist

- [x] Ran `cargo +nightly fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
- [ ] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed
- [x] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it