### PR TITLE
fix(error): render error source chains once

### DIFF
--- a/bindings/python/src/crawl.rs
+++ b/bindings/python/src/crawl.rs
@@ -43,7 +43,7 @@ impl CrawlResult {
 
     #[getter]
     fn error(&self) -> Option<String> {
-        self.inner.outcome.as_ref().err().map(ToString::to_string)
+        self.inner.outcome.as_ref().err().map(servo_fetch::Error::report)
     }
 
     /// `True` if the crawl succeeded for this URL.
@@ -73,7 +73,7 @@ impl CrawlResult {
                 "{name}(url={:?}, depth={}, error={:?})",
                 this.inner.url,
                 this.inner.depth,
-                e.to_string()
+                e.report()
             ),
         })
     }

--- a/bindings/python/src/errors.rs
+++ b/bindings/python/src/errors.rs
@@ -58,11 +58,11 @@ pub(crate) fn map_error(err: servo_fetch::Error) -> PyErr {
             InvalidUrlError::new_err(format!("invalid URL '{}': {reason}", redact_url(url)))
         }
         servo_fetch::Error::AddressNotAllowed { host } => NetworkError::new_err(format!("address not allowed: {host}")),
-        servo_fetch::Error::Engine { source, .. } => EngineError::new_err(source.to_string()),
-        servo_fetch::Error::Schema(e) => SchemaError::new_err(e.to_string()),
-        servo_fetch::Error::Cookies { .. } => CookieError::new_err(err.to_string()),
+        servo_fetch::Error::Engine { .. } => EngineError::new_err(err.report()),
+        servo_fetch::Error::Schema(_) => SchemaError::new_err(err.report()),
+        servo_fetch::Error::Cookies { .. } => CookieError::new_err(err.report()),
         servo_fetch::Error::InvalidHeader(msg) => pyo3::exceptions::PyValueError::new_err(msg.clone()),
-        _ => ServoFetchError::new_err(err.to_string()),
+        _ => ServoFetchError::new_err(err.report()),
     }
 }
 

--- a/crates/servo-fetch-cli/src/tools/error.rs
+++ b/crates/servo-fetch-cli/src/tools/error.rs
@@ -86,7 +86,7 @@ impl From<servo_fetch::Error> for ToolError {
             }
             _ => ToolErrorClass::Internal(ErrorKind::Internal),
         };
-        let message = err.to_string();
+        let message = err.report();
         Self {
             class,
             message,

--- a/crates/servo-fetch-cli/src/wire.rs
+++ b/crates/servo-fetch-cli/src/wire.rs
@@ -50,7 +50,7 @@ pub(crate) fn crawl_event(result: CrawlResult) -> wire::CrawlEvent {
             url: result.url,
             depth,
             fetched_at,
-            error: e.to_string(),
+            error: e.report(),
         },
     }
 }

--- a/crates/servo-fetch/src/cookies.rs
+++ b/crates/servo-fetch/src/cookies.rs
@@ -110,18 +110,18 @@ impl std::fmt::Debug for CookieSpec {
 /// Load cookies from a Netscape format `cookies.txt` file.
 pub fn load_cookies(path: impl AsRef<Path>) -> Result<Vec<CookieSpec>> {
     let path = path.as_ref();
-    let fail = |reason: String| Error::Cookies {
-        path: path.display().to_string(),
-        reason,
+    let fail = |source: crate::error::BoxError| Error::Cookies {
+        path: path.to_path_buf(),
+        source,
     };
     let mut text = String::new();
     std::fs::File::open(path)
         .and_then(|f| f.take(MAX_FILE_BYTES + 1).read_to_string(&mut text))
-        .map_err(|e| fail(e.to_string()))?;
+        .map_err(|e| fail(e.into()))?;
     if text.len() as u64 > MAX_FILE_BYTES {
-        return Err(fail(format!("file exceeds {MAX_FILE_BYTES} bytes")));
+        return Err(fail(format!("file exceeds {MAX_FILE_BYTES} bytes").into()));
     }
-    parse_cookies(&text).map_err(|e| fail(e.to_string()))
+    parse_cookies(&text).map_err(|e| fail(e.into()))
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/servo-fetch/src/crawl.rs
+++ b/crates/servo-fetch/src/crawl.rs
@@ -200,7 +200,7 @@ impl serde::Serialize for CrawlResult {
                 map.serialize_entry("url", &self.url)?;
                 map.serialize_entry("depth", &self.depth)?;
                 map.serialize_entry("fetchedAt", &fetched_at)?;
-                map.serialize_entry("error", &e.to_string())?;
+                map.serialize_entry("error", &e.report())?;
                 map.end()
             }
         }
@@ -1381,7 +1381,7 @@ mod tests {
         let url = Url::parse("https://example.com/fail").unwrap();
         let r = error_result(&url, 2, crate::error::Error::engine("timeout", None), SystemTime::now());
         assert!(matches!(r.status, CrawlStatus::Error));
-        assert!(r.error.as_ref().is_some_and(|e| e.to_string().contains("timeout")));
+        assert!(r.error.as_ref().is_some_and(|e| e.report().contains("timeout")));
         assert!(r.content.is_none());
     }
 

--- a/crates/servo-fetch/src/error.rs
+++ b/crates/servo-fetch/src/error.rs
@@ -39,7 +39,7 @@ pub enum Error {
     },
 
     /// The Servo engine is unavailable or crashed.
-    #[error("engine error: {source}")]
+    #[error("engine error")]
     Engine {
         /// URL being processed, if known.
         url: Option<String>,
@@ -49,7 +49,7 @@ pub enum Error {
     },
 
     /// JavaScript evaluation failed.
-    #[error("JavaScript evaluation failed: {source}")]
+    #[error("JavaScript evaluation failed")]
     JavaScript {
         /// URL being processed, if known.
         url: Option<String>,
@@ -59,7 +59,7 @@ pub enum Error {
     },
 
     /// Screenshot capture failed.
-    #[error("screenshot capture failed: {source}")]
+    #[error("screenshot capture failed")]
     Screenshot {
         /// URL being captured, if known.
         url: Option<String>,
@@ -73,12 +73,13 @@ pub enum Error {
     Extract(#[from] crate::extract::ExtractError),
 
     /// Failed to load or parse a cookies file.
-    #[error("failed to load cookies from {path}: {reason}")]
+    #[error("failed to load cookies from {}", path.display())]
     Cookies {
         /// The cookies file path.
-        path: String,
-        /// Why loading failed.
-        reason: String,
+        path: std::path::PathBuf,
+        /// Source error.
+        #[source]
+        source: BoxError,
     },
 
     /// Schema-based structured extraction failed.
@@ -149,7 +150,7 @@ pub enum Error {
     SessionBrokerFull,
 
     /// The isolated worker protocol could not continue.
-    #[error("isolated browser worker unavailable: {source}")]
+    #[error("isolated browser worker unavailable")]
     WorkerUnavailable {
         /// Underlying transport, framing, or worker error.
         #[source]
@@ -158,6 +159,19 @@ pub enum Error {
 }
 
 impl Error {
+    /// The message followed by every cause, separated by `: ` (what `anyhow` prints for `{:#}`).
+    #[must_use]
+    pub fn report(&self) -> String {
+        let mut report = self.to_string();
+        let mut source = StdError::source(self);
+        while let Some(error) = source {
+            report.push_str(": ");
+            report.push_str(&error.to_string());
+            source = error.source();
+        }
+        report
+    }
+
     /// Construct an [`Error::Engine`] from any error type, preserving source chain.
     pub(crate) fn engine(source: impl Into<BoxError>, url: Option<String>) -> Self {
         Self::Engine {
@@ -280,12 +294,12 @@ mod tests {
     }
 
     #[test]
-    fn engine_helper_preserves_source_chain() {
-        let inner = std::io::Error::other("disk full");
-        let err = Error::engine(inner, Some("https://example.com".into()));
+    fn engine_report_renders_source_chain_once() {
+        let err = Error::engine(std::io::Error::other("boom"), Some("https://example.com".into()));
         assert_eq!(err.url(), Some("https://example.com"));
         assert!(err.source().is_some());
-        assert_eq!(err.to_string(), "engine error: disk full");
+        assert_eq!(err.to_string(), "engine error");
+        assert_eq!(err.report(), "engine error: boom");
     }
 
     #[test]

--- a/crates/servo-fetch/src/session/supervisor.rs
+++ b/crates/servo-fetch/src/session/supervisor.rs
@@ -793,7 +793,7 @@ mod tests {
         let error = owner
             .release_with(|_| Err(std::io::Error::new(std::io::ErrorKind::PermissionDenied, "injected")))
             .unwrap_err();
-        assert!(error.to_string().contains("injected"));
+        assert!(error.report().contains("injected"));
         assert!(permits.clone().try_acquire_owned().is_err());
 
         owner.release().unwrap();

--- a/crates/servo-fetch/src/worker/wire.rs
+++ b/crates/servo-fetch/src/worker/wire.rs
@@ -169,7 +169,7 @@ impl WorkerErrorWire {
             Error::Engine { source, .. } | Error::JavaScript { source, .. } | Error::Screenshot { source, .. } => {
                 source.to_string()
             }
-            _ => error.to_string(),
+            _ => error.report(),
         };
         Self {
             kind: WorkerErrorKind::from_error(error),


### PR DESCRIPTION
## Summary

`Error` variants that carry a `#[source]` also embedded `{source}` in their `Display`, so reporters that render the cause chain (the CLI's anyhow `{:#}`) printed it twice: `engine error: boom: boom`.

## Test Plan

workspace tests 561 passed, Servo-backed e2e 30 passed.

## Checklist

- [x] Ran `cargo +nightly fmt`, `cargo clippy`, and `cargo test` locally (CI will fail otherwise)
- [ ] Documentation updated (README, SECURITY.md, CLI/skill guide) where user-facing behavior changed
- [x] Tests added or updated, or explained why not in the Test Plan
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read the AI usage policy in [CONTRIBUTING.md](../CONTRIBUTING.md#use-of-ai) and followed it